### PR TITLE
Fixed weird bug with PresenceObserver channel filtering

### DIFF
--- a/iOS/3.4/pubnub/libs/PubNub/Network/PNMessagingChannel.m
+++ b/iOS/3.4/pubnub/libs/PubNub/Network/PNMessagingChannel.m
@@ -837,7 +837,7 @@
 
     // Compose filtering predicate to retrieve list of channels
     // which are not presence observing channels
-    NSPredicate *filterPredicate = [NSPredicate predicateWithFormat:@"isPresenceObserver = %@", @NO];
+    NSPredicate *filterPredicate = [NSPredicate predicateWithFormat:@"isPresenceObserver = NO"];
 
 
     return [channelsList filteredArrayUsingPredicate:filterPredicate];


### PR DESCRIPTION
Certain PNChannels returned from SubscribeRequest responses with
isPresenceObserver == NO were not passing the filter predicate in the channelsWithOutPresenceFromList method. Using
the literal NO inside the predicate string fixes this.
