### PR TITLE
fixed the issue of falling MobilePush API request while PAM enables.

### DIFF
--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNPushNotificationsEnabledChannelsRequest.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNPushNotificationsEnabledChannelsRequest.m
@@ -86,7 +86,7 @@
                                       [self callbackMethodName],
                                       self.shortIdentifier,
                                       [PubNub escapedClientIdentifier],
-                                      ([self authorizationField]?[NSString stringWithFormat:@"?%@", [self authorizationField]]:@"")];
+                                      ([self authorizationField]?[NSString stringWithFormat:@"&%@", [self authorizationField]]:@"")];
 }
 
 - (NSString *)debugResourcePath {

--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNPushNotificationsRemoveRequest.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNPushNotificationsRemoveRequest.m
@@ -86,7 +86,7 @@
                                       [self callbackMethodName],
                                       self.shortIdentifier,
                                       [PubNub escapedClientIdentifier],
-                                      ([self authorizationField]?[NSString stringWithFormat:@"?%@", [self authorizationField]]:@"")];
+                                      ([self authorizationField]?[NSString stringWithFormat:@"&%@", [self authorizationField]]:@"")];
 }
 
 - (NSString *)debugResourcePath {

--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNPushNotificationsStateChangeRequest.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/Packets/PNPushNotificationsStateChangeRequest.m
@@ -129,7 +129,7 @@ struct PNPushNotificationsStateStruct PNPushNotificationsState = {
             [self callbackMethodName],
             self.shortIdentifier,
             [PubNub escapedClientIdentifier],
-            ([self authorizationField]?[NSString stringWithFormat:@"?%@", [self authorizationField]]:@"")];
+            ([self authorizationField]?[NSString stringWithFormat:@"&%@", [self authorizationField]]:@"")];
 }
 
 - (NSString *)debugResourcePath {


### PR DESCRIPTION
The character of auth parameter that is needed on PAM was '?' instead of '&' which caused the issue in sending request.
