### PR TITLE
dereference the error pointer before comparing it to nil.

### DIFF
--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Data/Crypto/PNCryptoHelper.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Data/Crypto/PNCryptoHelper.m
@@ -137,11 +137,9 @@ typedef enum _PNCryptorType {
     
     PNCryptoHelper *helper = [self new];
     [helper updateWithConfiguration:configuration withError:error];
-    if (error != nil) {
-        
+    if (*error != nil) {
         helper = nil;
     }
-    
     
     return helper;
 }


### PR DESCRIPTION
you are comparing a pointer to non-nil(which will always be true), so PNCryptoHelper will always get returned as nil.

for users who are using `cipher_key` to encrypt/decrypt their messages, they will get gibberish back on their iOS client.
