### PR TITLE
Fixed a crash happening only on iOS 6 devices using PubNub.

### DIFF
--- a/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/PNReachability.m
+++ b/iOS/iPadDemoApp/pubnub/libs/PubNub/Network/PNReachability.m
@@ -521,10 +521,8 @@ void PNReachabilityCallback(SCNetworkReachabilityRef reachability __unused, SCNe
             NSHTTPURLResponse *response;
             NSString *timeTokenRequestPath = [[PNNetworkHelper originLookupResourcePath] stringByReplacingOccurrencesOfString:@"(null)"
                                                                                                                withString:@"pubsub.pubnub.com"];
-            NSMutableURLRequest *timeTokenRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:timeTokenRequestPath]];
-            timeTokenRequest.timeoutInterval = kPNReachabilityOriginLookupTimeout;
+            NSMutableURLRequest *timeTokenRequest = [[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:timeTokenRequestPath] cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:kPNReachabilityOriginLookupTimeout];
             NSData *downloadedTimeTokenData = [NSURLConnection sendSynchronousRequest:timeTokenRequest returningResponse:&response error:&requestError];
-            [[NSURLCache sharedURLCache] removeCachedResponseForRequest:timeTokenRequest];
             
             dispatch_async(dispatch_get_main_queue(), ^{
                 


### PR DESCRIPTION
I was getting a crash when attempting to clear the sharedURLCache on iOS6. Strangely, the timeTokenRequest doesn't exist in the cache (maybe this is why it crashes?). In any case, I simply changed the init call to ensure it always hits the remote server and doesn't cache the response instead of assuming it caches and then removing the cached response.

Stack Trace for iOS 6 crash:
#0	0x39405e04 in dispatch_resume$VARIANT$up ()
#1	0x30fed274 in __CFURLCache::AddCacheTask0(__CFURLCacheNode*) ()
#2	0x30fecf7c in __CFURLCache::AddCacheTask(__CFURLCacheNode*) ()
#3	0x30fedf1e in CFURLCacheRemoveCachedResponseForRequest ()
#4	0x0039caf0 in __41-[PNReachability handleOriginLookupTimer]_block_invoke at /Users/schapman/workspace/Delphi_Mobile_Libs/Externals/PubNub/Network/PNReachability.m:527
#5	0x3940611e in _dispatch_call_block_and_release ()
#6	0x39414258 in _dispatch_root_queue_drain ()
#7	0x394143b8 in _dispatch_worker_thread2 ()
#8	0x3943aa10 in _pthread_wqthread ()
