### PR TITLE
Fix an issue where the delegate method `-pubnubClient:willSuspendWithBlo...

### DIFF
--- a/PubNub.podspec
+++ b/PubNub.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = 'PubNub'
-  s.version      = '3.7.7'
+  s.version      = '3.7.7-fix'
   s.summary      = 'The PubNub Real-Time Network. Build real-time apps quickly and scale them globally.'
   s.authors = {
     'PubNub, Inc.' => 'support@pubnub.com'
   }
   s.source = {
-    :git => 'https://github.com/pubnub/objective-c.git',
+    :git => 'https://github.com/SandyChapman/objective-c.git',
     :tag => 'v3.7.7'
   }
   


### PR DESCRIPTION
...ck:` is not called until _after_ the client resumes. This is preventing custom client work that should happen prior to the application (and PubNub) suspending.

To do this, we must move the beginBackgroundTask call outside of the async block as the main queue may be (and usually is) suspended at the end of the runloop iteration. This means the async block which should be run on the next main thread runloop iteration to not be called until the app resumes.