### PR TITLE
Fix for participants always returning nil.

### DIFF
--- a/PubNub/PubNub/PubNub/Data/Channels/PNChannel.m
+++ b/PubNub/PubNub/PubNub/Data/Channels/PNChannel.m
@@ -278,10 +278,13 @@ static NSObject *_synchronizationObject = nil;
 - (NSArray *)participants {
     
     __block NSArray *participants = nil;
+    
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     [_synchronizationObject pn_dispatchBlock:^{
-
         participants = [self.participantsList allValues];
+        dispatch_semaphore_signal(semaphore);
     }];
+    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
     
     
     return participants;


### PR DESCRIPTION
This pull request addresses an issue in which participants would alway return nil when called on a PNChannel. [_synchronizationObject pn_dispatchBlock:] runs asynchronously and, subsequently, -[PNChannel participants] returns before the local participants reference can be set by the block.

I intended to add tests for this but wasn't sure where you would like them.