### PR TITLE
Removing code that changed how NSNull is represented after an object is ...

### DIFF
--- a/PubNub/PubNub/PubNub/Data/PNJSONSerialization.m
+++ b/PubNub/PubNub/PubNub/Data/PNJSONSerialization.m
@@ -193,12 +193,6 @@
         JSONString = object;
     }
 
-    // Replace null value has been passed or not (serialized [NSNull null] value)
-	if ([JSONString respondsToSelector:@selector(stringByReplacingOccurrencesOfString:withString:)]) {
-
-		JSONString = [JSONString stringByReplacingOccurrencesOfString:@":null" withString:@":\"null\""];
-	}
-
     return JSONString;
 }
 


### PR DESCRIPTION
...serialized. 

This code was preventing messages from being properly deserialized after being received.

Fix for #87 