### PR TITLE
Specify CocoaLumberjack version requirement.

### DIFF
--- a/PubNub.podspec
+++ b/PubNub.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
   # s.public_header_files = 'Pod/Classes/**/*.h'
   s.library   = 'z'
   s.dependency 'AFNetworking', '~> 2.5'
-  s.dependency 'CocoaLumberjack'
+  s.dependency 'CocoaLumberjack', '~> 2.0'
 
 
 s.license = %{


### PR DESCRIPTION
PubNub 4.0 only works with CocoaLumberjack 2.x, but SDK integrators may be using older versions in their projects.

The podfile now specifies 2.0 as a minimum requirement.