### PR TITLE
unused DDLogLevel should be static

### DIFF
--- a/PubNub/Core/PubNub+Time.m
+++ b/PubNub/Core/PubNub+Time.m
@@ -8,12 +8,6 @@
 #import "PubNub+CorePrivate.h"
 #import "PNStatus.h"
 
-#pragma mark CocoaLumberjack logging support
-
-DDLogLevel ddLogLevel = (DDLogLevel)(PNInfoLogLevel|PNFailureStatusLogLevel|
-                                            PNAPICallLogLevel);
-
-
 #pragma mark - Interface implementation
 
 @implementation PubNub (Time)


### PR DESCRIPTION
Not declaring DDLogLevel static causes duplicate symbol warnings when
linked with other pods that use CocoaLumberjack.  However, since
DDLogLevel is not being used in this file, removing it altogether
avoids the unused variable warning that would result by simply
inserting the static keyword.