### PR TITLE
Updated CocoaLumberjack dependency to ~> 2.0.0

### DIFF
--- a/PubNub.podspec
+++ b/PubNub.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   ]
 
   s.library   = "z"
-  s.dependency "CocoaLumberjack", "2.0.0"
+  s.dependency "CocoaLumberjack", "~> 2.0.0"
 
 
 s.license = %{ :type => "MIT", :text => <<-LICENSE'


### PR DESCRIPTION
Also I'd suggest to rename this repo from objective-c to pubnub-objective-c.