### PR TITLE
Update to allow CocoaLumberjack minor versions higher than 2.0.0

### DIFF
--- a/PubNub.podspec
+++ b/PubNub.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
   ]
 
   s.library   = "z"
-  s.dependency "CocoaLumberjack", "2.0.0"
+  s.dependency "CocoaLumberjack", "~> 2.0.0"
 
 
 s.license = %{ :type => "MIT", :text => <<-LICENSE'


### PR DESCRIPTION
CocoaLumberjack v2.0.0 has a known issue that prevents it from compiling if using the `DDLogV*` macros for C/C++ logging. v2.0.1 fixed the compilation issue. Updating the podspec to allow for minor version updates.

This would allow our project to use both PubNub v4.0 and CocoaLumberjack v2.0.1.