### PR TITLE
Changed Base64 decoding settings

### DIFF
--- a/PubNub/Misc/Helpers/PNString.h
+++ b/PubNub/Misc/Helpers/PNString.h
@@ -46,7 +46,7 @@
 /**
  @brief      Convert provided base64-encoded \c string to \a NSData.
  @dicsuccion This is shortcut to [[NSData alloc] initWithBase64EncodedString:object
-                                                             options:(NSDataBase64DecodingOptions)0]
+                                  ptions:NSDataBase64DecodingIgnoreUnknownCharacters]
              method.
  
  @param string Reference on base64-encoded string which should be converted.

--- a/PubNub/Misc/Helpers/PNString.m
+++ b/PubNub/Misc/Helpers/PNString.m
@@ -55,7 +55,7 @@
 + (NSData *)bas64DataFrom:(NSString *)string {
     
     return [[NSData alloc] initWithBase64EncodedString:string
-                                               options:(NSDataBase64DecodingOptions)0];
+                                               options:NSDataBase64DecodingIgnoreUnknownCharacters];
 }
 
 


### PR DESCRIPTION
Looks like some clients changed Base64 algorithms and now add redundant characters which not handled by Apple's Base64 decoding API with settings which has been set earlier.
Changed settings to ignore unknown characters during string processing.