### PR TITLE
Default APPLICATION_EXTENSION_API_ONLY to YES for framework targets.

### DIFF
--- a/Framework/PubNub Framework.xcodeproj/project.pbxproj
+++ b/Framework/PubNub Framework.xcodeproj/project.pbxproj
@@ -4814,6 +4814,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -4861,6 +4862,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
This allows pubnub to be used app extensions without linker warnings, i.e.
`linking against dylib not safe for use in application extensions`
