### PR TITLE
Added ability provide limited customization of NSURLSessionConfiguration

### DIFF
--- a/Example/PubNub Example.xcodeproj/project.pbxproj
+++ b/Example/PubNub Example.xcodeproj/project.pbxproj
@@ -202,12 +202,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 511725F41BE92F7B008F069E /* Build configuration list for PBXNativeTarget "PubNub Mac Example" */;
 			buildPhases = (
-				B43BE5CB23FFC9F475C67714 /* 📦 Check Pods Manifest.lock */,
+				B43BE5CB23FFC9F475C67714 /* [CP] Check Pods Manifest.lock */,
 				511725D01BE92F7B008F069E /* Sources */,
 				511725D11BE92F7B008F069E /* Frameworks */,
 				511725D21BE92F7B008F069E /* Resources */,
-				25A94CEBC351F9AB7C097937 /* 📦 Embed Pods Frameworks */,
-				FB121E715B8FCA19D35675B1 /* 📦 Copy Pods Resources */,
+				25A94CEBC351F9AB7C097937 /* [CP] Embed Pods Frameworks */,
+				FB121E715B8FCA19D35675B1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -222,12 +222,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 6003F5BF195388D20070C39A /* Build configuration list for PBXNativeTarget "PubNub_Example" */;
 			buildPhases = (
-				B1CACE47BA2FE188EE50BDA4 /* 📦 Check Pods Manifest.lock */,
+				B1CACE47BA2FE188EE50BDA4 /* [CP] Check Pods Manifest.lock */,
 				6003F586195388D20070C39A /* Sources */,
 				6003F587195388D20070C39A /* Frameworks */,
 				6003F588195388D20070C39A /* Resources */,
-				A0AD9FD9876D67D2B6B62A3F /* 📦 Embed Pods Frameworks */,
-				55C5A4C909622F5DB07E3205 /* 📦 Copy Pods Resources */,
+				A0AD9FD9876D67D2B6B62A3F /* [CP] Embed Pods Frameworks */,
+				55C5A4C909622F5DB07E3205 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -298,14 +298,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		25A94CEBC351F9AB7C097937 /* 📦 Embed Pods Frameworks */ = {
+		25A94CEBC351F9AB7C097937 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -313,14 +313,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-PubNub Mac Example/Pods-PubNub Mac Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		55C5A4C909622F5DB07E3205 /* 📦 Copy Pods Resources */ = {
+		55C5A4C909622F5DB07E3205 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -328,14 +328,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-PubNub_Example/Pods-PubNub_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A0AD9FD9876D67D2B6B62A3F /* 📦 Embed Pods Frameworks */ = {
+		A0AD9FD9876D67D2B6B62A3F /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -343,14 +343,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-PubNub_Example/Pods-PubNub_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B1CACE47BA2FE188EE50BDA4 /* 📦 Check Pods Manifest.lock */ = {
+		B1CACE47BA2FE188EE50BDA4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -358,14 +358,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		B43BE5CB23FFC9F475C67714 /* 📦 Check Pods Manifest.lock */ = {
+		B43BE5CB23FFC9F475C67714 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -373,14 +373,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		FB121E715B8FCA19D35675B1 /* 📦 Copy Pods Resources */ = {
+		FB121E715B8FCA19D35675B1 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/PubNub Example.xcodeproj/xcshareddata/xcschemes/PubNub Example.xcscheme
+++ b/Example/PubNub Example.xcodeproj/xcshareddata/xcschemes/PubNub Example.xcscheme
@@ -56,7 +56,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Framework/PubNub Framework.xcodeproj/project.pbxproj
+++ b/Framework/PubNub Framework.xcodeproj/project.pbxproj
@@ -764,6 +764,27 @@
 		798843AA1C191692003E8948 /* PubNub.h in Headers */ = {isa = PBXBuildFile; fileRef = 795158611C11EA5500A9D3AE /* PubNub.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		798843AB1C1916A6003E8948 /* PubNub+FAB.h in Headers */ = {isa = PBXBuildFile; fileRef = 79ACC3D91C11BB420056523A /* PubNub+FAB.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		798843AC1C1916AC003E8948 /* PubNub+FAB.m in Sources */ = {isa = PBXBuildFile; fileRef = 79ACC3DA1C11BB420056523A /* PubNub+FAB.m */; };
+		79A238D01D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D11D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D21D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D31D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D41D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D51D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D61D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79A238D71D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238D81D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238D91D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238DA1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238DB1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238DC1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238DD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */; };
+		79A238DE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
+		79A238DF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
+		79A238E01D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
+		79A238E11D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
+		79A238E21D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
+		79A238E31D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
+		79A238E41D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */; };
 		79A8BC1E1C58F93900015BDE /* PubNub+History.m in Sources */ = {isa = PBXBuildFile; fileRef = 79CBB05E1BD03DE4001FC34D /* PubNub+History.m */; };
 		79A8BC1F1C58F93900015BDE /* PNPresenceGlobalHereNowResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 79CBB0951BD03DE4001FC34D /* PNPresenceGlobalHereNowResult.m */; };
 		79A8BC201C58F93900015BDE /* PNString.m in Sources */ = {isa = PBXBuildFile; fileRef = 79CBB0BC1BD03DE4001FC34D /* PNString.m */; };
@@ -1421,6 +1442,9 @@
 		798842C81C18F369003E8948 /* CocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = CocoaLumberjack.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		798842F51C19133E003E8948 /* merge_static_libraries.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = merge_static_libraries.sh; sourceTree = "<group>"; };
 		798843A11C191579003E8948 /* PubNub.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = PubNub.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionConfiguration+PNConfiguration.h"; sourceTree = "<group>"; };
+		79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionConfiguration+PNConfiguration.m"; sourceTree = "<group>"; };
+		79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionConfiguration+PNConfigurationPrivate.h"; sourceTree = "<group>"; };
 		79A8BCC41C58F93900015BDE /* PubNub.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PubNub.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		79A8BCC61C58F97A00015BDE /* PubNub-tvOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PubNub-tvOS-Info.plist"; sourceTree = "<group>"; };
 		79A8BD8F1C58FA7F00015BDE /* CocoaLumberjack.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CocoaLumberjack.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1733,6 +1757,16 @@
 			path = ../../Support/Fabric/Headers;
 			sourceTree = "<group>";
 		};
+		79A238CC1D2E70BD00D080CD /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				79A238CD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h */,
+				79A238CE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m */,
+				79A238CF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
 		79CBB0341BD03D3F001FC34D = {
 			isa = PBXGroup;
 			children = (
@@ -1911,6 +1945,7 @@
 		79CBB0AA1BD03DE4001FC34D /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				79A238CC1D2E70BD00D080CD /* Categories */,
 				79CBB0CB1BD03DE4001FC34D /* Protocols */,
 				79CBB0AB1BD03DE4001FC34D /* Helpers */,
 				79CBB0BF1BD03DE4001FC34D /* Logger */,
@@ -2121,6 +2156,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A238D01D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				791582771BD709C60084FC70 /* PNPushNotificationsStateModificationParser.h in Headers */,
 				791582521BD709C60084FC70 /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				791582A21BD709C60084FC70 /* PNChannelGroupModificationParser.h in Headers */,
@@ -2163,6 +2199,7 @@
 				791582841BD709C60084FC70 /* PNStatus+Private.h in Headers */,
 				791582621BD709C60084FC70 /* PubNub+Subscribe.h in Headers */,
 				7915829D1BD709C60084FC70 /* PNStateListener.h in Headers */,
+				79A238DE1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				791582911BD709C60084FC70 /* PNHistoryParser.h in Headers */,
 				791582681BD709C60084FC70 /* PNHistoryResult.h in Headers */,
 				791582671BD709C60084FC70 /* PNConfiguration.h in Headers */,
@@ -2216,6 +2253,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A238D21D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				791583201BD709D10084FC70 /* PNPushNotificationsStateModificationParser.h in Headers */,
 				791582FB1BD709D10084FC70 /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				7915834B1BD709D10084FC70 /* PNChannelGroupModificationParser.h in Headers */,
@@ -2252,6 +2290,7 @@
 				791583481BD709D10084FC70 /* PubNub+CorePrivate.h in Headers */,
 				7915832F1BD709D10084FC70 /* PNHeartbeatParser.h in Headers */,
 				7915832B1BD709D10084FC70 /* PNSubscribeParser.h in Headers */,
+				79A238E01D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				7915830C1BD709D10084FC70 /* PNSubscribeStatus.h in Headers */,
 				791583471BD709D10084FC70 /* PNResult+Private.h in Headers */,
 				791583411BD709D10084FC70 /* PNLogFileManager.h in Headers */,
@@ -2353,6 +2392,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A238D51D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				798842B01C18F2D5003E8948 /* PNPushNotificationsStateModificationParser.h in Headers */,
 				798842461C18F15C003E8948 /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				798842A61C18F2D3003E8948 /* PNChannelGroupModificationParser.h in Headers */,
@@ -2389,6 +2429,7 @@
 				798842301C18F0A2003E8948 /* PubNub+CorePrivate.h in Headers */,
 				798842B21C18F2D6003E8948 /* PNSubscribeParser.h in Headers */,
 				798842A91C18F2D4003E8948 /* PNHeartbeatParser.h in Headers */,
+				79A238E31D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				798842771C18F208003E8948 /* PNSubscribeStatus.h in Headers */,
 				7988424B1C18F173003E8948 /* PNResult+Private.h in Headers */,
 				798842981C18F2A2003E8948 /* PNLogFileManager.h in Headers */,
@@ -2468,6 +2509,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A238D61D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				798843801C191579003E8948 /* PNPushNotificationsStateModificationParser.h in Headers */,
 				7988437C1C191579003E8948 /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				798843571C191579003E8948 /* PNChannelGroupModificationParser.h in Headers */,
@@ -2506,6 +2548,7 @@
 				7988434B1C191579003E8948 /* PNHeartbeatParser.h in Headers */,
 				798843451C191579003E8948 /* PNSubscribeStatus.h in Headers */,
 				7988438B1C191579003E8948 /* PNResult+Private.h in Headers */,
+				79A238E41D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				798843721C191579003E8948 /* PNLogFileManager.h in Headers */,
 				798843561C191579003E8948 /* PNStatus+Private.h in Headers */,
 				798843471C191579003E8948 /* PubNub+Subscribe.h in Headers */,
@@ -2564,6 +2607,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A238D11D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				79A8BC8D1C58F93900015BDE /* PNPushNotificationsStateModificationParser.h in Headers */,
 				79A8BC681C58F93900015BDE /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				79A8BCBA1C58F93900015BDE /* PNChannelGroupModificationParser.h in Headers */,
@@ -2600,6 +2644,7 @@
 				79A8BCB71C58F93900015BDE /* PubNub+CorePrivate.h in Headers */,
 				79A8BC9D1C58F93900015BDE /* PNHeartbeatParser.h in Headers */,
 				79A8BC991C58F93900015BDE /* PNSubscribeParser.h in Headers */,
+				79A238DF1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				79A8BC791C58F93900015BDE /* PNSubscribeStatus.h in Headers */,
 				79A8BCB61C58F93900015BDE /* PNResult+Private.h in Headers */,
 				79A8BCB01C58F93900015BDE /* PNLogFileManager.h in Headers */,
@@ -2680,6 +2725,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79A238D41D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				79ACC4591C11BC4D0056523A /* PNPushNotificationsStateModificationParser.h in Headers */,
 				79ACC4341C11BC4D0056523A /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				79ACC4851C11BC4D0056523A /* PNChannelGroupModificationParser.h in Headers */,
@@ -2718,6 +2764,7 @@
 				79ACC4641C11BC4D0056523A /* PNSubscribeParser.h in Headers */,
 				79ACC4451C11BC4D0056523A /* PNSubscribeStatus.h in Headers */,
 				79ACC4811C11BC4D0056523A /* PNResult+Private.h in Headers */,
+				79A238E21D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				79ACC47B1C11BC4D0056523A /* PNLogFileManager.h in Headers */,
 				79ACC4661C11BC4D0056523A /* PNStatus+Private.h in Headers */,
 				79ACC4441C11BC4D0056523A /* PubNub+Subscribe.h in Headers */,
@@ -2776,6 +2823,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79E20D2B1C8B0A70001BC9CC /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				79CBB16A1BD03DE4001FC34D /* PNChannelGroupModificationParser.h in Headers */,
 				79CBB1241BD03DE4001FC34D /* PNChannelGroupClientStateResult.h in Headers */,
 				79CBB17C1BD03DE4001FC34D /* PNPushNotificationsAuditParser.h in Headers */,
@@ -2800,7 +2848,6 @@
 				79CBB13C1BD03DE4001FC34D /* PNServiceData+Private.h in Headers */,
 				79CBB1661BD03DE4001FC34D /* PNObjectEventListener.h in Headers */,
 				79CBB1261BD03DE4001FC34D /* PNChannelGroupsResult.h in Headers */,
-				79E20D2B1C8B0A70001BC9CC /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				79E20D191C8AEC44001BC9CC /* PNEnvelopeInformation.h in Headers */,
 				79CBB16C1BD03DE4001FC34D /* PNClientStateParser.h in Headers */,
 				79CBB18C1BD03DE4001FC34D /* PNRequestParameters.h in Headers */,
@@ -2813,6 +2860,7 @@
 				79CBB1821BD03DE4001FC34D /* PNSubscribeParser.h in Headers */,
 				79CBB1441BD03DE4001FC34D /* PNSubscribeStatus.h in Headers */,
 				79CBB1391BD03DE4001FC34D /* PNResult+Private.h in Headers */,
+				79A238E11D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfigurationPrivate.h in Headers */,
 				79CBB15D1BD03DE4001FC34D /* PNLogFileManager.h in Headers */,
 				79CBB13F1BD03DE4001FC34D /* PNStatus+Private.h in Headers */,
 				79CBB1081BD03DE4001FC34D /* PubNub+Subscribe.h in Headers */,
@@ -2834,6 +2882,7 @@
 				79CBB1131BD03DE4001FC34D /* PNSubscriber.h in Headers */,
 				79CBB1591BD03DE4001FC34D /* PNURLRequest.h in Headers */,
 				79CBB18E1BD03DE4001FC34D /* PNURLBuilder.h in Headers */,
+				79A238D31D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				79CBB1841BD03DE4001FC34D /* PNTimeParser.h in Headers */,
 				79CBB1651BD03DE4001FC34D /* PNStructures.h in Headers */,
 				79CBB1461BD03DE4001FC34D /* PNTimeResult.h in Headers */,
@@ -3710,6 +3759,7 @@
 				7915820C1BD709C60084FC70 /* PubNub+Core.m in Sources */,
 				791582181BD709C60084FC70 /* PubNub+APNS.m in Sources */,
 				7915821B1BD709C60084FC70 /* PubNub+Time.m in Sources */,
+				79A238D71D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 				79E2D0F41C56434700BAA244 /* PNKeychain.m in Sources */,
 				791582281BD709C60084FC70 /* PNChannel.m in Sources */,
 				791582391BD709C60084FC70 /* PNNetwork.m in Sources */,
@@ -3787,6 +3837,7 @@
 				791582C41BD709D10084FC70 /* PubNub+Time.m in Sources */,
 				791582C11BD709D10084FC70 /* PubNub+APNS.m in Sources */,
 				791582B51BD709D10084FC70 /* PubNub+Core.m in Sources */,
+				79A238D91D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 				79E2D0F51C56434700BAA244 /* PNKeychain.m in Sources */,
 				791582E21BD709D10084FC70 /* PNNetwork.m in Sources */,
 				791582D11BD709D10084FC70 /* PNChannel.m in Sources */,
@@ -3896,6 +3947,7 @@
 				798842501C18F199003E8948 /* PubNub+APNS.m in Sources */,
 				7988425A1C18F1C8003E8948 /* PNHeartbeat.m in Sources */,
 				798842581C18F1C0003E8948 /* PubNub+Time.m in Sources */,
+				79A238DC1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 				79E2D0F81C56434700BAA244 /* PNKeychain.m in Sources */,
 				7988428C1C18F291003E8948 /* PNChannel.m in Sources */,
 				798842A01C18F2C2003E8948 /* PNNetwork.m in Sources */,
@@ -4005,6 +4057,7 @@
 				798843171C191579003E8948 /* PNGZIP.m in Sources */,
 				798843321C191579003E8948 /* PNLog.m in Sources */,
 				798843251C191579003E8948 /* PNAES.m in Sources */,
+				79A238DD1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4067,6 +4120,7 @@
 				79A8BC301C58F93900015BDE /* PubNub+Time.m in Sources */,
 				79A8BC2D1C58F93900015BDE /* PubNub+APNS.m in Sources */,
 				79A8BC211C58F93900015BDE /* PubNub+Core.m in Sources */,
+				79A238D81D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 				79A8BC491C58F93900015BDE /* PNKeychain.m in Sources */,
 				79A8BC4F1C58F93900015BDE /* PNNetwork.m in Sources */,
 				79A8BC3D1C58F93900015BDE /* PNChannel.m in Sources */,
@@ -4176,6 +4230,7 @@
 				79ACC3EF1C11BC4D0056523A /* PNData.m in Sources */,
 				79ACC4191C11BC4D0056523A /* PNAES.m in Sources */,
 				79ACC4161C11BC4D0056523A /* PNLog.m in Sources */,
+				79A238DB1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4238,6 +4293,7 @@
 				79CBB10C1BD03DE4001FC34D /* PubNub+Time.m in Sources */,
 				79CBB0FD1BD03DE4001FC34D /* PubNub+Core.m in Sources */,
 				79CBB0F91BD03DE4001FC34D /* PubNub+APNS.m in Sources */,
+				79A238DA1D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.m in Sources */,
 				79E2D0F61C56434700BAA244 /* PNKeychain.m in Sources */,
 				79CBB1871BD03DE4001FC34D /* PNNetwork.m in Sources */,
 				79CBB14B1BD03DE4001FC34D /* PNChannel.m in Sources */,

--- a/Framework/PubNub/PubNub.h
+++ b/Framework/PubNub/PubNub.h
@@ -16,6 +16,9 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 // Protocols
 #import "PNObjectEventListener.h"
 
+// Categories
+#import "NSURLSessionConfiguration+PNConfiguration.h"
+
 // Data objects
 #import "PNPresenceChannelGroupHereNowResult.h"
 #import "PNChannelGroupClientStateResult.h"

--- a/PubNub.podspec
+++ b/PubNub.podspec
@@ -41,6 +41,7 @@ Pod::Spec.new do |spec|
             'PubNub/Misc/Helpers/*.h',
             'PubNub/Misc/Logger/{PNLogFileManager,PNLogger,PNLogMacro}.h',
             'PubNub/Misc/Protocols/PNParser.h',
+            'PubNub/Misc/Categories/*Private.h',
             'PubNub/Network/**/*.h',
         ]
         core.exclude_files = "PubNub/Core/PubNub+FAB.{h,m}"

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.h
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.h
@@ -92,7 +92,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSArray<Class> *)pn_protocolClasses;
 
 /**
- @brief  Configure extra set of protocols which will handle requests which is sent to \b PubNub service.
+ @brief   Configure extra set of protocols which will handle requests which is sent to \b PubNub service.
+ @warning Protocol classes which is prefixed with: \b NS or \b _NS will be ignored.
  
  @since 4.4.0
  

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.h
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.h
@@ -1,0 +1,130 @@
+#import <Foundation/Foundation.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ @brief \c NSURLSessionConfiguration extension to provide limited \c NSURLSession configuration abilities for 
+        developers.
+ 
+ @author Sergey Mamontov
+ @since 4.4.0
+ @copyright © 2009-2016 PubNub, Inc.
+ */
+@interface NSURLSessionConfiguration (PNConfiguration)
+
+
+///------------------------------------------------
+/// @name Configuration
+///------------------------------------------------
+
+/**
+ @brief  Retrieve reference on previously configured set of custom HTTP headers.
+ @note   Dictionary won't include headers provided by \b PubNub client.
+ 
+ @since 4.4.0
+ 
+ @return Previously configured custom set of HTTP headers which should be sent along with every request to 
+         \b PubNub service.
+ */
++ (nullable NSDictionary<NSString *, id> *)pn_HTTPAdditionalHeaders;
+
+/**
+ @brief      Extend additional headers with custom values.
+ @discussion Additional set of headers which is not used by \b PubNub service but can be used by intermediate 
+             tunneling software.
+ @note       Next set of fields will be ignored: Accept, Accept-Encoding, User-Agent and Connection.
+ 
+ @since 4.4.0
+ 
+ @param HTTPAdditionalHeaders Reference on custom set of HTTP headers which should be sent along with every 
+                              request to \b PubNub service.
+ */
++ (void)pn_setHTTPAdditionalHeaders:(nullable NSDictionary<NSString *, id> *)HTTPAdditionalHeaders;
+
+/**
+ @brief  Retrieve previously configured configured network service type.
+ @note   \c NSURLNetworkServiceTypeDefault is set by default and will be returned if nothing changed.
+ 
+ @since 4.4.0
+ 
+ @return One of \c NSURLRequestNetworkServiceType enum fields which represent target network service type.
+ */
++ (NSURLRequestNetworkServiceType)pn_networkServiceType;
+
+/**
+ @brief  Set target network service type.
+ 
+ @since 4.4.0
+ 
+ @param networkServiceType One of \c NSURLRequestNetworkServiceType enum fields which represent target network
+                           service type.
+ */
++ (void)pn_setNetworkServiceType:(NSURLRequestNetworkServiceType)networkServiceType;
+
+/**
+ @brief  Retrieve whether previously has been set to use \c WiFi access \b only or \c cellular can be used as 
+         well.
+ 
+ @since 4.4.0
+ 
+ @return \c YES in case if cellular data can be used as well to access \b PubNub service.
+ */
++ (BOOL)pn_allowsCellularAccess;
+
+/**
+ @brief      Set whether it is allowed to use cellular data to access \b PubNub service or not.
+ @discussion \b Default: \b YES
+ 
+ @since 4.4.0
+ 
+ @param allowsCellularAccess Whether cellular data usage allowed to get access to \b PubNub service or not.
+ */
++ (void)pn_setAllowsCellularAccess:(BOOL)allowsCellularAccess;
+
+/**
+ @brief  Extra set of protocols which will handle requests which is sent to \b PubNub service.
+ 
+ @since 4.4.0
+ 
+ @return Previusly configured requests handling protocol classes.
+ */
++ (nullable NSArray<Class> *)pn_protocolClasses;
+
+/**
+ @brief  Configure extra set of protocols which will handle requests which is sent to \b PubNub service.
+ 
+ @since 4.4.0
+ 
+ @param protocolClasses Reference on requests handling protocol classes which should be used with requests to
+                        \b PubNub service.
+ */
++ (void)pn_setProtocolClasses:(nullable NSArray<Class> *)protocolClasses;
+
+/**
+ @brief  Retrieve reference on previously configured connection proxy information.
+ 
+ @since 4.4.0
+ 
+ @return Previously configured connection proxy information which will be used by \c NSURLSession to open and 
+         send requests to \b PubNub service.
+ */
++ (nullable NSDictionary<NSString *, id> *)pn_connectionProxyDictionary;
+
+/**
+ @brief      Configure connection proxy.
+ @discussion This dictionary will be used by \c NSURLSession to open connection to \b PubNub service and send
+             requests using it.
+ 
+ @since 4.4.0
+ 
+ @param connectionProxyDictionary Dictionary which contain information to setup proxy-based connectino.
+ */
++ (void)pn_setConnectionProxyDictionary:(nullable NSDictionary<NSString *, id> *)connectionProxyDictionary;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.m
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.m
@@ -68,7 +68,7 @@ NS_ASSUME_NONNULL_END
     return (headers.count ? headers : nil);
 }
 
-+ (void)pn_setHTTPAdditionalHeaders:(nullable NSDictionary<NSString *, id> *)HTTPAdditionalHeaders {
++ (void)pn_setHTTPAdditionalHeaders:(NSDictionary<NSString *, id> *)HTTPAdditionalHeaders {
     
     NSMutableDictionary *headers = [HTTPAdditionalHeaders mutableCopy];
     [headers removeObjectsForKeys:@[@"Accept", @"Accept-Encoding", @"User-Agent", @"Connection"]];
@@ -109,8 +109,22 @@ NS_ASSUME_NONNULL_END
 + (NSArray<Class> *)pn_protocolClasses {
     
     NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    NSArray<Class> *protocols = (configuration.protocolClasses.count ? configuration.protocolClasses : nil);
+    if (protocols.count) {
+        
+        NSMutableArray *filteredProtocols = [protocols mutableCopy];
+        [protocols enumerateObjectsUsingBlock:^(Class protocolClass, NSUInteger protocolClassIdx, BOOL *protocolClassesEnumeratorStop) {
+            
+            NSString *className = NSStringFromClass(protocolClass);
+            if ([className hasPrefix:@"_NS"] || [className hasPrefix:@"NS"]) {
+                
+                [filteredProtocols removeObject:protocolClass];
+            }
+        }];
+        protocols = [filteredProtocols copy];
+    }
     
-    return (configuration.protocolClasses.count ? configuration.protocolClasses : nil);
+    return protocols;
 }
 
 + (void)pn_setProtocolClasses:(NSArray<Class> *)protocolClasses {

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.m
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.m
@@ -1,0 +1,164 @@
+/**
+ @author Sergey Mamontov
+ @since 4.4.0
+ @copyright © 2009-2016 PubNub, Inc.
+ */
+#import "NSURLSessionConfiguration+PNConfigurationPrivate.h"
+#if TARGET_OS_WATCH
+    #import <WatchKit/WatchKit.h>
+#elif __IPHONE_OS_VERSION_MIN_REQUIRED
+    #import <UIKit/UIKit.h>
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Private interface declaration
+
+@interface NSURLSessionConfiguration (PNConfigurationProtected)
+
+
+#pragma mark - Misc
+
+/**
+ @brief  Allow to construct set of headers which should be used for network requests.
+ 
+ @return Dictionary with headers which should be added to each request.
+ 
+ @since 4.4.0
+ */
++ (NSDictionary *)pn_defaultHeaders;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+
+#pragma mark Interface implementation
+
+@implementation NSURLSessionConfiguration (PNConfiguration)
+
+
+#pragma mark - Initialization and Configuration
+
++ (instancetype)pn_ephemeralSessionConfiguration {
+    
+    static NSURLSessionConfiguration *_sharedSessionConfiguration;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        
+        _sharedSessionConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+        _sharedSessionConfiguration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+        _sharedSessionConfiguration.URLCache = nil;
+        _sharedSessionConfiguration.HTTPAdditionalHeaders = [self pn_defaultHeaders];
+    });
+    
+    return _sharedSessionConfiguration;
+}
+
++ (NSDictionary<NSString *, id> *)pn_HTTPAdditionalHeaders {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    NSMutableDictionary *headers = [configuration.HTTPAdditionalHeaders mutableCopy];
+    [headers removeObjectsForKeys:@[@"Accept", @"Accept-Encoding", @"User-Agent", @"Connection"]];
+    
+    return (headers.count ? headers : nil);
+}
+
++ (void)pn_setHTTPAdditionalHeaders:(nullable NSDictionary<NSString *, id> *)HTTPAdditionalHeaders {
+    
+    NSMutableDictionary *headers = [HTTPAdditionalHeaders mutableCopy];
+    [headers removeObjectsForKeys:@[@"Accept", @"Accept-Encoding", @"User-Agent", @"Connection"]];
+    if (headers.count) {
+        
+        NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+        [headers addEntriesFromDictionary:configuration.HTTPAdditionalHeaders];
+        configuration.HTTPAdditionalHeaders = headers;
+    }
+}
+
++ (NSURLRequestNetworkServiceType)pn_networkServiceType {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    
+    return configuration.networkServiceType;
+}
+
++ (void)pn_setNetworkServiceType:(NSURLRequestNetworkServiceType)networkServiceType {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    configuration.networkServiceType = networkServiceType;
+}
+
++ (BOOL)pn_allowsCellularAccess {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    
+    return configuration.allowsCellularAccess;
+}
+
++ (void)pn_setAllowsCellularAccess:(BOOL)allowsCellularAccess {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    configuration.allowsCellularAccess = allowsCellularAccess;
+}
+
++ (NSArray<Class> *)pn_protocolClasses {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    
+    return (configuration.protocolClasses.count ? configuration.protocolClasses : nil);
+}
+
++ (void)pn_setProtocolClasses:(NSArray<Class> *)protocolClasses {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    configuration.protocolClasses = protocolClasses;
+}
+
++ (NSDictionary<NSString *, id> *)pn_connectionProxyDictionary {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    
+    return configuration.connectionProxyDictionary;
+}
+
++ (void)pn_setConnectionProxyDictionary:(NSDictionary<NSString *, id> *)connectionProxyDictionary {
+    
+    NSURLSessionConfiguration *configuration = [self pn_ephemeralSessionConfiguration];
+    configuration.connectionProxyDictionary = connectionProxyDictionary;
+}
+
+
+#pragma mark - Misc
+
++ (NSDictionary *)pn_defaultHeaders {
+    
+    NSString *device = @"iPhone";
+#if TARGET_OS_WATCH
+    NSString *osVersion = [[WKInterfaceDevice currentDevice] systemVersion];
+#elif __IPHONE_OS_VERSION_MIN_REQUIRED
+    NSString *osVersion = [[UIDevice currentDevice] systemVersion];
+#elif __MAC_OS_X_VERSION_MIN_REQUIRED
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo]operatingSystemVersion];
+    NSMutableString *osVersion = [NSMutableString stringWithFormat:@"%@.%@",
+                                  @(version.majorVersion), @(version.minorVersion)];
+    if (version.patchVersion > 0) {
+        
+        [osVersion appendFormat:@".%@", @(version.patchVersion)];
+    }
+#endif
+    NSString *userAgent = [NSString stringWithFormat:@"iPhone; CPU %@ OS %@ Version",
+                           device, osVersion];
+    
+    return @{@"Accept":@"*/*", @"Accept-Encoding":@"gzip,deflate", @"User-Agent":userAgent,
+             @"Connection":@"keep-alive"};
+}
+
+#pragma mark -
+
+
+@end

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfigurationPrivate.h
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfigurationPrivate.h
@@ -1,0 +1,37 @@
+/**
+ @author Sergey Mamontov
+ @since 4.4.0
+ @copyright © 2009-2016 PubNub, Inc.
+ */
+#import "NSURLSessionConfiguration+PNConfiguration.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Private interface declaration
+
+@interface NSURLSessionConfiguration (PNConfigurationPrivate)
+
+
+///------------------------------------------------
+/// @name Initialization and Configuration
+///------------------------------------------------
+
+/**
+ @brief      Create and configure shared \c NSURLSession configuration instance.
+ @discussion This instance will be used by \b PubNub client every time when new \c NSURLSession instance 
+             should be created. Shared instance also stores additional user-provided adjustments which will be
+             used by new \c NSURLSession instance.
+ 
+ @since 4.4.0
+ 
+ @return Configured and ready to use \c NSURLSession configuration instance.
+ */
++ (instancetype)pn_ephemeralSessionConfiguration;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -521,6 +521,10 @@ NS_ASSUME_NONNULL_END
     NSURL *fullURL = [NSURL URLWithString:requestURL.absoluteString relativeToURL:self.baseURL];
     NSMutableURLRequest *httpRequest = [NSMutableURLRequest requestWithURL:fullURL];
     httpRequest.HTTPMethod = ([postData length] ? @"POST" : @"GET");
+    OSSpinLockLock(&_lock);
+    httpRequest.cachePolicy = self.session.configuration.requestCachePolicy;
+    httpRequest.allHTTPHeaderFields = self.session.configuration.HTTPAdditionalHeaders;
+    OSSpinLockUnlock(&_lock);
     if (postData) {
         
         NSMutableDictionary *allHeaders = [httpRequest.allHTTPHeaderFields mutableCopy];

--- a/PubNub/PubNub.h
+++ b/PubNub/PubNub.h
@@ -4,6 +4,9 @@
 // Protocols
 #import "PNObjectEventListener.h"
 
+// Categories
+#import "NSURLSessionConfiguration+PNConfiguration.h"
+
 // Data objects
 #import "PNPresenceChannelGroupHereNowResult.h"
 #import "PNChannelGroupClientStateResult.h"

--- a/Support/Fabric/Headers/PubNub.h
+++ b/Support/Fabric/Headers/PubNub.h
@@ -16,6 +16,9 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 // Protocols
 #import "PNObjectEventListener.h"
 
+// Categories
+#import "NSURLSessionConfiguration+PNConfiguration.h"
+
 // Data objects
 #import "PNPresenceChannelGroupHereNowResult.h"
 #import "PNChannelGroupClientStateResult.h"

--- a/Tests/PubNub Tests.xcodeproj/project.pbxproj
+++ b/Tests/PubNub Tests.xcodeproj/project.pbxproj
@@ -627,13 +627,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 517A9EDA1BE3181700FAA43A /* Build configuration list for PBXNativeTarget "OSX ObjC Tests" */;
 			buildPhases = (
-				E23E551A83F7FDCAED6611A4 /* 📦 Check Pods Manifest.lock */,
+				E23E551A83F7FDCAED6611A4 /* [CP] Check Pods Manifest.lock */,
 				79E198C81CE3EEC400F36216 /* Clean Legacy Code Coverage files */,
 				517A9ECF1BE3181700FAA43A /* Sources */,
 				517A9ED01BE3181700FAA43A /* Frameworks */,
 				517A9ED11BE3181700FAA43A /* Resources */,
-				5B092AC79048C27D83E75052 /* 📦 Embed Pods Frameworks */,
-				D6CF442334495DB6A53083E1 /* 📦 Copy Pods Resources */,
+				5B092AC79048C27D83E75052 /* [CP] Embed Pods Frameworks */,
+				D6CF442334495DB6A53083E1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -648,13 +648,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 519C32861B20C11500FAC283 /* Build configuration list for PBXNativeTarget "iOS ObjC Tests" */;
 			buildPhases = (
-				F4F5AF44E709E998DC9D6894 /* 📦 Check Pods Manifest.lock */,
+				F4F5AF44E709E998DC9D6894 /* [CP] Check Pods Manifest.lock */,
 				79E198C41CE3EDF700F36216 /* Clean Legacy Code Coverage files */,
 				519C32791B20C11500FAC283 /* Sources */,
 				519C327A1B20C11500FAC283 /* Frameworks */,
 				519C327B1B20C11500FAC283 /* Resources */,
-				FE624F309D2D5607A1C0C323 /* 📦 Embed Pods Frameworks */,
-				C08E171FA9C152A118999ED4 /* 📦 Copy Pods Resources */,
+				FE624F309D2D5607A1C0C323 /* [CP] Embed Pods Frameworks */,
+				C08E171FA9C152A118999ED4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -705,13 +705,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 797BDD3C1C1F5176006EF006 /* Build configuration list for PBXNativeTarget "tvOS ObjC Tests" */;
 			buildPhases = (
-				4D05E3765A1B00ACA9B9EA9A /* 📦 Check Pods Manifest.lock */,
+				4D05E3765A1B00ACA9B9EA9A /* [CP] Check Pods Manifest.lock */,
 				79E198C71CE3EEBB00F36216 /* Clean Legacy Code Coverage files */,
 				797BDD061C1F5176006EF006 /* Sources */,
 				797BDD231C1F5176006EF006 /* Frameworks */,
 				797BDD251C1F5176006EF006 /* Resources */,
-				D8EDCBA9E0CAF805B6866FFB /* 📦 Embed Pods Frameworks */,
-				833AEE6152D14ABD2000EC24 /* 📦 Copy Pods Resources */,
+				D8EDCBA9E0CAF805B6866FFB /* [CP] Embed Pods Frameworks */,
+				833AEE6152D14ABD2000EC24 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -906,14 +906,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		4D05E3765A1B00ACA9B9EA9A /* 📦 Check Pods Manifest.lock */ = {
+		4D05E3765A1B00ACA9B9EA9A /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -921,14 +921,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		5B092AC79048C27D83E75052 /* 📦 Embed Pods Frameworks */ = {
+		5B092AC79048C27D83E75052 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1006,14 +1006,14 @@
 			shellPath = /bin/sh;
 			shellScript = "INTERMEDIATES_DIR=\"${BUILD_DIR}/../Intermediates\"\n\nif [ -e \"${INTERMEDIATES_DIR}\" ]; then\n    find ${INTERMEDIATES_DIR} -type f -name \"*.gcda\" -exec rm -rf {} \\;\n    find ${INTERMEDIATES_DIR} -type f -name \"*.gcno\" -exec rm -rf {} \\;\nfi";
 		};
-		833AEE6152D14ABD2000EC24 /* 📦 Copy Pods Resources */ = {
+		833AEE6152D14ABD2000EC24 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1021,14 +1021,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-tvOS ObjC Tests/Pods-tvOS ObjC Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C08E171FA9C152A118999ED4 /* 📦 Copy Pods Resources */ = {
+		C08E171FA9C152A118999ED4 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1036,14 +1036,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-iOS ObjC Tests/Pods-iOS ObjC Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D6CF442334495DB6A53083E1 /* 📦 Copy Pods Resources */ = {
+		D6CF442334495DB6A53083E1 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1051,14 +1051,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-OSX ObjC Tests/Pods-OSX ObjC Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D8EDCBA9E0CAF805B6866FFB /* 📦 Embed Pods Frameworks */ = {
+		D8EDCBA9E0CAF805B6866FFB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1066,14 +1066,14 @@
 			shellScript = "\"${SRCROOT}/../Pods/Target Support Files/Pods-tvOS ObjC Tests/Pods-tvOS ObjC Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E23E551A83F7FDCAED6611A4 /* 📦 Check Pods Manifest.lock */ = {
+		E23E551A83F7FDCAED6611A4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1081,14 +1081,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		F4F5AF44E709E998DC9D6894 /* 📦 Check Pods Manifest.lock */ = {
+		F4F5AF44E709E998DC9D6894 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1096,14 +1096,14 @@
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		FE624F309D2D5607A1C0C323 /* 📦 Embed Pods Frameworks */ = {
+		FE624F309D2D5607A1C0C323 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "📦 Embed Pods Frameworks";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/PubNub Tests.xcodeproj/project.pbxproj
+++ b/Tests/PubNub Tests.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		799CE2F71C45B95400AAEBDC /* PNChannelGroupFilteringSubscribeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 799CE2F61C45B95400AAEBDC /* PNChannelGroupFilteringSubscribeTests.m */; };
 		799CE2F91C45B9FD00AAEBDC /* PNFilteringSubscribeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 799CE2F81C45B9FD00AAEBDC /* PNFilteringSubscribeTests.m */; };
 		799CE2FB1C45BA3000AAEBDC /* PNPresenceChannelGroupTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 799CE2FA1C45BA3000AAEBDC /* PNPresenceChannelGroupTests.m */; };
+		79A238E91D2EB6BA00D080CD /* NSURLSessionConfigurationCategoryTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A238E81D2EB6BA00D080CD /* NSURLSessionConfigurationCategoryTest.m */; };
 		79E198C31CE3DCF600F36216 /* PNNumberTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 79E198C21CE3DCF600F36216 /* PNNumberTests.m */; };
 		79E20D2D1C8B1C64001BC9CC /* PNBasicPresenceTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 799CE2F21C45B8FD00AAEBDC /* PNBasicPresenceTestCase.m */; };
 		79E20D2E1C8B1C64001BC9CC /* PNBasicPresenceTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = 799CE2F21C45B8FD00AAEBDC /* PNBasicPresenceTestCase.m */; };
@@ -279,6 +280,7 @@
 		799CE2F61C45B95400AAEBDC /* PNChannelGroupFilteringSubscribeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNChannelGroupFilteringSubscribeTests.m; path = Tests/PNChannelGroupFilteringSubscribeTests.m; sourceTree = "<group>"; };
 		799CE2F81C45B9FD00AAEBDC /* PNFilteringSubscribeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNFilteringSubscribeTests.m; path = Tests/PNFilteringSubscribeTests.m; sourceTree = "<group>"; };
 		799CE2FA1C45BA3000AAEBDC /* PNPresenceChannelGroupTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNPresenceChannelGroupTests.m; path = Tests/PNPresenceChannelGroupTests.m; sourceTree = "<group>"; };
+		79A238E81D2EB6BA00D080CD /* NSURLSessionConfigurationCategoryTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = NSURLSessionConfigurationCategoryTest.m; path = Tests/NSURLSessionConfigurationCategoryTest.m; sourceTree = "<group>"; };
 		79E198C21CE3DCF600F36216 /* PNNumberTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNNumberTests.m; path = Tests/PNNumberTests.m; sourceTree = "<group>"; };
 		79EF04911B4EAAB7007478CB /* PNAPNSTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNAPNSTests.m; path = Tests/PNAPNSTests.m; sourceTree = "<group>"; };
 		79EF04921B4EAAB7007478CB /* PNChannelGroupSubscribeTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNChannelGroupSubscribeTests.m; path = Tests/PNChannelGroupSubscribeTests.m; sourceTree = "<group>"; };
@@ -464,6 +466,7 @@
 				799CE2F81C45B9FD00AAEBDC /* PNFilteringSubscribeTests.m */,
 				799CE2FA1C45BA3000AAEBDC /* PNPresenceChannelGroupTests.m */,
 				79E198C21CE3DCF600F36216 /* PNNumberTests.m */,
+				79A238E81D2EB6BA00D080CD /* NSURLSessionConfigurationCategoryTest.m */,
 			);
 			name = Tests;
 			path = "iOS Tests";
@@ -1178,6 +1181,7 @@
 				967707F71B8F4A80002B8E84 /* PNPresenceEventTests.m in Sources */,
 				799CE2F31C45B8FD00AAEBDC /* PNBasicPresenceTestCase.m in Sources */,
 				79EF04AA1B4EAAB7007478CB /* PNClientStateChannelTests.m in Sources */,
+				79A238E91D2EB6BA00D080CD /* NSURLSessionConfigurationCategoryTest.m in Sources */,
 				79EF04BB1B4EAAE4007478CB /* PNBasicClientTestCase.m in Sources */,
 				79EF04C21B4EAB01007478CB /* NSString+PNTest.m in Sources */,
 				79EF04B11B4EAAB7007478CB /* PNPublishWithHistoryTests.m in Sources */,

--- a/Tests/iOS Tests/Tests/NSURLSessionConfigurationCategoryTest.m
+++ b/Tests/iOS Tests/Tests/NSURLSessionConfigurationCategoryTest.m
@@ -1,0 +1,228 @@
+#import <XCTest/XCTest.h>
+#import "NSURLSessionConfiguration+PNConfigurationPrivate.h"
+
+
+#pragma mark NSURLProtocol
+
+@interface SessionConfigurationCategoryTestProtocol : NSURLProtocol
+
+@end
+
+@implementation SessionConfigurationCategoryTestProtocol
+
+@end
+
+
+/**
+ @brief      NSURLSessionConfiguration testing.
+ @discussion Verify NSURLSessionConfiguration category apply passed parameters to default \b PubNub session
+             configuration.
+
+ @author Sergey Mamontov
+ @copyright © 2009-2016 PubNub, Inc.
+ */
+@interface NSURLSessionConfigurationCategoryTest : XCTestCase
+
+
+#pragma mark - Properties
+
+/**
+ @brief  Stores reference on shared session configuration which is used to configure \c NSURLSession which
+         is used to call \b PubNub REST API.
+ */
+@property (nonatomic, weak) NSURLSessionConfiguration *configuration;
+
+/**
+ @brief  Storing reference on original set of protocol classes which may be used by mocking libraries.
+ */
+@property (nonatomic, strong) NSArray<Class> *originalProtocolClasses;
+
+
+#pragma mark - Misc
+
+/**
+ @brief  Allow to construct set of headers which should be used for network requests.
+ 
+ @return Dictionary with headers which should be added to each request.
+ */
++ (NSDictionary *)pn_testHeaders;
+
+#pragma mark -
+
+
+@end
+
+
+
+#pragma mark - Test case implementation 
+
+@implementation NSURLSessionConfigurationCategoryTest
+
+
+- (void)setUp {
+    
+    // Forward method call to the super class.
+    [super setUp];
+    
+    self.configuration = [NSURLSessionConfiguration pn_ephemeralSessionConfiguration];
+    self.originalProtocolClasses = [self.configuration.protocolClasses copy];
+    
+    // Reset shared session configuration instance.
+    [NSURLSessionConfiguration pn_setHTTPAdditionalHeaders:nil];
+    [NSURLSessionConfiguration pn_setNetworkServiceType:NSURLNetworkServiceTypeDefault];
+    [NSURLSessionConfiguration pn_setAllowsCellularAccess:YES];
+    [NSURLSessionConfiguration pn_setProtocolClasses:nil];
+    [NSURLSessionConfiguration pn_setConnectionProxyDictionary:nil];
+}
+
+- (void)tearDown {
+    
+    // Forward method call to the super class.
+    [super tearDown];
+    
+    // Restoring original set of protocol classes.
+    self.configuration.protocolClasses = self.originalProtocolClasses;
+}
+
+- (void)testDefaultSessionConfiguration {
+    
+    XCTAssertEqual(self.configuration.requestCachePolicy, NSURLRequestReloadIgnoringLocalCacheData, 
+                  @"Unexpected requests cache policy.");
+    XCTAssertNil(self.configuration.URLCache, @"NSURLCache should be 'nil' for default NSURLSession "
+                 "configuration.");
+    XCTAssertEqualObjects([NSURLSessionConfiguration pn_HTTPAdditionalHeaders], nil, 
+                          @"Custome HTTP headers should be 'nil'.");
+    XCTAssertEqualObjects(self.configuration.HTTPAdditionalHeaders, [[self class] pn_testHeaders], 
+                          @"Unexpected default set of additional HTTP headers.");
+}
+
+- (void)testSetAdditionalHeaders {
+    
+    // Set custom HTTP header.
+    NSDictionary *customHeaders = @{@"X-Powered-By": @"PubNub"};
+    [NSURLSessionConfiguration pn_setHTTPAdditionalHeaders:customHeaders];
+    
+    // Construct expected set of headers.
+    NSMutableDictionary *expectedHeaders = [customHeaders mutableCopy];
+    [expectedHeaders addEntriesFromDictionary:[[self class] pn_testHeaders]];
+    
+    XCTAssertEqualObjects([NSURLSessionConfiguration pn_HTTPAdditionalHeaders], customHeaders, 
+                          @"Unexpected additional HTTP headers.");
+    XCTAssertEqualObjects(self.configuration.HTTPAdditionalHeaders, expectedHeaders, 
+                          @"Unexpected additional HTTP headers.");
+}
+
+- (void)testSetAdditionalHeadersWithCustomUserAgent {
+    
+    // Set custom HTTP header.
+    NSDictionary *customHeaders = @{@"X-Powered-By": @"PubNub", @"User-Agent": @"PubNub-Test"};
+    [NSURLSessionConfiguration pn_setHTTPAdditionalHeaders:customHeaders];
+    
+    // Construct expected set of headers.
+    // Custom 'User-Agent' should be ignored.
+    NSMutableDictionary *expectedHeaders = [customHeaders mutableCopy];
+    [expectedHeaders addEntriesFromDictionary:[[self class] pn_testHeaders]];
+    
+    XCTAssertEqualObjects([NSURLSessionConfiguration pn_HTTPAdditionalHeaders], 
+                          [customHeaders dictionaryWithValuesForKeys:@[@"X-Powered-By"]], 
+                          @"Unexpected additional HTTP headers.");
+    XCTAssertEqualObjects(self.configuration.HTTPAdditionalHeaders, expectedHeaders, 
+                          @"Unexpected additional HTTP headers.");
+}
+
+- (void)testResetAdditionalHeadersToNil {
+    
+    // Set custom HTTP header.
+    NSMutableDictionary *customHeaders = [@{@"X-Powered-By": @"PubNub", 
+                                            @"User-Agent": @"PubNub-Test"} mutableCopy];
+    [NSURLSessionConfiguration pn_setHTTPAdditionalHeaders:customHeaders];
+    [NSURLSessionConfiguration pn_setHTTPAdditionalHeaders:nil];
+    
+    // Construct expected set of headers.
+    NSDictionary *expectedHeaders = [[self class] pn_testHeaders];
+    
+    XCTAssertEqualObjects([NSURLSessionConfiguration pn_HTTPAdditionalHeaders], nil, 
+                          @"Custome HTTP headers should be 'nil'.");
+    XCTAssertEqualObjects(self.configuration.HTTPAdditionalHeaders, expectedHeaders, 
+                          @"Expected only default HTTP header fields.");
+}
+
+- (void)testSetNetworkServiceType {
+    
+    [NSURLSessionConfiguration pn_setNetworkServiceType:NSURLNetworkServiceTypeBackground];
+    
+    XCTAssertEqual([NSURLSessionConfiguration pn_networkServiceType], NSURLNetworkServiceTypeBackground, 
+                   @"Unexpected network service type is set.");
+    XCTAssertEqual(self.configuration.networkServiceType, NSURLNetworkServiceTypeBackground, 
+                   @"Unexpected network service type is set.");
+}
+
+- (void)testSetAllowsCellularAccess {
+    
+    [NSURLSessionConfiguration pn_setAllowsCellularAccess:NO];
+    
+    XCTAssertEqual([NSURLSessionConfiguration pn_allowsCellularAccess], NO, 
+                   @"Expected cellular access to be disabled.");
+    XCTAssertEqual(self.configuration.allowsCellularAccess, NO, @"Expected cellular access to be disabled.");
+}
+
+- (void)testSetProtocolClasses {
+    
+    NSUInteger systemProvidedProtocolsCount = self.configuration.protocolClasses.count;
+    Class testProtocolClass = [SessionConfigurationCategoryTestProtocol class];
+    [NSURLSessionConfiguration pn_setProtocolClasses:@[testProtocolClass]];
+    
+    XCTAssertEqual([NSURLSessionConfiguration pn_protocolClasses].count, 1, 
+                   @"Unexpected number of custom request handlign protocol classes.");
+    XCTAssertEqual(self.configuration.protocolClasses.count, (systemProvidedProtocolsCount + 1), 
+                   @"Unexpected number of custom request handlign protocol classes.");
+    XCTAssertEqualObjects([NSURLSessionConfiguration pn_protocolClasses].firstObject, testProtocolClass, 
+                          @"Expected test protocol class.");
+    XCTAssertEqualObjects(self.configuration.protocolClasses.lastObject, testProtocolClass, 
+                          @"Expected test protocol class.");
+}
+
+
+- (void)testSetConnectionProxy {
+    
+    // Prepare and apply connection proxy dictionary.
+    NSDictionary *proxyDictionary = @{(NSString *)kCFStreamPropertySOCKSProxyHost : @"pubsub.pubnub.com",
+                                      (NSString *)kCFStreamPropertySOCKSProxyPort : @(80) };
+    [NSURLSessionConfiguration pn_setConnectionProxyDictionary:proxyDictionary];
+    
+    XCTAssertEqualObjects([NSURLSessionConfiguration pn_connectionProxyDictionary],  proxyDictionary, 
+                          @"Unexpected connection proxy dictionary content.");
+    XCTAssertEqualObjects(self.configuration.connectionProxyDictionary, proxyDictionary, 
+                          @"Unexpected connection proxy dictionary content.");
+}
+
+
+#pragma mark - Misc
+
++ (NSDictionary *)pn_testHeaders {
+    
+    NSString *device = @"iPhone";
+#if TARGET_OS_WATCH
+    NSString *osVersion = [[WKInterfaceDevice currentDevice] systemVersion];
+#elif __IPHONE_OS_VERSION_MIN_REQUIRED
+    NSString *osVersion = [[UIDevice currentDevice] systemVersion];
+#elif __MAC_OS_X_VERSION_MIN_REQUIRED
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo]operatingSystemVersion];
+    NSMutableString *osVersion = [NSMutableString stringWithFormat:@"%@.%@",
+                                  @(version.majorVersion), @(version.minorVersion)];
+    if (version.patchVersion > 0) {
+        
+        [osVersion appendFormat:@".%@", @(version.patchVersion)];
+    }
+#endif
+    NSString *userAgent = [NSString stringWithFormat:@"iPhone; CPU %@ OS %@ Version",
+                           device, osVersion];
+    
+    return @{@"Accept":@"*/*", @"Accept-Encoding":@"gzip,deflate", @"User-Agent":userAgent,
+             @"Connection":@"keep-alive"};
+}
+
+#pragma mark -
+
+
+@end


### PR DESCRIPTION
NSURLSessionConfiguration which is used by PubNub client to configure NSURLSession for API calls now can be adjusted. Next class methods of **NSURLSessionConfiguration** can be used now to adjust configuration: 

```objc
+ (NSDictionary<NSString *, id> *)pn_HTTPAdditionalHeaders;
+ (void)pn_setHTTPAdditionalHeaders:(NSDictionary<NSString *, id> *)HTTPAdditionalHeaders;
+ (NSURLRequestNetworkServiceType)pn_networkServiceType;
+ (void)pn_setNetworkServiceType:(NSURLRequestNetworkServiceType)networkServiceType; 
+ (BOOL)pn_allowsCellularAccess;
+ (void)pn_setAllowsCellularAccess:(BOOL)allowsCellularAccess;
+ (NSArray<Class> *)pn_protocolClasses;
+ (void)pn_setProtocolClasses:(NSArray<Class> *)protocolClasses;
+ (NSDictionary<NSString *, id> *)pn_connectionProxyDictionary;
+ (void)pn_setConnectionProxyDictionary:(NSDictionary<NSString *, id> *)connectionProxyDictionary;
```