### PR TITLE
Added ability to complete issues API calls before application suspension (for iOS)

### DIFF
--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -509,10 +509,20 @@ NS_ASSUME_NONNULL_END
     if ([notification.name isEqualToString:UIApplicationDidEnterBackgroundNotification]) {
         
         DDLogClientInfo([[self class] ddLogLevel], @"<PubNub> Did enter background execution context.");
+        if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
+            
+            [self.subscriptionNetwork handleClientWillResignActive];
+            [self.serviceNetwork handleClientWillResignActive];
+        }
     }
     else if ([notification.name isEqualToString:UIApplicationWillEnterForegroundNotification]) {
         
         DDLogClientInfo([[self class] ddLogLevel], @"<PubNub> Will enter foreground execution context.");
+        if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
+            
+            [self.subscriptionNetwork handleClientDidBecomeActive];
+            [self.serviceNetwork handleClientDidBecomeActive];
+        }
     }
 #elif __MAC_OS_X_VERSION_MIN_REQUIRED
     if ([notification.name isEqualToString:NSWorkspaceWillSleepNotification] ||

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -15,7 +15,7 @@
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     #import <UIKit/UIKit.h>
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 #import "PubNub+SubscribePrivate.h"
 #import "PNObjectEventListener.h"
 #import "PNClientInformation.h"

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -186,9 +186,24 @@ NS_ASSUME_NONNULL_BEGIN
  @warning    If there history/storage feature has been activated for \b PubNub account, some messages can be 
              pushed to it after some period of time and catch up won't be able to receive them.
  
+ @default    By default client use \b YES to try catch up on missed messages (while client has been 
+             disconnected because of network issues).
+ 
  @since 4.0
  */
 @property (nonatomic, assign, getter = shouldTryCatchUpOnSubscriptionRestore) BOOL catchUpOnSubscriptionRestore;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+/**
+ @brief  Stores whether client should try complete all API call which is done before application will be 
+         completelly suspended.
+ 
+ @default    By default client use \b YES to restore subscription on remote data objects live feeds.
+ 
+ @since 4.<#minor-version#>.0
+ */
+@property (nonatomic, assign, getter = shouldCompleteRequestsBeforeSuspension) BOOL completeRequestsBeforeSuspension;
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 
 /**
  @brief  Construct configuration instance using minimal required data.

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -193,7 +193,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign, getter = shouldTryCatchUpOnSubscriptionRestore) BOOL catchUpOnSubscriptionRestore;
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 /**
  @brief  Stores whether client should try complete all API call which is done before application will be 
          completelly suspended.
@@ -203,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
  @since 4.<#minor-version#>.0
  */
 @property (nonatomic, assign, getter = shouldCompleteRequestsBeforeSuspension) BOOL completeRequestsBeforeSuspension;
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief  Construct configuration instance using minimal required data.

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -136,6 +136,9 @@ NS_ASSUME_NONNULL_END
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
         _restoreSubscription = kPNDefaultShouldRestoreSubscription;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+        _completeRequestsBeforeSuspension = kPNDefaultShouldCompleteRequestsBeforeSuspension;
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
     }
     
     return self;
@@ -160,6 +163,9 @@ NS_ASSUME_NONNULL_END
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;
     configuration.restoreSubscription = self.shouldRestoreSubscription;
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+    configuration.completeRequestsBeforeSuspension = self.shouldCompleteRequestsBeforeSuspension;
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
     
     return configuration;
 }

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -136,9 +136,9 @@ NS_ASSUME_NONNULL_END
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
         _restoreSubscription = kPNDefaultShouldRestoreSubscription;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
         _completeRequestsBeforeSuspension = kPNDefaultShouldCompleteRequestsBeforeSuspension;
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     }
     
     return self;
@@ -163,9 +163,9 @@ NS_ASSUME_NONNULL_END
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;
     configuration.restoreSubscription = self.shouldRestoreSubscription;
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     configuration.completeRequestsBeforeSuspension = self.shouldCompleteRequestsBeforeSuspension;
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     
     return configuration;
 }

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -41,8 +41,8 @@ static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptio
 static BOOL const kPNDefaultShouldKeepTimeTokenOnListChange = YES;
 static BOOL const kPNDefaultShouldRestoreSubscription = YES;
 static BOOL const kPNDefaultShouldTryCatchUpOnSubscriptionRestore = YES;
-#elif __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 static BOOL const kPNDefaultShouldCompleteRequestsBeforeSuspension = YES;
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 #endif // PNConstants_h

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -41,5 +41,8 @@ static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptio
 static BOOL const kPNDefaultShouldKeepTimeTokenOnListChange = YES;
 static BOOL const kPNDefaultShouldRestoreSubscription = YES;
 static BOOL const kPNDefaultShouldTryCatchUpOnSubscriptionRestore = YES;
+#elif __IPHONE_OS_VERSION_MIN_REQUIRED
+static BOOL const kPNDefaultShouldCompleteRequestsBeforeSuspension = YES;
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 
 #endif // PNConstants_h

--- a/PubNub/Network/PNNetwork.h
+++ b/PubNub/Network/PNNetwork.h
@@ -80,7 +80,7 @@
 /// @name Handlers
 ///------------------------------------------------
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief      Handle \b PubNub client transition to inactive satate.
@@ -100,7 +100,7 @@
  */
 - (void)handleClientDidBecomeActive;
 
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 
 ///------------------------------------------------

--- a/PubNub/Network/PNNetwork.h
+++ b/PubNub/Network/PNNetwork.h
@@ -75,6 +75,34 @@
  */
 - (void)invalidate;
 
+
+///------------------------------------------------
+/// @name Handlers
+///------------------------------------------------
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+/**
+ @brief      Handle \b PubNub client transition to inactive satate.
+ @discussion Depending from network manager configuration it may request from system more time to complete 
+             already scheduled data tasks.
+ 
+ @since 4.<#minor-version#>.0
+ */
+- (void)handleClientWillResignActive;
+
+/**
+ @brief      Handle \b PubNub client transition to active satate.
+ @discussion If network manager requested from system more time to complete tasks processing it will cancel 
+             this request.
+ 
+ @since 4.<#minor-version#>.0
+ */
+- (void)handleClientDidBecomeActive;
+
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+
+
 ///------------------------------------------------
 /// @name Operation information
 ///------------------------------------------------

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -950,7 +950,8 @@ NS_ASSUME_NONNULL_END
             [weakSelf endBackgroundTasksCompletionIfRequired];
         }];
              
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05f * NSEC_PER_SEC)),
+        // Give some time before checking whether tasks has been scheduled for execution or not.
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3f * NSEC_PER_SEC)),
                        dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                            
             // Get list of scheduled operation.

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -16,6 +16,9 @@
 #import "PNErrorStatus.h"
 #import "PNErrorParser.h"
 #import "PNURLBuilder.h"
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+    #import <UIKit/UIKit.h>
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 #import "PNConstants.h"
 #import "PNLogMacro.h"
 #import "PNHelpers.h"
@@ -145,6 +148,28 @@ NS_ASSUME_NONNULL_BEGIN
  @since 4.0.2
  */
 @property (nonatomic, strong) PNNetworkResponseSerializer *serializer;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+/**
+ @brief      Stores reference on list of currently scheduled data tasks.
+ @discussion List allow to get information about active data task synchronously at any moment 
+             (when \c NSURLSession allow to get this information only from block which will be scheduled on
+             processing queue).
+ 
+ @since 4.<#minor-version#>.0
+ */
+@property (nonatomic, strong) NSMutableArray<NSURLSessionDataTask *> *scheduledDataTasks;
+
+/**
+ @brief  Stores reference on identifier which has been used to request from system more time to complete
+         pending tasks when client resign active.
+ 
+ @since 4.<#minor-version#>.0
+ */
+@property (nonatomic, assign) UIBackgroundTaskIdentifier tasksCompletionIdentifier;
+
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 
 /**
  @brief  Stores reference on queue which should be used by session to call callbacks and completion blocks on
@@ -290,6 +315,23 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)parseData:(nullable id)data withParser:(Class <PNParser>)parser
        completion:(void(^)(NSDictionary * _Nullable parsedData, BOOL parseError))block;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+/**
+ @brief  Complete processing of tasks which has been scheduled but not completelly processed before \b PubNub 
+         client resign active state.
+ 
+ @since 4.<#minor-version#>.0
+ 
+ @param dataTasks    List of \c NSURLSession data tasks which didn't completed before \b PubNub client resign
+                     active state.
+ @param onCompletion Whether list processed after another data task completed or right \b PubNub after client
+                     resign active state.
+ */
+- (void)processIncompleteBeforeClientResignActiveTasks:(NSArray<NSURLSessionDataTask *> *)dataTasks
+                                  onDataTaskCompletion:(BOOL)onCompletion;
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 
 
 #pragma mark - Session constructor
@@ -439,6 +481,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Misc
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+/**
+ @brief  Check whether there \c operation is in the list of passed \c tasks. 
+ 
+ @since 4.<#minor-version#>.0
+ 
+ @param operation One of \b PNOperationType enum fields which is used during search.
+ @param tasks     List of currently scheduled and pending / executing data tasks among which should be found 
+                  reference on \c operation.
+ 
+ @return \c YES in case if \c operation has been found in list of passed \c tasks.
+ */
+- (BOOL)hasOperation:(PNOperationType)operation inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks;
+
+/**
+ @brief  Depending on current network manager state it may require to complete currently active tasks 
+         completion from background execution context.
+ 
+ @since 4.<#minor-version#>.0
+ */
+- (void)endBackgroundTasksCompletionIfRequired;
+
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+
 /**
  @brief  Print out any session configuration instance customizations which has been done by developer.
  
@@ -490,6 +557,10 @@ NS_ASSUME_NONNULL_END
         _client = client;
         _configuration = client.configuration;
         _forLongPollRequests = longPollEnabled;
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+        _scheduledDataTasks = [NSMutableArray new];
+        _tasksCompletionIdentifier = UIBackgroundTaskInvalid;
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
         _identifier = [[NSString stringWithFormat:@"com.pubnub.network.%p", self] copy];
         _processingQueue = dispatch_queue_create([_identifier UTF8String], DISPATCH_QUEUE_CONCURRENT);;
         _serializer = [PNNetworkResponseSerializer new];
@@ -562,6 +633,12 @@ NS_ASSUME_NONNULL_END
     };
     OSSpinLockLock(&_lock);
     task = [self.session dataTaskWithRequest:request completionHandler:[handler copy]];
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+    if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
+        
+        [self.scheduledDataTasks addObject:task];
+    }
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
     OSSpinLockUnlock(&_lock);
     
     return task;
@@ -728,9 +805,45 @@ NS_ASSUME_NONNULL_END
     }
 }
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+- (void)processIncompleteBeforeClientResignActiveTasks:(NSArray<NSURLSessionDataTask *> *)dataTasks
+                                  onDataTaskCompletion:(BOOL)onCompletion {
+    
+    NSUInteger incompleteTasksCount = dataTasks.count;
+    if (incompleteTasksCount > 0 && self.forLongPollRequests) {
+        
+        if (![self hasOperation:PNUnsubscribeOperation inDataTasks:dataTasks]) {
+            
+            incompleteTasksCount = 0;
+        }
+    }
+    
+    if (incompleteTasksCount == 0) {
+        
+        DDLogRequest([[self class] ddLogLevel], @"<PubNub::Network> All tasks completed. There is"
+                     " no need in additional execution time in background context.");
+        [self endBackgroundTasksCompletionIfRequired];
+    }
+    else if (!onCompletion) {
+        
+        DDLogRequest([[self class] ddLogLevel], @"<PubNub::Network> There is %lu incompleted "
+                     "tasks. Required additional execution time in background context.", 
+                     (unsigned long)incompleteTasksCount);
+    }
+}
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+
 - (void)cancelAllRequests {
 
     OSSpinLockLock(&_lock);
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+    if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
+        
+        [self.scheduledDataTasks removeAllObjects];
+    }
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+    
     [self.session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks,
                                                   NSArray *downloadTasks) {
         
@@ -822,11 +935,59 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Handlers
 
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+- (void)handleClientWillResignActive {
+    
+    OSSpinLockLock(&_lock);
+    if (self.tasksCompletionIdentifier == UIBackgroundTaskInvalid) {
+        
+        // Give manager some time to figure out whether background task should be used to complete all 
+        // scheduled data tasks or not.
+        __weak __typeof__(self) weakSelf = self;
+        self.tasksCompletionIdentifier = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{
+            
+            [weakSelf endBackgroundTasksCompletionIfRequired];
+        }];
+             
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.05f * NSEC_PER_SEC)),
+                       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                           
+            // Get list of scheduled operation.
+            __strong __typeof__(weakSelf) strongSelf = weakSelf;
+            OSSpinLockLock(&strongSelf->_lock);
+            if (strongSelf.tasksCompletionIdentifier != UIBackgroundTaskInvalid) {
+                
+                [strongSelf processIncompleteBeforeClientResignActiveTasks:self.scheduledDataTasks
+                                                      onDataTaskCompletion:NO];
+            }
+            OSSpinLockUnlock(&strongSelf->_lock);
+        });
+    } 
+    OSSpinLockUnlock(&_lock);
+}
+
+- (void)handleClientDidBecomeActive {
+    
+    [self endBackgroundTasksCompletionIfRequired];
+}
+
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+
+
 -(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
     
     if (error) {
         
         OSSpinLockLock(&_lock);
+        // Clean up cached tasks if required.
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+        if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
+            
+            [self.scheduledDataTasks removeAllObjects];
+        }
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+        
         // Replace invalidated session with new one which can be used for next requests.
         [self prepareSessionWithRequesrTimeout:self.requestTimeout
                             maximumConnections:self.maximumConnections];
@@ -930,6 +1091,20 @@ NS_ASSUME_NONNULL_END
         [self handleOperation:operation processingCompletedWithResult:result
                        status:status completionBlock:block];
     }
+    
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+    if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
+        
+        OSSpinLockLock(&_lock);
+        [self.scheduledDataTasks removeObject:task];
+        if (self.tasksCompletionIdentifier != UIBackgroundTaskInvalid) {
+            
+            [self processIncompleteBeforeClientResignActiveTasks:self.scheduledDataTasks
+                                            onDataTaskCompletion:YES];
+        }
+        OSSpinLockUnlock(&_lock); 
+    }
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 }
 
 - (void)handleOperation:(PNOperationType)operation processingCompletedWithResult:(nullable PNResult *)result
@@ -960,6 +1135,36 @@ NS_ASSUME_NONNULL_END
 
 
 #pragma mark - Misc
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+
+- (BOOL)hasOperation:(PNOperationType)operation inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks {
+    
+    BOOL hasOperation = NO;
+    for (NSURLSessionDataTask *dataTask in tasks) {
+        
+        if ([PNURLBuilder isURL:dataTask.originalRequest.URL forOperation:operation]) {
+            
+            hasOperation = YES;
+            break;
+        }
+    }
+    
+    return hasOperation;
+}
+
+- (void)endBackgroundTasksCompletionIfRequired {
+    
+    bool locked = OSSpinLockTry(&_lock);
+    if (self.tasksCompletionIdentifier != UIBackgroundTaskInvalid) {
+        
+        [[UIApplication sharedApplication] endBackgroundTask:self.tasksCompletionIdentifier];
+        self.tasksCompletionIdentifier = UIBackgroundTaskInvalid;
+    }
+    if (locked) { OSSpinLockUnlock(&_lock); }
+}
+
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
 
 - (void)printIfRequiredSessionCustomizationInformation {
     

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -16,9 +16,9 @@
 #import "PNErrorStatus.h"
 #import "PNErrorParser.h"
 #import "PNURLBuilder.h"
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     #import <UIKit/UIKit.h>
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 #import "PNConstants.h"
 #import "PNLogMacro.h"
 #import "PNHelpers.h"
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong) PNNetworkResponseSerializer *serializer;
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief      Stores reference on list of currently scheduled data tasks.
@@ -169,7 +169,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) UIBackgroundTaskIdentifier tasksCompletionIdentifier;
 
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief  Stores reference on queue which should be used by session to call callbacks and completion blocks on
@@ -316,7 +316,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)parseData:(nullable id)data withParser:(Class <PNParser>)parser
        completion:(void(^)(NSDictionary * _Nullable parsedData, BOOL parseError))block;
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief  Complete processing of tasks which has been scheduled but not completelly processed before \b PubNub 
@@ -331,7 +331,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)processIncompleteBeforeClientResignActiveTasks:(NSArray<NSURLSessionDataTask *> *)dataTasks
                                   onDataTaskCompletion:(BOOL)onCompletion;
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 
 #pragma mark - Session constructor
@@ -481,7 +482,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark - Misc
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief  Check whether there \c operation is in the list of passed \c tasks. 
@@ -504,7 +505,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)endBackgroundTasksCompletionIfRequired;
 
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 /**
  @brief  Print out any session configuration instance customizations which has been done by developer.
@@ -557,10 +558,10 @@ NS_ASSUME_NONNULL_END
         _client = client;
         _configuration = client.configuration;
         _forLongPollRequests = longPollEnabled;
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
         _scheduledDataTasks = [NSMutableArray new];
         _tasksCompletionIdentifier = UIBackgroundTaskInvalid;
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
         _identifier = [[NSString stringWithFormat:@"com.pubnub.network.%p", self] copy];
         _processingQueue = dispatch_queue_create([_identifier UTF8String], DISPATCH_QUEUE_CONCURRENT);;
         _serializer = [PNNetworkResponseSerializer new];
@@ -633,12 +634,12 @@ NS_ASSUME_NONNULL_END
     };
     OSSpinLockLock(&_lock);
     task = [self.session dataTaskWithRequest:request completionHandler:[handler copy]];
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
         
         [self.scheduledDataTasks addObject:task];
     }
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     OSSpinLockUnlock(&_lock);
     
     return task;
@@ -805,7 +806,7 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 - (void)processIncompleteBeforeClientResignActiveTasks:(NSArray<NSURLSessionDataTask *> *)dataTasks
                                   onDataTaskCompletion:(BOOL)onCompletion {
@@ -832,17 +833,17 @@ NS_ASSUME_NONNULL_END
                      (unsigned long)incompleteTasksCount);
     }
 }
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 - (void)cancelAllRequests {
 
     OSSpinLockLock(&_lock);
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
         
         [self.scheduledDataTasks removeAllObjects];
     }
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     
     [self.session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks,
                                                   NSArray *downloadTasks) {
@@ -935,7 +936,7 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Handlers
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 - (void)handleClientWillResignActive {
     
@@ -973,7 +974,7 @@ NS_ASSUME_NONNULL_END
     [self endBackgroundTasksCompletionIfRequired];
 }
 
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 
 -(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
@@ -982,12 +983,12 @@ NS_ASSUME_NONNULL_END
         
         OSSpinLockLock(&_lock);
         // Clean up cached tasks if required.
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
         if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
             
             [self.scheduledDataTasks removeAllObjects];
         }
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
         
         // Replace invalidated session with new one which can be used for next requests.
         [self prepareSessionWithRequesrTimeout:self.requestTimeout
@@ -1093,7 +1094,7 @@ NS_ASSUME_NONNULL_END
                        status:status completionBlock:block];
     }
     
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
     if (self.configuration.shouldCompleteRequestsBeforeSuspension) {
         
         OSSpinLockLock(&_lock);
@@ -1105,7 +1106,7 @@ NS_ASSUME_NONNULL_END
         }
         OSSpinLockUnlock(&_lock); 
     }
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 }
 
 - (void)handleOperation:(PNOperationType)operation processingCompletedWithResult:(nullable PNResult *)result
@@ -1137,7 +1138,7 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Misc
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#if __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 - (BOOL)hasOperation:(PNOperationType)operation inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks {
     
@@ -1165,7 +1166,7 @@ NS_ASSUME_NONNULL_END
     if (locked) { OSSpinLockUnlock(&_lock); }
 }
 
-#endif // __IPHONE_OS_VERSION_MIN_REQUIRED
+#endif // __IPHONE_OS_VERSION_MIN_REQUIRED && !TARGET_OS_WATCH
 
 - (void)printIfRequiredSessionCustomizationInformation {
     

--- a/PubNub/Network/PNURLBuilder.h
+++ b/PubNub/Network/PNURLBuilder.h
@@ -31,9 +31,28 @@ NS_ASSUME_NONNULL_BEGIN
  @param operation  One of \b PNOperationType fields which describes operation type (to choose correct API 
                    endpoint).
  @param parameters Object which represent set of parameters which should be used during path composition.
+ 
+ @return URL to perform required by \c operation API call.
  */
 + (nullable NSURL *)URLForOperation:(PNOperationType)operation
                      withParameters:(PNRequestParameters *)parameters;
+
+
+///------------------------------------------------
+/// @name API URL verificator
+///------------------------------------------------
+
+/**
+ @brief  Check whether passed URL represent call to API described by passed \c operation.
+ 
+ @since 4.<#minor-version#>.0
+ 
+ @param url        Previously generated API call URL which should be used during verification.
+ @param operation  One of \b PNOperationType fields which describes operation type against which verification will be done.
+ 
+ @return \c YES in case if passed \c url is for API which described by \c operation.
+ */
++ (BOOL)isURL:(NSURL *)url forOperation:(PNOperationType)operation;
 
 #pragma mark -
 

--- a/PubNub/Network/PNURLBuilder.m
+++ b/PubNub/Network/PNURLBuilder.m
@@ -79,6 +79,21 @@ static NSString * const PNOperationRequestTemplate[22] = {
     return requestURL;
 }
 
+
+#pragma mark - API URL verificator
+
++ (BOOL)isURL:(NSURL *)url forOperation:(PNOperationType)operation {
+    
+    BOOL result = NO;
+    if (url) {
+        
+        NSString *requestURLPrefixString = [PNOperationRequestTemplate[operation] componentsSeparatedByString:@"{"].firstObject;
+        result = ([url.absoluteString rangeOfString:requestURLPrefixString].location != NSNotFound);
+    }
+    
+    return result;
+}
+
 #pragma mark -
 
 


### PR DESCRIPTION
Now if application goes to background execution context **PubNub** client will try to complete non-subscrtibe (unsubscribe will work) requests. This is behaviour by default, but it can be changed with `completeRequestsBeforeSuspension` property from **PNConfiguration**.