### PR TITLE
Changed default logs directory which should be used for tvOS client

### DIFF
--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -538,7 +538,11 @@ NS_ASSUME_NONNULL_END
 - (void)setupClientLogger {
     
     // Configure file manager with default storage in application's Documents folder.
+#if TARGET_OS_TV && !TARGET_OS_SIMULATOR
+    NSSearchPathDirectory searchPath = NSCachesDirectory;
+#else 
     NSSearchPathDirectory searchPath = (TARGET_OS_IPHONE ? NSDocumentDirectory : NSApplicationSupportDirectory);
+#endif
     NSArray<NSString *> *documents = NSSearchPathForDirectoriesInDomains(searchPath, NSUserDomainMask, YES);
     NSString *logsPath = documents.lastObject;
 #if __MAC_OS_X_VERSION_MIN_REQUIRED

--- a/PubNub/Misc/Logger/Core/PNLLogger.m
+++ b/PubNub/Misc/Logger/Core/PNLLogger.m
@@ -694,7 +694,7 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 - (NSString *)createLogFile {
     
     NSString *filePath = [self.directory stringByAppendingPathComponent:[self newLogFileName]];
-#if TARGET_OS_IOS
+#if !TARGET_OS_TV && TARGET_OS_IOS
     NSDictionary *attributes = @{NSFileProtectionKey: NSFileProtectionCompleteUntilFirstUserAuthentication};
 #else
     NSDictionary *attributes = nil;


### PR DESCRIPTION
tvOS on physical device doesn't allow to write logs into _Documents_ folder. Changes allow to switch default logs location to _Caches_ folder if client is built and running on Apple TV.