### PR TITLE
+ added NS_SWIFT_NAME to all public API

### DIFF
--- a/PubNub/Core/PubNub+APNS.h
+++ b/PubNub/Core/PubNub+APNS.h
@@ -88,7 +88,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)addPushNotificationsOnChannels:(NSArray<NSString *> *)channels withDevicePushToken:(NSData *)pushToken
-                         andCompletion:(nullable PNPushNotificationsStateModificationCompletionBlock)block;
+                         andCompletion:(nullable PNPushNotificationsStateModificationCompletionBlock)block NS_SWIFT_NAME(addPushNotificationsOnChannels(_:withDevicePushToken:andCompletion:));
 
 /**
  @brief      Disable push notifications on provided set of \c channels.
@@ -129,7 +129,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)removePushNotificationsFromChannels:(NSArray<NSString *> *)channels
                         withDevicePushToken:(NSData *)pushToken
-                              andCompletion:(nullable PNPushNotificationsStateModificationCompletionBlock)block;
+                              andCompletion:(nullable PNPushNotificationsStateModificationCompletionBlock)block NS_SWIFT_NAME(removePushNotificationsFromChannels(_:withDevicePushToken:andCompletion:));
 
 /**
  @brief      Disable push notifications from all channels which is registered with specified \c pushToken.
@@ -168,7 +168,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)removeAllPushNotificationsFromDeviceWithPushToken:(NSData *)pushToken
-                           andCompletion:(nullable PNPushNotificationsStateModificationCompletionBlock)block;
+                           andCompletion:(nullable PNPushNotificationsStateModificationCompletionBlock)block NS_SWIFT_NAME(removeAllPushNotificationsFromDeviceWithPushToken(_:andCompletion:));
 
 
 ///------------------------------------------------
@@ -213,7 +213,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)pushNotificationEnabledChannelsForDeviceWithPushToken:(NSData *)pushToken
-                                  andCompletion:(PNPushNotificationsStateAuditCompletionBlock)block;
+                                  andCompletion:(PNPushNotificationsStateAuditCompletionBlock)block NS_SWIFT_NAME(pushNotificationEnabledChannelsForDeviceWithPushToken(_:andCompletion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+ChannelGroup.h
+++ b/PubNub/Core/PubNub+ChannelGroup.h
@@ -133,7 +133,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)channelsForGroup:(NSString *)group withCompletion:(PNGroupChannelsAuditCompletionBlock)block;
+- (void)channelsForGroup:(NSString *)group withCompletion:(PNGroupChannelsAuditCompletionBlock)block NS_SWIFT_NAME(channelsForGroup(_:withCompletion:));
 
 
 ///------------------------------------------------
@@ -178,7 +178,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)addChannels:(NSArray<NSString *> *)channels toGroup:(NSString *)group
-     withCompletion:(nullable PNChannelGroupChangeCompletionBlock)block;
+     withCompletion:(nullable PNChannelGroupChangeCompletionBlock)block NS_SWIFT_NAME(addChannels(_:toGroup:withCompletion:));
 
 /**
  @brief      Remove specified \c channels from \c group.
@@ -218,7 +218,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)removeChannels:(NSArray<NSString *> *)channels fromGroup:(NSString *)group
-        withCompletion:(nullable PNChannelGroupChangeCompletionBlock)block;
+        withCompletion:(nullable PNChannelGroupChangeCompletionBlock)block NS_SWIFT_NAME(removeChannels(_:fromGroup:withCompletion:));
 
 /**
  @brief      Remove all channels from \c group.
@@ -256,7 +256,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */ 
 - (void)removeChannelsFromGroup:(NSString *)group
-                 withCompletion:(nullable PNChannelGroupChangeCompletionBlock)block;
+                 withCompletion:(nullable PNChannelGroupChangeCompletionBlock)block NS_SWIFT_NAME(removeChannelsFromGroup(_:withCompletion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+Core.h
+++ b/PubNub/Core/PubNub+Core.h
@@ -88,7 +88,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
 
  @since 4.0
 */
-+ (instancetype)clientWithConfiguration:(PNConfiguration *)configuration;
++ (instancetype)clientWithConfiguration:(PNConfiguration *)configuration NS_SWIFT_NAME(clientWithConfiguration(_:));
 
 /**
  @brief      Construct new \b PubNub client instance with pre-defined configuration.
@@ -117,7 +117,7 @@ self.client = [PubNub clientWithConfiguration:configuration callbackQueue:queue]
  @since 4.0
 */
 + (instancetype)clientWithConfiguration:(PNConfiguration *)configuration
-                          callbackQueue:(nullable dispatch_queue_t)callbackQueue;
+                          callbackQueue:(nullable dispatch_queue_t)callbackQueue NS_SWIFT_NAME(clientWithConfiguration(_:callbackQueue:));
 
 /**
  @brief      Make copy of client with it's current state using new configuration.
@@ -150,7 +150,7 @@ configuration.TLSEnabled = NO;
  
  @since 4.0
  */
-- (void)copyWithConfiguration:(PNConfiguration *)configuration completion:(void(^)(PubNub *client))block;
+- (void)copyWithConfiguration:(PNConfiguration *)configuration completion:(void(^)(PubNub *client))block NS_SWIFT_NAME(copyWithConfiguration(_:completion:));
 
 /**
  @brief      Make copy of client with it's current state using new configuration.
@@ -189,7 +189,7 @@ configuration.TLSEnabled = NO;
  */
 - (void)copyWithConfiguration:(PNConfiguration *)configuration
                 callbackQueue:(nullable dispatch_queue_t)callbackQueue
-                   completion:(void(^)(PubNub *client))block;
+                   completion:(void(^)(PubNub *client))block NS_SWIFT_NAME(copyWithConfiguration(_:callbackQueue:completion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+History.h
+++ b/PubNub/Core/PubNub+History.h
@@ -77,7 +77,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)historyForChannel:(NSString *)channel withCompletion:(PNHistoryCompletionBlock)block;
+- (void)historyForChannel:(NSString *)channel withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:withCompletion:));
 
 
 ///------------------------------------------------
@@ -132,7 +132,7 @@ NSNumber *endDate = @([[NSDate date] timeIntervalSince1970]);
  @since 4.0
  */
 - (void)historyForChannel:(NSString *)channel start:(nullable NSNumber *)startDate 
-                      end:(nullable NSNumber *)endDate withCompletion:(PNHistoryCompletionBlock)block;
+                      end:(nullable NSNumber *)endDate withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:start:end:withCompletion:));
 
 /**
  @brief      Allow to fetch events from specified \c channel's history within specified time frame.
@@ -186,7 +186,7 @@ NSNumber *endDate = @([[NSDate date] timeIntervalSince1970]);
  */
 - (void)historyForChannel:(NSString *)channel start:(nullable NSNumber *)startDate 
                       end:(nullable NSNumber *)endDate limit:(NSUInteger)limit 
-           withCompletion:(PNHistoryCompletionBlock)block;
+           withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:start:end:limit:withCompletion:));
 
 
 ///------------------------------------------------
@@ -248,7 +248,7 @@ NSNumber *endDate = @([[NSDate date] timeIntervalSince1970]);
  */
 - (void)historyForChannel:(NSString *)channel start:(nullable NSNumber *)startDate 
                       end:(nullable NSNumber *)endDate includeTimeToken:(BOOL)shouldIncludeTimeToken 
-           withCompletion:(PNHistoryCompletionBlock)block;
+           withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:start:end:includeTimeToken:withCompletion:));
 
 /**
  @brief      Allow to fetch events from specified \c channel's history within specified time frame.
@@ -308,7 +308,7 @@ NSNumber *endDate = @([[NSDate date] timeIntervalSince1970]);
  */
 - (void)historyForChannel:(NSString *)channel start:(nullable NSNumber *)startDate 
                       end:(nullable NSNumber *)endDate limit:(NSUInteger)limit
-         includeTimeToken:(BOOL)shouldIncludeTimeToken withCompletion:(PNHistoryCompletionBlock)block;
+         includeTimeToken:(BOOL)shouldIncludeTimeToken withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:start:end:limit:includeTimeToken:withCompletion:));
 
 /**
  @brief      Allow to fetch events from specified \c channel's history within specified time frame.
@@ -364,7 +364,7 @@ NSNumber *endDate = @([[NSDate date] timeIntervalSince1970]);
  */
 - (void)historyForChannel:(NSString *)channel start:(nullable NSNumber *)startDate
                       end:(nullable NSNumber *)endDate limit:(NSUInteger)limit 
-                  reverse:(BOOL)shouldReverseOrder withCompletion:(PNHistoryCompletionBlock)block;
+                  reverse:(BOOL)shouldReverseOrder withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:start:end:limit:reverse:withCompletion:));
 
 /**
  @brief      Allow to fetch events from specified \c channel's history within specified time frame.
@@ -425,7 +425,7 @@ NSNumber *endDate = @([[NSDate date] timeIntervalSince1970]);
 - (void)historyForChannel:(NSString *)channel start:(nullable NSNumber *)startDate
                       end:(nullable NSNumber *)endDate limit:(NSUInteger)limit 
                   reverse:(BOOL)shouldReverseOrder includeTimeToken:(BOOL)shouldIncludeTimeToken 
-           withCompletion:(PNHistoryCompletionBlock)block;
+           withCompletion:(PNHistoryCompletionBlock)block NS_SWIFT_NAME(historyForChannel(_:start:end:limit:reverse:includeTimeToken:withCompletion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+Presence.h
+++ b/PubNub/Core/PubNub+Presence.h
@@ -119,7 +119,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)hereNowWithCompletion:(PNGlobalHereNowCompletionBlock)block;
+- (void)hereNowWithCompletion:(PNGlobalHereNowCompletionBlock)block NS_SWIFT_NAME(hereNowWithCompletion(_:));
 
 /**
  @brief      Request information about subscribers on all remote data objects live feeds.
@@ -168,7 +168,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)hereNowWithVerbosity:(PNHereNowVerbosityLevel)level completion:(PNGlobalHereNowCompletionBlock)block;
+- (void)hereNowWithVerbosity:(PNHereNowVerbosityLevel)level completion:(PNGlobalHereNowCompletionBlock)block NS_SWIFT_NAME(hereNowWithVerbosity(_:completion:));
 
 
 ///------------------------------------------------
@@ -216,7 +216,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)hereNowForChannel:(NSString *)channel withCompletion:(PNHereNowCompletionBlock)block;
+- (void)hereNowForChannel:(NSString *)channel withCompletion:(PNHereNowCompletionBlock)block NS_SWIFT_NAME(hereNowForChannel(_:withCompletion:));
 
 /**
  @brief      Request information about subscribers on specific channel live feeds.
@@ -262,7 +262,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)hereNowForChannel:(NSString *)channel withVerbosity:(PNHereNowVerbosityLevel)level
-               completion:(PNHereNowCompletionBlock)block;
+               completion:(PNHereNowCompletionBlock)block NS_SWIFT_NAME(hereNowForChannel(_:withVerbosity:completion:));
 
 
 ///------------------------------------------------
@@ -314,7 +314,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)hereNowForChannelGroup:(NSString *)group withCompletion:(PNChannelGroupHereNowCompletionBlock)block;
+- (void)hereNowForChannelGroup:(NSString *)group withCompletion:(PNChannelGroupHereNowCompletionBlock)block NS_SWIFT_NAME(hereNowForChannelGroup(_:withCompletion:));
 
 /**
  @brief      Request information about subscribers on specific channel group live feeds.
@@ -364,7 +364,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)hereNowForChannelGroup:(NSString *)group withVerbosity:(PNHereNowVerbosityLevel)level
-                    completion:(PNChannelGroupHereNowCompletionBlock)block;
+                    completion:(PNChannelGroupHereNowCompletionBlock)block NS_SWIFT_NAME(hereNowForChannelGroup(_:withVerbosity:completion:));
 
 
 ///------------------------------------------------
@@ -406,7 +406,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)whereNowUUID:(NSString *)uuid withCompletion:(PNWhereNowCompletionBlock)block;
+- (void)whereNowUUID:(NSString *)uuid withCompletion:(PNWhereNowCompletionBlock)block NS_SWIFT_NAME(whereNowUUID(_:withCompletion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+Publish.h
+++ b/PubNub/Core/PubNub+Publish.h
@@ -88,7 +88,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)  publish:(id)message toChannel:(NSString *)channel
-   withCompletion:(nullable PNPublishCompletionBlock)block;
+   withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -134,7 +134,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)  publish:(id)message toChannel:(NSString *)channel 
      withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-       completion:(nullable PNPublishCompletionBlock)block;
+       completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:withMetadata:completion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -181,7 +181,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)  publish:(id)message toChannel:(NSString *)channel compressed:(BOOL)compressed
-   withCompletion:(nullable PNPublishCompletionBlock)block;
+   withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:compressed:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -230,7 +230,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)  publish:(id)message toChannel:(NSString *)channel compressed:(BOOL)compressed 
      withMetadata:(nullable NSDictionary<NSString *, id> *)metadata 
-       completion:(nullable PNPublishCompletionBlock)block;
+       completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:compressed:withMetadata:completion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -275,7 +275,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)  publish:(id)message toChannel:(NSString *)channel storeInHistory:(BOOL)shouldStore
-   withCompletion:(nullable PNPublishCompletionBlock)block;
+   withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:storeInHistory:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -322,7 +322,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)  publish:(id)message toChannel:(NSString *)channel storeInHistory:(BOOL)shouldStore 
      withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-       completion:(nullable PNPublishCompletionBlock)block;
+       completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:storeInHistory:withMetadata:completion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -369,7 +369,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)publish:(id)message toChannel:(NSString *)channel storeInHistory:(BOOL)shouldStore
-     compressed:(BOOL)compressed withCompletion:(nullable PNPublishCompletionBlock)block;
+     compressed:(BOOL)compressed withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:storeInHistory:compressed:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -419,7 +419,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)publish:(id)message toChannel:(NSString *)channel storeInHistory:(BOOL)shouldStore
      compressed:(BOOL)compressed withMetadata:(nullable NSDictionary<NSString *, id> *)metadata 
-     completion:(nullable PNPublishCompletionBlock)block;
+     completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:storeInHistory:compressed:withMetadata:completion:));
 
 
 ///------------------------------------------------
@@ -471,7 +471,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads
-     withCompletion:(nullable PNPublishCompletionBlock)block;
+     withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -519,7 +519,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads
        withMetadata:(nullable NSDictionary<NSString *, id> *)metadata 
-         completion:(nullable PNPublishCompletionBlock)block;
+         completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:withMetadata:completion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -570,7 +570,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads compressed:(BOOL)compressed 
-     withCompletion:(nullable PNPublishCompletionBlock)block;
+     withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:compressed:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -622,7 +622,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads compressed:(BOOL)compressed 
        withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-         completion:(nullable PNPublishCompletionBlock)block;
+         completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:compressed:withMetadata:completion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -671,7 +671,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads storeInHistory:(BOOL)shouldStore
-     withCompletion:(nullable PNPublishCompletionBlock)block;
+     withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:storeInHistory:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -722,7 +722,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads storeInHistory:(BOOL)shouldStore
        withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-         completion:(nullable PNPublishCompletionBlock)block;
+         completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:storeInHistory:withMetadata:completion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -774,7 +774,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads storeInHistory:(BOOL)shouldStore
-         compressed:(BOOL)compressed withCompletion:(nullable PNPublishCompletionBlock)block;
+         compressed:(BOOL)compressed withCompletion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:storeInHistory:compressed:withCompletion:));
 
 /**
  @brief      Send provided Foundation object to \b PubNub service.
@@ -827,7 +827,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
 - (void)    publish:(nullable id)message toChannel:(NSString *)channel
   mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads storeInHistory:(BOOL)shouldStore
          compressed:(BOOL)compressed withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-         completion:(nullable PNPublishCompletionBlock)block;
+         completion:(nullable PNPublishCompletionBlock)block NS_SWIFT_NAME(publish(_:toChannel:mobilePushPayload:storeInHistory:compressed:withMetadata:completion:));
 
 
 ///------------------------------------------------
@@ -859,7 +859,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel
-       withCompletion:(PNMessageSizeCalculationCompletionBlock)block;
+       withCompletion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:withCompletion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub 
@@ -890,7 +890,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel 
          withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-           completion:(PNMessageSizeCalculationCompletionBlock)block;
+           completion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:withMetadata:completion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub 
@@ -921,7 +921,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel compressed:(BOOL)compressMessage
-       withCompletion:(PNMessageSizeCalculationCompletionBlock)block;
+       withCompletion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:compressed:withCompletion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub
@@ -955,7 +955,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel compressed:(BOOL)compressMessage
          withMetadata:(nullable NSDictionary<NSString *, id> *)metadata 
-           completion:(PNMessageSizeCalculationCompletionBlock)block;
+           completion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:compressed:withMetadata:completion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub 
@@ -985,7 +985,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel storeInHistory:(BOOL)shouldStore
-       withCompletion:(PNMessageSizeCalculationCompletionBlock)block;
+       withCompletion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:storeInHistory:withCompletion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub 
@@ -1017,7 +1017,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel storeInHistory:(BOOL)shouldStore
          withMetadata:(nullable NSDictionary<NSString *, id> *)metadata 
-           completion:(PNMessageSizeCalculationCompletionBlock)block;
+           completion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:storeInHistory:withMetadata:completion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub 
@@ -1050,7 +1050,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel compressed:(BOOL)compressMessage
-       storeInHistory:(BOOL)shouldStore withCompletion:(PNMessageSizeCalculationCompletionBlock)block;
+       storeInHistory:(BOOL)shouldStore withCompletion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:compressed:storeInHistory:withCompletion:));
 
 /**
  @brief      Helper method which allow to calculate resulting message before it will be sent to \b PubNub 
@@ -1086,7 +1086,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  */
 - (void)sizeOfMessage:(id)message toChannel:(NSString *)channel compressed:(BOOL)compressMessage
        storeInHistory:(BOOL)shouldStore withMetadata:(nullable NSDictionary<NSString *, id> *)metadata
-           completion:(PNMessageSizeCalculationCompletionBlock)block;
+           completion:(PNMessageSizeCalculationCompletionBlock)block NS_SWIFT_NAME(sizeOfMessage(_:toChannel:compressed:storeInHistory:withMetadata:completion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+State.h
+++ b/PubNub/Core/PubNub+State.h
@@ -99,7 +99,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)setState:(nullable NSDictionary<NSString *, id> *)state forUUID:(NSString *)uuid 
-       onChannel:(NSString *)channel withCompletion:(nullable PNSetStateCompletionBlock)block;
+       onChannel:(NSString *)channel withCompletion:(nullable PNSetStateCompletionBlock)block NS_SWIFT_NAME(setState(_:forUUID:onChannel:withCompletion:));
 
 /**
  @brief      Modify state information for \c uuid on specified channel group.
@@ -138,7 +138,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)setState:(nullable NSDictionary<NSString *, id> *)state forUUID:(NSString *)uuid
-  onChannelGroup:(NSString *)group withCompletion:(nullable PNSetStateCompletionBlock)block;
+  onChannelGroup:(NSString *)group withCompletion:(nullable PNSetStateCompletionBlock)block NS_SWIFT_NAME(setState(_:forUUID:onChannelGroup:withCompletion:));
 
 
 ///------------------------------------------------
@@ -183,7 +183,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)stateForUUID:(NSString *)uuid onChannel:(NSString *)channel
-      withCompletion:(PNChannelStateCompletionBlock)block;
+      withCompletion:(PNChannelStateCompletionBlock)block NS_SWIFT_NAME(stateForUUID(_:onChannel:withCompletion:));
 
 /**
  @brief      Retrieve state information for \c uuid on specified channel group.
@@ -224,7 +224,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)stateForUUID:(NSString *)uuid onChannelGroup:(NSString *)group
-      withCompletion:(PNChannelGroupStateCompletionBlock)block;
+      withCompletion:(PNChannelGroupStateCompletionBlock)block NS_SWIFT_NAME(stateForUUID(_:onChannelGroup:withCompletion:));
 
 #pragma mark -
 

--- a/PubNub/Core/PubNub+Subscribe.h
+++ b/PubNub/Core/PubNub+Subscribe.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.0
  */
-- (void)addListener:(id <PNObjectEventListener>)listener;
+- (void)addListener:(id <PNObjectEventListener>)listener NS_SWIFT_NAME(addListener(_:));
 
 /**
  @brief      Remove listener from list for callback calls.
@@ -94,7 +94,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.0
  */
-- (void)removeListener:(id <PNObjectEventListener>)listener;
+- (void)removeListener:(id <PNObjectEventListener>)listener NS_SWIFT_NAME(removeListener(_:));
 
 
 ///------------------------------------------------
@@ -132,7 +132,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)subscribeToChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence;
+- (void)subscribeToChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence NS_SWIFT_NAME(subscribeToChannels(_:withPresence:));
 
 /**
  @brief      Try subscribe on specified set of channels.
@@ -157,7 +157,7 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
  @since 4.2.0
  */
 - (void)subscribeToChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence
-             usingTimeToken:(nullable NSNumber *)timeToken;
+             usingTimeToken:(nullable NSNumber *)timeToken NS_SWIFT_NAME(subscribeToChannels(_:withPresence:usingTimeToken:));
 
 /**
  @brief      Try subscribe on specified set of channels.
@@ -183,7 +183,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)subscribeToChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence
-                clientState:(nullable NSDictionary<NSString *, id> *)state;
+                clientState:(nullable NSDictionary<NSString *, id> *)state NS_SWIFT_NAME(subscribeToChannels(_:withPresence:clientState:));
 
 /**
  @brief      Try subscribe on specified set of channels.
@@ -212,7 +212,7 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
  */
 - (void)subscribeToChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence
              usingTimeToken:(nullable NSNumber *)timeToken 
-                clientState:(nullable NSDictionary<NSString *, id> *)state;
+                clientState:(nullable NSDictionary<NSString *, id> *)state NS_SWIFT_NAME(subscribeToChannels(_:withPresence:usingTimeToken:clientState:));
 
 /**
  @brief      Try subscribe on specified set of channel groups.
@@ -232,7 +232,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)subscribeToChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence;
+- (void)subscribeToChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence NS_SWIFT_NAME(subscribeToChannelGroups(_:withPresence:));
 
 /**
  @brief      Try subscribe on specified set of channel groups.
@@ -257,7 +257,7 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
  @since 4.2.0
  */
 - (void)subscribeToChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence
-                  usingTimeToken:(nullable NSNumber *)timeToken;
+                  usingTimeToken:(nullable NSNumber *)timeToken NS_SWIFT_NAME(subscribeToChannelGroups(_:withPresence:usingTimeToken:));
 
 /**
  @brief      Try subscribe on specified set of channel groups.
@@ -283,7 +283,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  @since 4.0
  */
 - (void)subscribeToChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence
-                     clientState:(nullable NSDictionary<NSString *, id> *)state;
+                     clientState:(nullable NSDictionary<NSString *, id> *)state NS_SWIFT_NAME(subscribeToChannelGroups(_:withPresence:clientState:));
 
 /**
  @brief      Try subscribe on specified set of channel groups.
@@ -312,7 +312,7 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
  */
 - (void)subscribeToChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence
                   usingTimeToken:(nullable NSNumber *)timeToken 
-                     clientState:(nullable NSDictionary<NSString *, id> *)state;
+                     clientState:(nullable NSDictionary<NSString *, id> *)state NS_SWIFT_NAME(subscribeToChannelGroups(_:withPresence:usingTimeToken:clientState:));
 
 /**
  @brief      Enable presence observation on specified \c channels.
@@ -332,7 +332,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)subscribeToPresenceChannels:(NSArray<NSString *> *)channels;
+- (void)subscribeToPresenceChannels:(NSArray<NSString *> *)channels NS_SWIFT_NAME(subscribeToPresenceChannels(_:));
 
 
 ///------------------------------------------------
@@ -358,7 +358,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)unsubscribeFromChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence;
+- (void)unsubscribeFromChannels:(NSArray<NSString *> *)channels withPresence:(BOOL)shouldObservePresence NS_SWIFT_NAME(unsubscribeFromChannels(_:withPresence:));
 
 /**
  @brief      Unsubscribe/leave from specified set of channel groups.
@@ -380,7 +380,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)unsubscribeFromChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence;
+- (void)unsubscribeFromChannelGroups:(NSArray<NSString *> *)groups withPresence:(BOOL)shouldObservePresence NS_SWIFT_NAME(unsubscribeFromChannelGroups(_:withPresence:));
 
 /**
  @brief      Disable presence events observation on specified channels.
@@ -399,7 +399,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)unsubscribeFromPresenceChannels:(NSArray<NSString *> *)channels;
+- (void)unsubscribeFromPresenceChannels:(NSArray<NSString *> *)channels NS_SWIFT_NAME(unsubscribeFromPresenceChannels(_:));
 
 /**
  @brief      Unsubscribe from all channels and groups on which client has been subscrbed so far.

--- a/PubNub/Core/PubNub+Time.h
+++ b/PubNub/Core/PubNub+Time.h
@@ -70,7 +70,7 @@ self.client = [PubNub clientWithConfiguration:configuration];
  
  @since 4.0
  */
-- (void)timeWithCompletion:(PNTimeCompletionBlock)block;
+- (void)timeWithCompletion:(PNTimeCompletionBlock)block NS_SWIFT_NAME(timeWithCompletion(_:));
 
 #pragma mark -
 

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -234,7 +234,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.0
  */
-+ (instancetype)configurationWithPublishKey:(NSString *)publishKey subscribeKey:(NSString *)subscribeKey;
++ (instancetype)configurationWithPublishKey:(NSString *)publishKey subscribeKey:(NSString *)subscribeKey NS_SWIFT_NAME(init(publishKey:subscribeKey:));
 
 #pragma mark -
 


### PR DESCRIPTION
All public API now has NS_SWIFT_NAME with Swift equivalent specified in it. This allow to prevent Swift function signature generator from changing it between Swift releases.