### PR TITLE
NSCalendar usage as property fix.

### DIFF
--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -557,7 +557,7 @@ NS_ASSUME_NONNULL_END
     __weak __typeof__(self) weakSelf = self;
     self.logger = [PNLLogger loggerWithIdentifier:kPNClientIdentifier directory:logsPath 
                                      logExtension:@"log"];
-    self.logger.enabled = YES;
+    self.logger.enabled = NO;
     self.logger.writeToConsole = YES;
     self.logger.writeToFile = YES;
     [self.logger setLogLevel:(PNInfoLogLevel|PNFailureStatusLogLevel|PNAPICallLogLevel)];

--- a/PubNub/Misc/Logger/Core/PNLLogger.h
+++ b/PubNub/Misc/Logger/Core/PNLLogger.h
@@ -148,15 +148,6 @@ NS_ASSUME_NONNULL_BEGIN
                         logExtension:(nullable NSString *)extension;
 
 /**
- @brief  Set whether \c logger should process messages which is sent to it or not.
- 
- @param isLoggingEnabled \c YES in case if logger should process data which is sent to it.
- 
- @since 4.5.0
- */
-- (void)enabled:(BOOL)isLoggingEnabled;
-
-/**
  @brief      Enable particular logging level.
  @discussion If any call to logger with specified \c level will be done it will be handled and message will be
              printed out and written into file (if enabled).

--- a/PubNub/Misc/Logger/Core/PNLLogger.m
+++ b/PubNub/Misc/Logger/Core/PNLLogger.m
@@ -144,13 +144,6 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 @property (nonatomic, assign) NSUInteger logLevel;
 
 /**
- @brief  Stores reference on auto-updating calendar which is used during timestamp format composition.
- 
- @since 4.5.0
- */
-@property (nonatomic, strong) NSCalendar *calendar;
-
-/**
  @brief  Stores bit fields of calendar units which take part in timetoken composition.
  
  @since 4.5.0
@@ -527,10 +520,10 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     return self;
 }
 
-- (void)enabled:(BOOL)isLoggingEnabled {
+- (void)setEnabled:(BOOL)enabled {
     
     bool locked = OSSpinLockTry(&_accessLock);
-    _enabled = isLoggingEnabled;
+    _enabled = enabled;
     if (locked) { OSSpinLockUnlock(&_accessLock); }
 }
 
@@ -557,7 +550,7 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     bool locked = OSSpinLockTry(&_accessLock);
     BOOL notifyChange = (_logLevel != level && _logLevelChangeHandler);
     _logLevel = level;
-    if (level == 0) { [self enabled:NO]; }
+    if (level == 0) { _enabled = NO; }
     if (notifyChange) { dispatch_async(dispatch_get_main_queue(), _logLevelChangeHandler); }
     if (locked) { OSSpinLockUnlock(&_accessLock); }
 }
@@ -897,7 +890,6 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 
 - (void)prepareDateFormatter {
     
-    _calendar = [NSCalendar autoupdatingCurrentCalendar];
     _calendarUnits = (NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour |
                       NSCalendarUnitMinute | NSCalendarUnitSecond);
     
@@ -922,7 +914,8 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 
 - (NSUInteger)getTimestamp:(char *)timestamp fromDate:(NSDate *)date {
     
-    NSDateComponents *components = [self.calendar components:self.calendarUnits fromDate:date];
+    NSDateComponents *components = [[NSCalendar autoupdatingCurrentCalendar] components:self.calendarUnits
+                                                                               fromDate:date];
     NSTimeInterval seconds = [date timeIntervalSince1970];
     int milliseconds = (int)((seconds - floor(seconds)) * 1000);
     snprintf(timestamp, kPNLLogEntryTimestampLength, "%04ld-%02ld-%02ld %02ld:%02ld:%02ld:%03d", 


### PR DESCRIPTION
Replaced property based calendar instance usage with inplace instance creation (to prevent crash in low memory cases).