### PR TITLE
Added multi-channel history request API to API call builder interface.

### DIFF
--- a/PubNub/Core/PubNub+History.m
+++ b/PubNub/Core/PubNub+History.m
@@ -24,6 +24,40 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PubNub (HistoryProtected)
 
 
+#pragma mark - History in frame with extended response
+
+/**
+ @brief      Allow to fetch events from specified \c channel's history within specified time frame.
+ @note       All 'history' API group methods allow to fetch up to \b 100 events at once. If in specified time
+             frame there is more then 100 events paging may be required. For paging use last event time token
+             from response and some distant future date for next portion of events.
+ 
+ @param multipleChannels       Whether history should be fetched for multiple \c object or not. If set to 
+                               \c YES then \c object contain list of channel names for which history should be
+                               retrieved.
+ @param object                 Name of the channel for which events should be pulled out from storage.
+ @param startDate              Reference on time token for oldest event starting from which next should be 
+                               returned events. Value will be converted to required precision internally.
+ @param endDate                Reference on time token for latest event till which events should be pulled 
+                               out. Value will be converted to required precision internally.
+ @param limit                  Maximum number of events which should be returned in response (not more then 
+                               \b 100).
+ @param shouldReverseOrder     Whether events order in response should be reversed or not.
+ @param shouldIncludeTimeToken Whether event dates (time tokens) should be included in response or not.
+ @param block                  History pull processing completion block which pass two arguments: 
+                               \c result - in case of successful request processing \c data field will contain
+                               results of history request operation; \c status - in case if error occurred 
+                               during request processing.
+ 
+ @since 4.5.6
+ */
+- (void)historyForChannels:(BOOL)multipleChannels object:(id)object start:(nullable NSNumber *)startDate
+                       end:(nullable NSNumber *)endDate limit:(nullable NSNumber *)limit 
+                   reverse:(nullable NSNumber *)shouldReverseOrder 
+          includeTimeToken:(nullable NSNumber *)shouldIncludeTimeToken  
+            withCompletion:(PNHistoryCompletionBlock)block;
+
+
 #pragma mark - Handlers
 
 /**
@@ -61,18 +95,18 @@ NS_ASSUME_NONNULL_END
     PNHistoryAPICallBuilder *builder = nil;
     builder = [PNHistoryAPICallBuilder builderWithExecutionBlock:^(NSArray<NSString *> *flags, 
                                                                    NSDictionary *parameters) {
-                                         
+
         NSString *channel = parameters[NSStringFromSelector(@selector(channel))];
+        NSArray<NSString*> *channels = parameters[NSStringFromSelector(@selector(channels))];
+        NSNumber *limit = parameters[NSStringFromSelector(@selector(limit))];
         NSNumber *start = parameters[NSStringFromSelector(@selector(start))];
         NSNumber *end = parameters[NSStringFromSelector(@selector(end))];
-        NSNumber *limit = parameters[NSStringFromSelector(@selector(end))];
         NSNumber *reverse = parameters[NSStringFromSelector(@selector(reverse))];
         NSNumber *includeTimeToken = parameters[NSStringFromSelector(@selector(includeTimeToken))];
         id block = parameters[@"block"];
 
-        [self historyForChannel:channel start:start end:end limit:(limit ? limit.unsignedIntegerValue : 100 ) 
-                        reverse:reverse.boolValue includeTimeToken:includeTimeToken.boolValue 
-                 withCompletion:block];
+        [self historyForChannels:(channels != nil) object:(channels?: channel) start:start end:end 
+                           limit:limit reverse:reverse includeTimeToken:includeTimeToken withCompletion:block];
     }];
     
     return ^PNHistoryAPICallBuilder *{ return builder; };
@@ -132,6 +166,15 @@ NS_ASSUME_NONNULL_END
                     limit:(NSUInteger)limit reverse:(BOOL)shouldReverseOrder 
          includeTimeToken:(BOOL)shouldIncludeTimeToken withCompletion:(PNHistoryCompletionBlock)block {
     
+    [self historyForChannels:NO object:channel start:startDate end:endDate limit:@(limit) 
+                     reverse:@(shouldIncludeTimeToken) includeTimeToken:@(shouldIncludeTimeToken) 
+              withCompletion:block];
+}
+
+- (void)historyForChannels:(BOOL)multipleChannels object:(id)object start:(NSNumber *)startDate
+                       end:(NSNumber *)endDate limit:(NSNumber *)limit reverse:(NSNumber *)shouldReverseOrder 
+          includeTimeToken:(NSNumber *)shouldIncludeTimeToken withCompletion:(PNHistoryCompletionBlock)block {
+    
     // Swap time frame dates if required.
     if (startDate && endDate && [startDate compare:endDate] == NSOrderedDescending) {
         
@@ -140,35 +183,59 @@ NS_ASSUME_NONNULL_END
         endDate = _startDate;
     }
     // Clamp limit to allowed values.
-    limit = MIN(limit, (NSUInteger)100);
+    limit = (limit?: @(multipleChannels ? 1 : 100));
+    unsigned int limitValue = MIN(limit.unsignedIntValue, (multipleChannels ? 25 : 100));
 
     PNRequestParameters *parameters = [PNRequestParameters new];
-    [parameters addQueryParameters:@{@"count": @(limit),
-                                     @"reverse": (shouldReverseOrder ? @"true" : @"false"),
-                                     @"include_token": (shouldIncludeTimeToken ? @"true" : @"false")}];
     if (startDate) {
         
         [parameters addQueryParameter:[PNNumber timeTokenFromNumber:startDate].stringValue
                          forFieldName:@"start"];
     }
+    
     if (endDate) {
         
         [parameters addQueryParameter:[PNNumber timeTokenFromNumber:endDate].stringValue
                          forFieldName:@"end"];
     }
-    if (channel.length) {
-        
-        [parameters addPathComponent:[PNString percentEscapedString:channel] forPlaceholder:@"{channel}"];
-    }
     
-    DDLogAPICall(self.logger, @"<PubNub::API> %@ for '%@' channel%@%@ with %@ limit%@.",
-                 (shouldReverseOrder ? @"Reversed history" : @"History"), (channel?: @"<error>"),
-                 (startDate ? [NSString stringWithFormat:@" from %@", startDate] : @""),
-                 (endDate ? [NSString stringWithFormat:@" to %@", endDate] : @""), @(limit),
-                 (shouldIncludeTimeToken ? @" (including message time tokens)" : @""));
+    if (!multipleChannels) {
+        
+        [parameters addQueryParameter:[NSString stringWithFormat:@"%d", limitValue] forFieldName:@"count"];
+        [parameters addQueryParameter:(shouldReverseOrder.boolValue ? @"true" : @"false")
+                         forFieldName:@"reverse"];
+        [parameters addQueryParameter:(shouldIncludeTimeToken.boolValue ? @"true" : @"false")
+                         forFieldName:@"include_token"];
+        NSString *channel = object;
+        if (channel.length) {
+            
+            [parameters addPathComponent:[PNString percentEscapedString:channel] forPlaceholder:@"{channel}"];
+        }
+        
+        DDLogAPICall(self.logger, @"<PubNub::API> %@ for '%@' channel%@%@ with %@ limit%@.",
+                     (shouldReverseOrder ? @"Reversed history" : @"History"), (channel?: @"<error>"),
+                     (startDate ? [NSString stringWithFormat:@" from %@", startDate] : @""),
+                     (endDate ? [NSString stringWithFormat:@" to %@", endDate] : @""), @(limitValue),
+                     (shouldIncludeTimeToken ? @" (including message time tokens)" : @""));
+    }
+    else {
+        
+        [parameters addQueryParameter:[NSString stringWithFormat:@"%d", limitValue] forFieldName:@"max"];
+        NSArray<NSString *> *channels = object;
+        if (channels.count) {
+            
+            [parameters addPathComponent:[PNChannel namesForRequest:channels] forPlaceholder:@"{channels}"];
+        }
+        
+        DDLogAPICall(self.logger, @"<PubNub::API> History for '%@' channels%@%@ with %@ limit.",
+                     (channels != nil ? [channels componentsJoinedByString:@", "] : @"<error>"),
+                     (startDate ? [NSString stringWithFormat:@" from %@", startDate] : @""),
+                     (endDate ? [NSString stringWithFormat:@" to %@", endDate] : @""), @(limitValue));
+    }
+    PNOperationType operation = (!multipleChannels ? PNHistoryOperation : PNHistoryForChannelsOperation);
 
     __weak __typeof(self) weakSelf = self;
-    [self processOperation:PNHistoryOperation withParameters:parameters
+    [self processOperation:operation withParameters:parameters 
            completionBlock:^(PNResult *result, PNStatus *status) {
 
         // Silence static analyzer warnings.
@@ -181,9 +248,9 @@ NS_ASSUME_NONNULL_END
 
             status.retryBlock = ^{
 
-                [weakSelf historyForChannel:channel start:startDate end:endDate limit:limit
-                                   reverse:shouldReverseOrder includeTimeToken:shouldIncludeTimeToken 
-                             withCompletion:block];
+                [weakSelf historyForChannels:multipleChannels object:object start:startDate end:endDate 
+                                       limit:limit reverse:shouldReverseOrder 
+                            includeTimeToken:shouldIncludeTimeToken withCompletion:block];
             };
         }
         [weakSelf handleHistoryResult:result withStatus:status completion:block];

--- a/PubNub/Core/PubNub+Publish.m
+++ b/PubNub/Core/PubNub+Publish.m
@@ -594,7 +594,7 @@ NS_ASSUME_NONNULL_END
         [parameters addPathComponent:[PNString percentEscapedString:channel] forPlaceholder:@"{channel}"];
     }
     if (!shouldStore) { [parameters addQueryParameter:@"0" forFieldName:@"store"]; }
-    if (ttl) { [parameters addQueryParameter:ttl forFieldName:@"ttl"]; }
+    if (ttl) { [parameters addQueryParameter:ttl.stringValue forFieldName:@"ttl"]; }
     if (!replicate) { [parameters addQueryParameter:@"true" forFieldName:@"norep"]; }
     if (([message isKindOfClass:[NSString class]] && message.length) || message) {
         

--- a/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.h
@@ -29,10 +29,23 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) PNHistoryAPICallBuilder *(^channel)(NSString *channel);
 
 /**
+ @brief      Specify list of channels for which history should be returned.
+ @discussion On block call return block which consume (\b required) name of channels for which access to 
+             history / storage should be done.
+ @discussion \b Important: if history retrieved for list of channels, then \c limit may be changed to equal
+             maximum number of messages for channel (\b 25).  
+ @discussion \b Important: maximum \b 500 channels can be used at once.
+ 
+ @since 4.5.6
+ */
+@property (nonatomic, readonly, strong) PNHistoryAPICallBuilder *(^channels)(NSArray<NSString *> *channels);
+
+/**
  @brief      Specify start of interval from \c channel history from which events should be returned.
  @discussion On block call return block which consume time token for oldest event starting from which next 
              should be returned events.
  @note       Value will be converted to required precision internally.
+ @note       Ignored in case if history for multiple channels should be retrieved.
  
  @since 4.5.4
  */
@@ -43,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
  @discussion On block call return block which consume time token for latest event till which events should be 
              pulled out.
  @note       Value will be converted to required precision internally.
+ @note       Ignored in case if history for multiple channels should be retrieved.
  
  @since 4.5.4
  */
@@ -52,6 +66,8 @@ NS_ASSUME_NONNULL_BEGIN
  @brief      Specify how many events should be returned at once.
  @discussion On block call return block which consume maximum number of events which should be returned in
              response (not more then \b 100).
+ @discussion \b Important: if history requested for multiple channels then maximum \c limit can be set to 
+             \b 25 messages per-channel and by default is \b 1.
  
  @since 4.5.4
  */
@@ -61,6 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
  @brief      Specify whether events' time tokens should be retrieved or not.
  @discussion On block call return block which consume \a BOOL and specify wheter events' time tokens should be
              retrieved as well or not.
+ @note       Ignored in case if history for multiple channels should be retrieved.
  
  @since 4.5.4
  */
@@ -70,6 +87,7 @@ NS_ASSUME_NONNULL_BEGIN
  @brief      Specify whether events order in response should be reversed or not.
  @discussion On block call return block which consume \a BOOL and specify whether events order in response 
              should be reversed or not.
+ @note       Ignored in case if history for multiple channels should be retrieved.
  
  @since 4.5.4
  */

--- a/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.m
@@ -24,6 +24,16 @@
     };
 }
 
+- (PNHistoryAPICallBuilder *(^)(NSArray<NSString *> *))channels {
+    
+    return ^PNHistoryAPICallBuilder* (NSArray<NSString *> *channels) {
+        
+        [self setValue:channels forParameter:NSStringFromSelector(_cmd)];
+        
+        return self;
+    };
+}
+
 - (PNHistoryAPICallBuilder *(^)(NSNumber *start))start {
     
     return ^PNHistoryAPICallBuilder* (NSNumber *start) {

--- a/PubNub/Data/Service Objects/PNHistoryResult.h
+++ b/PubNub/Data/Service Objects/PNHistoryResult.h
@@ -19,21 +19,36 @@ NS_ASSUME_NONNULL_BEGIN
 ///------------------------------------------------
 
 /**
- @brief  Channel history messages.
+ @brief      Channel history messages.
+ @discussion \b Important: for \c PNHistoryForChannelsOperation operation this property always will be 
+             \c empty array.
  
  @since 4.0
  */
 @property (nonatomic, readonly, strong) NSArray *messages;
 
 /**
- @brief  History time frame start time.
+ @brief      Channels history.
+ @discussion Each key represent name of channel for which messages has been received and valus is list of 
+             messages from channel's storage.
+ @discussion \b Important: for  \c PNHistoryOperation operation this property always will be \c empty 
+             dictionary.
+ 
+ @since 4.5.6
+ */
+@property (nonatomic, readonly, strong) NSDictionary<NSString *, NSArray *> *channels;
+
+/**
+ @brief      History time frame start time.
+ @discussion \b Important: for \c PNHistoryForChannelsOperation operation this property always will be \b 0.
  
  @since 4.0
  */
 @property (nonatomic, readonly, strong) NSNumber *start;
 
 /**
- @brief   History time frame end time.
+ @brief      History time frame end time.
+ @discussion \b Important: for \c PNHistoryForChannelsOperation operation this property always will be \b 0.
  
  @since 4.0
  */

--- a/PubNub/Data/Service Objects/PNHistoryResult.m
+++ b/PubNub/Data/Service Objects/PNHistoryResult.m
@@ -20,6 +20,11 @@
     return (self.serviceData[@"messages"]?: @[]);
 }
 
+- (NSDictionary<NSString *,NSArray *> *)channels {
+    
+    return (self.serviceData[@"channels"]?: @{});
+}
+
 - (NSNumber *)start {
     
     return (self.serviceData[@"start"]?: @0);

--- a/PubNub/Misc/PNPrivateStructures.h
+++ b/PubNub/Misc/PNPrivateStructures.h
@@ -16,11 +16,12 @@
 
  @since 4.0
  */
-static NSString * const PNOperationTypeStrings[22] = {
+static NSString * const PNOperationTypeStrings[23] = {
     [PNSubscribeOperation] = @"Subscribe",
     [PNUnsubscribeOperation] = @"Unsubscribe",
     [PNPublishOperation] = @"Publish",
     [PNHistoryOperation] = @"History",
+    [PNHistoryForChannelsOperation] = @"History for Channels",
     [PNWhereNowOperation] = @"Where Now",
     [PNHereNowGlobalOperation] = @"Global Here Now",
     [PNHereNowForChannelOperation] = @"Here Now for Channel",
@@ -41,8 +42,9 @@ static NSString * const PNOperationTypeStrings[22] = {
     [PNTimeOperation] = @"Time",
 };
 
-static NSString * const PNOperationResultClasses[22] = {
+static NSString * const PNOperationResultClasses[23] = {
     [PNHistoryOperation] = @"PNHistoryResult",
+    [PNHistoryForChannelsOperation] = @"PNHistoryResult",
     [PNWhereNowOperation] = @"PNPresenceWhereNowResult",
     [PNHereNowGlobalOperation] = @"PNPresenceGlobalHereNowResult",
     [PNHereNowForChannelOperation] = @"PNPresenceChannelHereNowResult",
@@ -55,11 +57,12 @@ static NSString * const PNOperationResultClasses[22] = {
     [PNTimeOperation] = @"PNTimeResult",
 };
 
-static NSString * const PNOperationStatusClasses[22] = {
+static NSString * const PNOperationStatusClasses[23] = {
     [PNSubscribeOperation] = @"PNSubscribeStatus",
     [PNUnsubscribeOperation] = @"PNAcknowledgmentStatus",
     [PNPublishOperation] = @"PNPublishStatus",
     [PNHistoryOperation] = @"PNErrorStatus",
+    [PNHistoryForChannelsOperation] = @"PNErrorStatus",
     [PNWhereNowOperation] = @"PNErrorStatus",
     [PNHereNowGlobalOperation] = @"PNErrorStatus",
     [PNHereNowForChannelOperation] = @"PNErrorStatus",

--- a/PubNub/Misc/PNStructures.h
+++ b/PubNub/Misc/PNStructures.h
@@ -401,6 +401,7 @@ typedef NS_ENUM(NSInteger, PNOperationType){
     PNUnsubscribeOperation,
     PNPublishOperation,
     PNHistoryOperation,
+    PNHistoryForChannelsOperation,
     PNWhereNowOperation,
     PNHereNowGlobalOperation,
     PNHereNowForChannelOperation,

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -699,11 +699,12 @@ NS_ASSUME_NONNULL_END
     dispatch_once(&onceToken, ^{
         
         _resultExpectingOperations = @[
-                   @(PNHistoryOperation), @(PNWhereNowOperation), @(PNHereNowGlobalOperation),
-                   @(PNHereNowForChannelOperation), @(PNHereNowForChannelGroupOperation),
-                   @(PNStateForChannelOperation), @(PNStateForChannelGroupOperation),
-                   @(PNChannelGroupsOperation), @(PNChannelsForGroupOperation),
-                   @(PNPushNotificationEnabledChannelsOperation), @(PNTimeOperation)];
+                   @(PNHistoryOperation), @(PNHistoryForChannelsOperation), @(PNWhereNowOperation), 
+                   @(PNHereNowGlobalOperation), @(PNHereNowForChannelOperation), 
+                   @(PNHereNowForChannelGroupOperation), @(PNStateForChannelOperation), 
+                   @(PNStateForChannelGroupOperation), @(PNChannelGroupsOperation), 
+                   @(PNChannelsForGroupOperation), @(PNPushNotificationEnabledChannelsOperation), 
+                   @(PNTimeOperation)];
     });
     
     return [_resultExpectingOperations containsObject:@(operation)];

--- a/PubNub/Network/PNURLBuilder.m
+++ b/PubNub/Network/PNURLBuilder.m
@@ -15,11 +15,12 @@
  
  @since 4.0
  */
-static NSString * const PNOperationRequestTemplate[22] = {
+static NSString * const PNOperationRequestTemplate[23] = {
     [PNSubscribeOperation] = @"/v2/subscribe/{sub-key}/{channels}/0",
     [PNUnsubscribeOperation] = @"/v2/presence/sub_key/{sub-key}/channel/{channels}/leave",
     [PNPublishOperation] = @"/publish/{pub-key}/{sub-key}/0/{channel}/0/{message}",
     [PNHistoryOperation] = @"/v2/history/sub-key/{sub-key}/channel/{channel}",
+    [PNHistoryForChannelsOperation] = @"/v3/history/sub-key/{sub-key}/channel/{channels}",
     [PNWhereNowOperation] = @"/v2/presence/sub-key/{sub-key}/uuid/{uuid}",
     [PNHereNowGlobalOperation] = @"/v2/presence/sub-key/{sub-key}",
     [PNHereNowForChannelOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channel}",

--- a/PubNub/Network/Parsers/PNHistoryParser.m
+++ b/PubNub/Network/Parsers/PNHistoryParser.m
@@ -12,7 +12,27 @@
 #import "PNAES.h"
 
 
-#pragma mark Interface implementation
+#pragma mark Private interface declaration
+
+@interface PNHistoryParser ()
+
+/**
+ @brief      Process list of messages.
+ @discussion Processing may include message decryption and mobile payload format restore.
+ 
+ @since 4.5.6
+ 
+ @param messages       Reference on list of messages which should be processed.
+ @param additionalData Reference on dictionary which may contain additional data which maybe required during
+                       messages processing.
+ */
++ (NSMutableDictionary *)processedMessagesFrom:(nullable NSArray *)messages
+                                      withData:(nullable NSDictionary<NSString *, id> *)additionalData;
+
+@end
+
+
+#pragma mark - Interface implementation
 
 @implementation PNHistoryParser
 
@@ -21,7 +41,7 @@
 
 + (NSArray<NSNumber *> *)operations {
     
-    return @[@(PNHistoryOperation)];
+    return @[@(PNHistoryOperation), @(PNHistoryForChannelsOperation)];
 }
 
 + (BOOL)requireAdditionalData {
@@ -39,104 +59,129 @@
     // 'nil' initialized local variable.
     NSDictionary *processedResponse = nil;
     
-    // Array is valid response type for history request.
+    // Array is valid response type for v2 history request.
     if ([response isKindOfClass:[NSArray class]] && ((NSArray *)response).count == 3) {
         
         BOOL shouldStripMobilePayload = ((NSNumber *)additionalData[@"stripMobilePayload"]).boolValue;
         NSMutableDictionary *data = [@{@"start": (NSArray *)response[1], @"end": (NSArray *)response[2],
                                        @"messages": [NSMutableArray new]} mutableCopy];
         NSArray *messages = (NSArray *)response[0];
-        [messages enumerateObjectsUsingBlock:^(id messageObject, __unused NSUInteger messageObjectIdx,
-                                               __unused BOOL *messageObjectEnumeratorStop) {
+        NSMutableDictionary *processedMessages = [self processedMessagesFrom:messages withData:additionalData];
+        if (processedMessages[@"messages"]) { data[@"messages"] = processedMessages[@"messages"]; }
+        if (processedMessages[@"decryptError"]) { data[@"decryptError"] = @YES; }
+        processedResponse = data;
+    }
+     // Dictionary is valid response type for v3 history request.
+    else if ([response isKindOfClass:[NSDictionary class]] && response[@"channels"] && response[@"status"]) {
+        
+        NSMutableDictionary *data = [@{@"channels": [NSMutableDictionary new]} mutableCopy];
+        NSDictionary *channels = response[@"channels"];
+        [channels enumerateKeysAndObjectsUsingBlock:^(NSString *channel, NSArray *messages, BOOL *channelsEnumeratorStop) {
             
-            NSNumber *timeToken = nil;
-            id message = messageObject;
-            
-            // Check whether history response returned with 'timetoken' or not.
-            if ([messageObject isKindOfClass:[NSDictionary class]] &&messageObject[@"message"] && 
-                messageObject[@"timetoken"]) {
-                
-                timeToken = messageObject[@"timetoken"];
-                message = messageObject[@"message"];
-                messageObject = message;
-            }
-            
-            // Try decrypt message if possible.
-            if (((NSString *)additionalData[@"cipherKey"]).length){
-                
-                NSError *decryptionError;
-                id decryptedMessage = nil;
-                id dataForDecryption = ([message isKindOfClass:[NSDictionary class]] ? ((NSDictionary *)message)[@"pn_other"] : message);
-                if ([dataForDecryption isKindOfClass:[NSString class]]) {
-                    
-                    NSData *eventData = [PNAES decrypt:dataForDecryption withKey:additionalData[@"cipherKey"]
-                                              andError:&decryptionError];
-                    NSString *decryptedMessageString = nil;
-                    if (eventData) {
-                        
-                        decryptedMessageString = [[NSString alloc] initWithData:eventData
-                                                                       encoding:NSUTF8StringEncoding];
-                    }
-                    
-                    // In case if decrypted message (because of error suppression) is equal to original 
-                    // message, there is no need to retry JSON de-serialization.
-                    if (decryptedMessageString && ![decryptedMessageString isEqualToString:dataForDecryption]) {
-                        
-                        decryptedMessage = [PNJSON JSONObjectFrom:decryptedMessageString withError:nil];
-                    }
-                }
-                
-                if (decryptionError || !decryptedMessage) {
-                    
-                    PNLLogger *logger = [PNLLogger loggerWithIdentifier:kPNClientIdentifier];
-                    [logger enableLogLevel:PNAESErrorLogLevel];
-                    DDLogAESError(logger, @"<PubNub::AES> History entry decryption error: %@", 
-                                  decryptionError);
-                    data[@"decryptError"] = @YES;
-                    
-                    // Restore message to original form.
-                    message = messageObject;
-                }
-                else { 
-                    
-                    if (!shouldStripMobilePayload && [message isKindOfClass:[NSDictionary class]]) {
-                        
-                        NSMutableDictionary *mutableMessage = [message mutableCopy];
-                        [mutableMessage removeObjectForKey:@"pn_other"];
-                        if (![decryptedMessage isKindOfClass:[NSDictionary class]]) {
-                            
-                            mutableMessage[@"pn_other"] = decryptedMessage;
-                        } else { [mutableMessage addEntriesFromDictionary:decryptedMessage]; }
-                        decryptedMessage = [mutableMessage copy];
-                    }
-                    message = decryptedMessage;
-                }
-            }
-            
-            if (message) {
-                
-                if (shouldStripMobilePayload && [message isKindOfClass:[NSDictionary class]] &&
-                    (message[@"pn_apns"] || message[@"pn_gcm"] || message[@"pn_mpns"])) {
-                    
-                    id decomposedMessage = message;
-                    if (!message[@"pn_other"]) {
-                        
-                        NSMutableDictionary *dictionaryData = [message mutableCopy];
-                        [dictionaryData removeObjectsForKeys:@[@"pn_apns", @"pn_gcm", @"pn_mpns"]];
-                        decomposedMessage = dictionaryData;
-                    }
-                    else { decomposedMessage = message[@"pn_other"]; }
-                    message = decomposedMessage;
-                }
-                
-                message = (timeToken ? @{@"message": message, @"timetoken": timeToken} : message);
-                [data[@"messages"] addObject:message];
-            }
+            NSMutableDictionary *processedMessages = [self processedMessagesFrom:messages withData:additionalData];
+            data[@"channels"][channel] = (processedMessages[@"messages"]?: @[]);
+            if (processedMessages[@"decryptError"]) { data[@"decryptError"] = @YES; }
         }];
         processedResponse = data;
     }
     
     return processedResponse;
+}
+
++ (NSMutableDictionary *)processedMessagesFrom:(NSArray *)messages
+                                      withData:(NSDictionary<NSString *, id> *)additionalData {
+    
+    BOOL shouldStripMobilePayload = ((NSNumber *)additionalData[@"stripMobilePayload"]).boolValue;
+    NSMutableDictionary *data = @{@"messages": [NSMutableArray new]};
+    [messages enumerateObjectsUsingBlock:^(id messageObject, __unused NSUInteger messageObjectIdx,
+                                           __unused BOOL *messageObjectEnumeratorStop) {
+        
+        NSNumber *timeToken = nil;
+        id message = messageObject;
+        
+        // Check whether history response returned with 'timetoken' or not.
+        if ([messageObject isKindOfClass:[NSDictionary class]] &&messageObject[@"message"] && 
+            messageObject[@"timetoken"]) {
+            
+            timeToken = messageObject[@"timetoken"];
+            message = messageObject[@"message"];
+            messageObject = message;
+        }
+        
+        // Try decrypt message if possible.
+        if (((NSString *)additionalData[@"cipherKey"]).length){
+            
+            NSError *decryptionError;
+            id decryptedMessage = nil;
+            id dataForDecryption = ([message isKindOfClass:[NSDictionary class]] ? ((NSDictionary *)message)[@"pn_other"] : message);
+            if ([dataForDecryption isKindOfClass:[NSString class]]) {
+                
+                NSData *eventData = [PNAES decrypt:dataForDecryption withKey:additionalData[@"cipherKey"]
+                                          andError:&decryptionError];
+                NSString *decryptedMessageString = nil;
+                if (eventData) {
+                    
+                    decryptedMessageString = [[NSString alloc] initWithData:eventData
+                                                                   encoding:NSUTF8StringEncoding];
+                }
+                
+                // In case if decrypted message (because of error suppression) is equal to original 
+                // message, there is no need to retry JSON de-serialization.
+                if (decryptedMessageString && ![decryptedMessageString isEqualToString:dataForDecryption]) {
+                    
+                    decryptedMessage = [PNJSON JSONObjectFrom:decryptedMessageString withError:nil];
+                }
+            }
+            
+            if (decryptionError || !decryptedMessage) {
+                
+                PNLLogger *logger = [PNLLogger loggerWithIdentifier:kPNClientIdentifier];
+                [logger enableLogLevel:PNAESErrorLogLevel];
+                DDLogAESError(logger, @"<PubNub::AES> History entry decryption error: %@", 
+                              decryptionError);
+                data[@"decryptError"] = @YES;
+                
+                // Restore message to original form.
+                message = messageObject;
+            }
+            else { 
+                
+                if (!shouldStripMobilePayload && [message isKindOfClass:[NSDictionary class]]) {
+                    
+                    NSMutableDictionary *mutableMessage = [message mutableCopy];
+                    [mutableMessage removeObjectForKey:@"pn_other"];
+                    if (![decryptedMessage isKindOfClass:[NSDictionary class]]) {
+                        
+                        mutableMessage[@"pn_other"] = decryptedMessage;
+                    } else { [mutableMessage addEntriesFromDictionary:decryptedMessage]; }
+                    decryptedMessage = [mutableMessage copy];
+                }
+                message = decryptedMessage;
+            }
+        }
+        
+        if (message) {
+            
+            if (shouldStripMobilePayload && [message isKindOfClass:[NSDictionary class]] &&
+                (message[@"pn_apns"] || message[@"pn_gcm"] || message[@"pn_mpns"])) {
+                
+                id decomposedMessage = message;
+                if (!message[@"pn_other"]) {
+                    
+                    NSMutableDictionary *dictionaryData = [message mutableCopy];
+                    [dictionaryData removeObjectsForKeys:@[@"pn_apns", @"pn_gcm", @"pn_mpns"]];
+                    decomposedMessage = dictionaryData;
+                }
+                else { decomposedMessage = message[@"pn_other"]; }
+                message = decomposedMessage;
+            }
+            
+            message = (timeToken ? @{@"message": message, @"timetoken": timeToken} : message);
+            [data[@"messages"] addObject:message];
+        }
+    }];
+    
+    return data;
 }
 
 #pragma mark -


### PR DESCRIPTION
Added interface which allow to fetch history for multiple channels with single API call.  
Interface has few limitations:  
* maximum **500** channels per call
* maximum **25** messages per-channel (default **1**)

Interface available only with API call builder interface.