### PR TITLE
Deprecated 'restoreSubscription' property

### DIFF
--- a/Example/PubNub Mac Example/AppDelegate.m
+++ b/Example/PubNub Mac Example/AppDelegate.m
@@ -781,7 +781,6 @@
     
     // Time Token Handling Settings
     self.myConfig.keepTimeTokenOnListChange = YES;
-    self.myConfig.restoreSubscription = YES;
     self.myConfig.catchUpOnSubscriptionRestore = YES;
     
     // Messages threshold
@@ -803,8 +802,6 @@
     // Time Token Handling Settings
     NSLog(@"keepTimeTokenOnChannelChange: %@",
           (self.myConfig.shouldKeepTimeTokenOnListChange ? @"YES" : @"NO"));
-    NSLog(@"resubscribeOnConnectionRestore: %@",
-          (self.myConfig.shouldRestoreSubscription ? @"YES" : @"NO"));
     NSLog(@"catchUpOnSubscriptionRestore: %@",
           (self.myConfig.shouldTryCatchUpOnSubscriptionRestore ? @"YES" : @"NO"));
     

--- a/Example/PubNub/PNAppDelegate.m
+++ b/Example/PubNub/PNAppDelegate.m
@@ -785,7 +785,6 @@
 
     // Time Token Handling Settings
     self.myConfig.keepTimeTokenOnListChange = YES;
-    self.myConfig.restoreSubscription = YES;
     self.myConfig.catchUpOnSubscriptionRestore = YES;
     
     // Messages threshold
@@ -807,8 +806,6 @@
     // Time Token Handling Settings
     NSLog(@"keepTimeTokenOnChannelChange: %@",
             (self.myConfig.shouldKeepTimeTokenOnListChange ? @"YES" : @"NO"));
-    NSLog(@"resubscribeOnConnectionRestore: %@",
-            (self.myConfig.shouldRestoreSubscription ? @"YES" : @"NO"));
     NSLog(@"catchUpOnSubscriptionRestore: %@",
             (self.myConfig.shouldTryCatchUpOnSubscriptionRestore ? @"YES" : @"NO"));
 

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -182,7 +182,9 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.0
  */
-@property (nonatomic, assign, getter = shouldRestoreSubscription) BOOL restoreSubscription NS_SWIFT_NAME(restoreSubscription);
+@property (nonatomic, assign, getter = shouldRestoreSubscription) BOOL restoreSubscription NS_SWIFT_NAME(restoreSubscription) 
+          DEPRECATED_MSG_ATTRIBUTE("This option will be deprecated in upcoming releases. Client will restore "
+                                   "it's subscription after network issues automatically.");
 
 /**
  @brief      Stores whether client should try to catch up for events which occurred on previously subscribed 

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -146,7 +146,6 @@ NS_ASSUME_NONNULL_END
         _TLSEnabled = kPNDefaultIsTLSEnabled;
         _heartbeatNotificationOptions = kPNDefaultHeartbeatNotificationOptions;
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
-        _restoreSubscription = kPNDefaultShouldRestoreSubscription;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
         _requestMessageCountThreshold = kPNDefaultRequestMessageCountThreshold;
 #if TARGET_OS_IOS
@@ -175,7 +174,6 @@ NS_ASSUME_NONNULL_END
     configuration.TLSEnabled = self.isTLSEnabled;
     configuration.heartbeatNotificationOptions = self.heartbeatNotificationOptions;
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;
-    configuration.restoreSubscription = self.shouldRestoreSubscription;
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
     configuration.applicationExtensionSharedGroupIdentifier = self.applicationExtensionSharedGroupIdentifier;
     configuration.requestMessageCountThreshold = self.requestMessageCountThreshold;

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -49,7 +49,6 @@ static NSTimeInterval const kPNDefaultNonSubscribeRequestTimeout = 10.0f;
 static BOOL const kPNDefaultIsTLSEnabled = YES;
 static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptions = PNHeartbeatNotifyFailure;
 static BOOL const kPNDefaultShouldKeepTimeTokenOnListChange = YES;
-static BOOL const kPNDefaultShouldRestoreSubscription = YES;
 static BOOL const kPNDefaultShouldTryCatchUpOnSubscriptionRestore = YES;
 static BOOL const kPNDefaultRequestMessageCountThreshold = 0;
 #if TARGET_OS_IOS

--- a/README.md
+++ b/README.md
@@ -137,8 +137,7 @@ To setup a custom configuration:
 
     // Time Token Handling Settings
     self.myConfig.keepTimeTokenOnListChange = YES; // When changing channels, 'catchup' ?
-    self.myConfig.restoreSubscription = YES; // If you lose the connection, should you resubscribe when it comes back?
-    self.myConfig.catchUpOnSubscriptionRestore = YES; // If restoreSubscription == YES, catchup ? Or start at 'now' ?
+    self.myConfig.catchUpOnSubscriptionRestore = YES; // Catchup ? Or start at 'now' ?
 ```
 
 ## New for 4.0


### PR DESCRIPTION
Now client by default will restore subscription on previous channels after network issues (property deprecated and doesn't affect subscriber functionality).