### PR TITLE
Added messages de-duplication logic.

### DIFF
--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -223,7 +223,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.5.4
  */
-@property (nonatomic, copy) NSString *applicationExtensionSharedGroupIdentifier  NS_SWIFT_NAME(applicationExtensionSharedGroupIdentifier) NS_AVAILABLE(10_10, 8_0);
+@property (nonatomic, copy) NSString *applicationExtensionSharedGroupIdentifier NS_SWIFT_NAME(applicationExtensionSharedGroupIdentifier) NS_AVAILABLE(10_10, 8_0);
 
 /**
  @brief      Number of maximum expected messages from \b PubNub service in single response.
@@ -234,7 +234,22 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.5.4
  */
-@property (nonatomic, assign) NSUInteger requestMessageCountThreshold  NS_SWIFT_NAME(requestMessageCountThreshold);
+@property (nonatomic, assign) NSUInteger requestMessageCountThreshold NS_SWIFT_NAME(requestMessageCountThreshold);
+
+/**
+ @brief      Messages de-duplication cache size.
+ @discussion This value is responsible for messages cache size which is used during messages de-duplication 
+             process. In various situations (for rexample in case of enabled multi-regional support) \b PubNub
+             service may decide to re-send few messages to ensure what they won't be missed (for example when 
+             region switched for better performance).
+             De-duplication ensure what at the end listeners won't receive message which has been processed 
+             already through real-time channels.
+ @default    By default this cache is set to \b 100 messages. It is possible to disable de-duplication by 
+             passing \b 0 to this property.
+ 
+ @since 4.5.8
+ */
+@property (nonatomic, assign) NSUInteger maximumMessagesCacheSize NS_SWIFT_NAME(maximumMessagesCacheSize);
 
 #if TARGET_OS_IOS
 /**

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -148,6 +148,7 @@ NS_ASSUME_NONNULL_END
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
         _requestMessageCountThreshold = kPNDefaultRequestMessageCountThreshold;
+        _maximumMessagesCacheSize = kPNDefaultMaximumMessagesCacheSize;
 #if TARGET_OS_IOS
         _completeRequestsBeforeSuspension = kPNDefaultShouldCompleteRequestsBeforeSuspension;
 #endif // TARGET_OS_IOS
@@ -177,6 +178,7 @@ NS_ASSUME_NONNULL_END
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
     configuration.applicationExtensionSharedGroupIdentifier = self.applicationExtensionSharedGroupIdentifier;
     configuration.requestMessageCountThreshold = self.requestMessageCountThreshold;
+    configuration.maximumMessagesCacheSize = self.maximumMessagesCacheSize;
 #if TARGET_OS_IOS
     configuration.completeRequestsBeforeSuspension = self.shouldCompleteRequestsBeforeSuspension;
 #endif // TARGET_OS_IOS

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -51,6 +51,7 @@ static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptio
 static BOOL const kPNDefaultShouldKeepTimeTokenOnListChange = YES;
 static BOOL const kPNDefaultShouldTryCatchUpOnSubscriptionRestore = YES;
 static BOOL const kPNDefaultRequestMessageCountThreshold = 0;
+static BOOL const kPNDefaultMaximumMessagesCacheSize = 100;
 #if TARGET_OS_IOS
 static BOOL const kPNDefaultShouldCompleteRequestsBeforeSuspension = YES;
 #endif // TARGET_OS_IOS

--- a/PubNub/Network/Parsers/PNSubscribeParser.m
+++ b/PubNub/Network/Parsers/PNSubscribeParser.m
@@ -287,6 +287,8 @@ NS_ASSUME_NONNULL_END
     if ([PNChannel isPresenceObject:event[@"subscription"]]) {
         
         [event addEntriesFromDictionary:[self presenceFromData:data[PNEventEnvelope.payload]]];
+        event[@"subscription"] = [PNChannel channelForPresence:event[@"subscription"]];
+        event[@"channel"] = [PNChannel channelForPresence:event[@"channel"]];
     }
     else {
         


### PR DESCRIPTION
With new **PNConfiguration** instance property `maximumMessagesCacheSize` it is possible to enable (by providing non-zero value) messages de-duplication logic.
By default this property will be set to **100**.