### PR TITLE
Fixed issue with copyWithConfiguration method which 

### DIFF
--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -295,6 +295,9 @@ NS_ASSUME_NONNULL_END
     [client.listenersManager inheritStateFromListener:self.listenersManager];
     [client removeListener:self];
     [self.listenersManager removeAllListeners];
+    // Because inheritence replace current event subscribers with set from old client new should add
+    // itself back.
+    [client addListener:client];
     
     dispatch_block_t subscriptionRestoreBlock = ^{
         

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -275,8 +275,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.5.0
  */
-@property (nonatomic, assign, getter = shouldStripMobilePayload) BOOL stripMobilePayload NS_SWIFT_NAME(stripMobilePayload)
-          DEPRECATED_MSG_ATTRIBUTE("This option deprecated and will be removed in next general SDK update.");
+@property (nonatomic, assign, getter = shouldStripMobilePayload) BOOL stripMobilePayload NS_SWIFT_NAME(stripMobilePayload);
 
 /**
  @brief  Construct configuration instance using minimal required data.


### PR DESCRIPTION
Now client will re-add itself as observer after settings inheritance from old client.