### PR TITLE
Fixed issues with telemetry instance.

### DIFF
--- a/Example/PubNub Example.xcodeproj/project.pbxproj
+++ b/Example/PubNub Example.xcodeproj/project.pbxproj
@@ -55,11 +55,11 @@
 		6003F5A8195388D20070C39A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		689DC9F68C012D3E869E6C60 /* Pods-PubNub_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNub_Example.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-PubNub_Example/Pods-PubNub_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		78D5FDD94AEDFE48ED24E6A4 /* PubNub.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = PubNub.podspec; path = ../PubNub.podspec; sourceTree = "<group>"; };
-		793D26AC1B44048900509447 /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 1; lastKnownFileType = text; name = CHANGELOG; path = ../CHANGELOG; sourceTree = "<group>"; };
-		793D26AE1B44049400509447 /* VERSION */ = {isa = PBXFileReference; fileEncoding = 1; lastKnownFileType = text; name = VERSION; path = ../VERSION; sourceTree = "<group>"; };
+		793D26AC1B44048900509447 /* CHANGELOG */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = CHANGELOG; path = ../CHANGELOG; sourceTree = "<group>"; };
+		793D26AE1B44049400509447 /* VERSION */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = VERSION; path = ../VERSION; sourceTree = "<group>"; };
 		7A9945019D33BCC2C3B3B7C1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		873B8AEA1B1F5CCA007FD442 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		97FB4DB81B36266800CA7C91 /* Rakefile */ = {isa = PBXFileReference; fileEncoding = 1; lastKnownFileType = text; name = Rakefile; path = ../Rakefile; sourceTree = "<group>"; };
+		97FB4DB81B36266800CA7C91 /* Rakefile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Rakefile; path = ../Rakefile; sourceTree = "<group>"; };
 		C4C1ED79724D56B45766CFFA /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 		CE8E3E8D381615049B34093B /* Pods-PubNub Mac Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PubNub Mac Example.release.xcconfig"; path = "../Pods/Target Support Files/Pods-PubNub Mac Example/Pods-PubNub Mac Example.release.xcconfig"; sourceTree = "<group>"; };
 		D3E9E665B0DB810E183D7620 /* Pods_PubNub_Mac_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PubNub_Mac_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/Framework/PubNub Framework.xcodeproj/project.pbxproj
+++ b/Framework/PubNub Framework.xcodeproj/project.pbxproj
@@ -407,6 +407,20 @@
 		793887081BEAD4DE00DCC662 /* PNNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 793887031BEAD49100DCC662 /* PNNumber.m */; };
 		793887091BEAD4E100DCC662 /* PNNumber.m in Sources */ = {isa = PBXBuildFile; fileRef = 793887031BEAD49100DCC662 /* PNNumber.m */; };
 		795158621C11EA5500A9D3AE /* PubNub.h in Headers */ = {isa = PBXBuildFile; fileRef = 795158611C11EA5500A9D3AE /* PubNub.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B6631F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B6641F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
+		7960B6651F68122000FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B6661F68122100FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B6671F68122100FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B6681F68122100FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B6691F68122200FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B66A1F68122200FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7960B66B1F68123300FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
+		7960B66C1F68123300FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
+		7960B66D1F68123300FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
+		7960B66E1F68123400FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
+		7960B66F1F68123400FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
+		7960B6701F68123500FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */; };
 		79650C2C1E775E8300006F66 /* PNDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 79650C291E775E8300006F66 /* PNDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79650C2D1E775E8300006F66 /* PNLockSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 79650C2A1E775E8300006F66 /* PNLockSupport.h */; };
 		79650C2E1E775E8300006F66 /* PNLockSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 79650C2B1E775E8300006F66 /* PNLockSupport.m */; };
@@ -1597,6 +1611,8 @@
 		7951585B1C11C88500A9D3AE /* Fabric+FABKits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Fabric+FABKits.h"; sourceTree = "<group>"; };
 		7951585C1C11C88500A9D3AE /* Fabric.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Fabric.h; sourceTree = "<group>"; };
 		795158611C11EA5500A9D3AE /* PubNub.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PubNub.h; sourceTree = "<group>"; };
+		7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PNDeleteMessageAPICallBuilder.h; sourceTree = "<group>"; };
+		7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNDeleteMessageAPICallBuilder.m; sourceTree = "<group>"; };
 		79650C291E775E8300006F66 /* PNDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PNDefines.h; sourceTree = "<group>"; };
 		79650C2A1E775E8300006F66 /* PNLockSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PNLockSupport.h; sourceTree = "<group>"; };
 		79650C2B1E775E8300006F66 /* PNLockSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNLockSupport.m; sourceTree = "<group>"; };
@@ -1951,6 +1967,8 @@
 		79A0D8121DC22C950039A264 /* History */ = {
 			isa = PBXGroup;
 			children = (
+				7960B6611F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h */,
+				7960B6621F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m */,
 				79A0D8131DC22C950039A264 /* PNHistoryAPICallBuilder.h */,
 				79A0D8141DC22C950039A264 /* PNHistoryAPICallBuilder.m */,
 			);
@@ -2466,6 +2484,7 @@
 				7915826E1BD709C60084FC70 /* PubNub+Time.h in Headers */,
 				7915826B1BD709C60084FC70 /* PubNub+APNS.h in Headers */,
 				791582851BD709C60084FC70 /* PNLogMacro.h in Headers */,
+				7960B6631F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				79E2D0EE1C56434700BAA244 /* PNKeychain.h in Headers */,
 				791582991BD709C60084FC70 /* PNNetwork.h in Headers */,
 				791582931BD709C60084FC70 /* PNChannel.h in Headers */,
@@ -2588,6 +2607,7 @@
 				79E2D0EF1C56434700BAA244 /* PNKeychain.h in Headers */,
 				79A0D8BA1DC22FC90039A264 /* PNPresenceChannelGroupHereNowAPICallBuilder.h in Headers */,
 				791583421BD709D10084FC70 /* PNNetwork.h in Headers */,
+				7960B6661F68122100FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				7915833C1BD709D10084FC70 /* PNChannel.h in Headers */,
 				791583281BD709D10084FC70 /* PNHelpers.h in Headers */,
 				7925DB891D3FFCAC00857C0D /* PNLLogger.h in Headers */,
@@ -2637,6 +2657,7 @@
 				798842421C18F146003E8948 /* PNClientStateUpdateStatus.h in Headers */,
 				79A0D8AB1DC22FA70039A264 /* PNHistoryAPICallBuilder.h in Headers */,
 				798842AE1C18F2D5003E8948 /* PNPresenceWhereNowParser.h in Headers */,
+				7960B6691F68122200FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				798842491C18F16A003E8948 /* PNPresenceWhereNowResult.h in Headers */,
 				798842AD1C18F2D5003E8948 /* PNPresenceHereNowParser.h in Headers */,
 				79A0D9591DC230FA0039A264 /* PNSubscribeChannelsOrGroupsAPIBuilder.h in Headers */,
@@ -2783,6 +2804,7 @@
 				798843651C191579003E8948 /* PNSubscriberResults.h in Headers */,
 				798843601C191579003E8948 /* PNClientInformation.h in Headers */,
 				798843581C191579003E8948 /* PubNub+CorePrivate.h in Headers */,
+				7960B66A1F68122200FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				7988438F1C191579003E8948 /* PNSubscribeParser.h in Headers */,
 				7988434B1C191579003E8948 /* PNHeartbeatParser.h in Headers */,
 				798843451C191579003E8948 /* PNSubscribeStatus.h in Headers */,
@@ -2954,6 +2976,7 @@
 				79A8BC941C58F93900015BDE /* PNKeychain.h in Headers */,
 				79A0D8B91DC22FC80039A264 /* PNPresenceChannelGroupHereNowAPICallBuilder.h in Headers */,
 				79A8BCB11C58F93900015BDE /* PNNetwork.h in Headers */,
+				7960B6651F68122000FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				79A8BCAA1C58F93900015BDE /* PNChannel.h in Headers */,
 				79A8BC961C58F93900015BDE /* PNHelpers.h in Headers */,
 				7925DB881D3FFCAC00857C0D /* PNLLogger.h in Headers */,
@@ -3028,6 +3051,7 @@
 				79ACC4411C11BC4D0056523A /* PNSubscriberResults.h in Headers */,
 				79ACC43F1C11BC4D0056523A /* PubNub+ChannelGroup.h in Headers */,
 				79ACC4821C11BC4D0056523A /* PubNub+CorePrivate.h in Headers */,
+				7960B6681F68122100FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				79ACC4681C11BC4D0056523A /* PNHeartbeatParser.h in Headers */,
 				79ACC4641C11BC4D0056523A /* PNSubscribeParser.h in Headers */,
 				79ACC4451C11BC4D0056523A /* PNSubscribeStatus.h in Headers */,
@@ -3199,6 +3223,7 @@
 				79CBB1861BD03DE4001FC34D /* PNNetwork.h in Headers */,
 				79A0D8BB1DC22FC90039A264 /* PNPresenceChannelGroupHereNowAPICallBuilder.h in Headers */,
 				79CBB14A1BD03DE4001FC34D /* PNChannel.h in Headers */,
+				7960B6671F68122100FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
 				79CBB1541BD03DE4001FC34D /* PNHelpers.h in Headers */,
 				7925DB8A1D3FFCAC00857C0D /* PNLLogger.h in Headers */,
 				793887071BEAD4A800DCC662 /* PNNumber.h in Headers */,
@@ -3842,6 +3867,7 @@
 				79A0D86D1DC22C950039A264 /* PNTimeAPICallBuilder.m in Sources */,
 				79A0D8701DC22C950039A264 /* PNAPICallBuilder.m in Sources */,
 				79A0D86B1DC22C950039A264 /* PNUnsubscribeChannelsOrGroupsAPICallBuilder.m in Sources */,
+				7960B6641F6811D700FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				791582241BD709C60084FC70 /* PNHistoryResult.m in Sources */,
 				7915821F1BD709C60084FC70 /* PNStateListener.m in Sources */,
 				79A0D8491DC22C950039A264 /* PNHistoryAPICallBuilder.m in Sources */,
@@ -3944,6 +3970,7 @@
 				791582D91BD709D10084FC70 /* PNSubscribeParser.m in Sources */,
 				791582BA1BD709D10084FC70 /* PNSubscribeStatus.m in Sources */,
 				791582EF1BD709D10084FC70 /* PubNub+Subscribe.m in Sources */,
+				7960B66C1F68123300FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				791582E51BD709D10084FC70 /* PubNub+Presence.m in Sources */,
 				791582E41BD709D10084FC70 /* PNPublishStatus.m in Sources */,
 				79A0D8D21DC2300F0039A264 /* PNPresenceAPICallBuilder.m in Sources */,
@@ -4046,6 +4073,7 @@
 				798842B81C18F2EA003E8948 /* PNHeartbeatParser.m in Sources */,
 				798842721C18F1E3003E8948 /* PNSubscribeStatus.m in Sources */,
 				798842571C18F1C0003E8948 /* PubNub+Subscribe.m in Sources */,
+				7960B66F1F68123400FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				798842B91C18F2EA003E8948 /* PNHistoryParser.m in Sources */,
 				7988426D1C18F1E3003E8948 /* PNPublishStatus.m in Sources */,
 				79A0D8D51DC230100039A264 /* PNPresenceAPICallBuilder.m in Sources */,
@@ -4187,6 +4215,7 @@
 				79A0D89A1DC22F800039A264 /* PNAPNSAuditAPICallBuilder.m in Sources */,
 				7925DB941D3FFCAC00857C0D /* PNLLogger.m in Sources */,
 				7988433B1C191579003E8948 /* PNResult.m in Sources */,
+				7960B6701F68123500FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				798843351C191579003E8948 /* PNStatus.m in Sources */,
 				798843331C191579003E8948 /* PNString.m in Sources */,
 				798843281C191579003E8948 /* PNNumber.m in Sources */,
@@ -4251,6 +4280,7 @@
 				79A8BC451C58F93900015BDE /* PNSubscribeParser.m in Sources */,
 				79A8BC261C58F93900015BDE /* PNSubscribeStatus.m in Sources */,
 				79A8BC5C1C58F93900015BDE /* PubNub+Subscribe.m in Sources */,
+				7960B66B1F68123300FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				79A8BC531C58F93900015BDE /* PubNub+Presence.m in Sources */,
 				79A8BC511C58F93900015BDE /* PNPublishStatus.m in Sources */,
 				79A0D8D11DC2300F0039A264 /* PNPresenceAPICallBuilder.m in Sources */,
@@ -4392,6 +4422,7 @@
 				79A0D8981DC22F7F0039A264 /* PNAPNSAuditAPICallBuilder.m in Sources */,
 				7925DB921D3FFCAC00857C0D /* PNLLogger.m in Sources */,
 				79ACC42A1C11BC4D0056523A /* PNResult.m in Sources */,
+				7960B66E1F68123400FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				79ACC4251C11BC4D0056523A /* PNStatus.m in Sources */,
 				79ACC41D1C11BC4D0056523A /* PNNumber.m in Sources */,
 				79ACC3EC1C11BC4D0056523A /* PNString.m in Sources */,
@@ -4456,6 +4487,7 @@
 				79CBB1711BD03DE4001FC34D /* PNHeartbeatParser.m in Sources */,
 				79CBB1451BD03DE4001FC34D /* PNSubscribeStatus.m in Sources */,
 				79CBB1091BD03DE4001FC34D /* PubNub+Subscribe.m in Sources */,
+				7960B66D1F68123300FFAEBB /* PNDeleteMessageAPICallBuilder.m in Sources */,
 				79CBB1731BD03DE4001FC34D /* PNHistoryParser.m in Sources */,
 				79CBB1381BD03DE4001FC34D /* PNPublishStatus.m in Sources */,
 				79A0D8D31DC2300F0039A264 /* PNPresenceAPICallBuilder.m in Sources */,

--- a/PubNub/Data/Managers/PNTelemetry.m
+++ b/PubNub/Data/Managers/PNTelemetry.m
@@ -167,8 +167,9 @@ NS_ASSUME_NONNULL_END
     
     // Check whether subscribe operation asked for latency measurment or not. 
     // There is no point to track long-poll operation latency.
-    if (operationType != PNSubscribeOperation) {
+    if (operationType != PNSubscribeOperation && identifier) {
         NSNumber *date = @([[NSDate date] timeIntervalSince1970]);
+
         pn_safe_property_write(self.resourceAccessQueue, ^{
             self.trackedLatencies[identifier] = date;
         });
@@ -179,7 +180,7 @@ NS_ASSUME_NONNULL_END
     
     // Check whether subscribe operation asked for latency measurment or not. 
     // There is no point to track long-poll operation latency.
-    if (operationType != PNSubscribeOperation) {
+    if (operationType != PNSubscribeOperation && identifier) {
         NSTimeInterval date = [[NSDate date] timeIntervalSince1970];
         __block NSNumber *startDate;
 

--- a/PubNub/Data/Managers/PNTelemetry.m
+++ b/PubNub/Data/Managers/PNTelemetry.m
@@ -6,6 +6,7 @@
 #import "PNTelemetry.h"
 #import "PNPrivateStructures.h"
 #import "PNLockSupport.h"
+#import "PNHelpers.h"
 #import "PNNumber.h"
 
 
@@ -66,11 +67,12 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) NSTimer *cleanUpTimer;
 
 /**
- @brief  Spin/unfair-lock which is used to protect access to shared resources from multiple threads.
- 
- @since 4.6.2
+ @brief  Stores reference on queue which is used to serialize access to shared telemetry
+         information.
+
+ @since 4.7.1
  */
-@property (nonatomic, assign) os_unfair_lock resourceAccessLock;
+@property (nonatomic, strong) dispatch_queue_t resourceAccessQueue;
 
 
 #pragma mark - Operation information
@@ -120,13 +122,14 @@ NS_ASSUME_NONNULL_END
     
     // Cjeck whether initialization has been successful or not.
     if ((self = [super init])) {
-        
-        self.resourceAccessLock = OS_UNFAIR_LOCK_INIT;
-        self.latencies = [NSMutableDictionary new];
-        self.trackedLatencies = [NSMutableDictionary new];
-        self.cleanUpTimer = [NSTimer scheduledTimerWithTimeInterval:1.0f target:self
-                                                           selector:@selector(handleCleanUpTimer:) 
-                                                           userInfo:nil repeats:YES];
+
+        _resourceAccessQueue = dispatch_queue_create("com.pubnub.telemetry", DISPATCH_QUEUE_CONCURRENT);
+        _latencies = [NSMutableDictionary new];
+        _trackedLatencies = [NSMutableDictionary new];
+        _cleanUpTimer = [NSTimer scheduledTimerWithTimeInterval:1.0f
+                                                         target:self
+                                                       selector:@selector(handleCleanUpTimer:)
+                                                       userInfo:nil repeats:YES];
     }
     
     return self;
@@ -138,15 +141,16 @@ NS_ASSUME_NONNULL_END
 - (NSDictionary *)operationsLatencyForRequest {
     
     NSMutableDictionary *latenciesForRequest = [NSMutableDictionary new];
-    pn_trylock(&_resourceAccessLock, ^{
-        
+    pn_safe_property_read(self.resourceAccessQueue, ^{
         NSString *averageKeyPath = [@"@avg." stringByAppendingString:kPNOperationLatencyKey];
-        [self.latencies enumerateKeysAndObjectsUsingBlock:^(NSString *latencyKey, 
-                                                            NSMutableArray<NSDictionary *> *latencies, 
+
+        [self.latencies enumerateKeysAndObjectsUsingBlock:^(NSString *latencyKey,
+                                                            NSMutableArray<NSDictionary *> *latencies,
                                                             BOOL *latenciesEnumeratorStop) {
-            
+
             NSString *averageLatencyKey = [@"l_" stringByAppendingString:latencyKey];
-            latenciesForRequest[averageLatencyKey] = [latencies valueForKeyPath:averageKeyPath];
+            NSNumber *averageLatency = [latencies valueForKeyPath:averageKeyPath];
+            latenciesForRequest[averageLatencyKey] = [NSString stringWithFormat:@"%.10f", averageLatency.doubleValue];
         }];
     });
     
@@ -165,7 +169,9 @@ NS_ASSUME_NONNULL_END
     // There is no point to track long-poll operation latency.
     if (operationType != PNSubscribeOperation) {
         NSNumber *date = @([[NSDate date] timeIntervalSince1970]);
-        pn_trylock(&_resourceAccessLock, ^{ self.trackedLatencies[identifier] = date; });
+        pn_safe_property_write(self.resourceAccessQueue, ^{
+            self.trackedLatencies[identifier] = date;
+        });
     }
 }
 
@@ -174,17 +180,16 @@ NS_ASSUME_NONNULL_END
     // Check whether subscribe operation asked for latency measurment or not. 
     // There is no point to track long-poll operation latency.
     if (operationType != PNSubscribeOperation) {
-        
         NSTimeInterval date = [[NSDate date] timeIntervalSince1970];
-        pn_trylock(&_resourceAccessLock, ^{
-            
-            NSNumber *startDate = self.trackedLatencies[identifier];
-            if (startDate) {
-                
-                [self.trackedLatencies removeObjectForKey:identifier];
-                [self setLatency:(date - startDate.doubleValue) forOperation:operationType];
-            }
+        __block NSNumber *startDate;
+
+        pn_safe_property_read(self.resourceAccessQueue, ^{
+            startDate = self.trackedLatencies[identifier];
         });
+        pn_safe_property_write(self.resourceAccessQueue, ^{
+            [self.trackedLatencies removeObjectForKey:identifier];
+        });
+        [self setLatency:(date - startDate.doubleValue) forOperation:operationType];
     }
 
 }
@@ -198,12 +203,12 @@ NS_ASSUME_NONNULL_END
     // Check whether subscribe operation asked for latency measurment or not. 
     // There is no point to track long-poll operation latency.
     if (operationType != PNSubscribeOperation) {
-        
         NSNumber *date = @([[NSDate date] timeIntervalSince1970]);
-        pn_trylock(&_resourceAccessLock, ^{
-            
-            NSString *endpointName = [self endpointNameForOperation:operationType];
+        NSString *endpointName = [self endpointNameForOperation:operationType];
+
+        pn_safe_property_write(self.resourceAccessQueue, ^{
             NSMutableArray *latencies = self.latencies[endpointName];
+
             if (!latencies) {
                 latencies = [NSMutableArray new];
                 self.latencies[endpointName] = latencies;
@@ -265,23 +270,26 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Handlers
 
 - (void)handleCleanUpTimer:(NSTimer *)timer {
-    
-    pn_trylock(&_resourceAccessLock, ^{
-        
+
+    pn_safe_property_write(self.resourceAccessQueue, ^{
         NSTimeInterval date = [[NSDate date] timeIntervalSince1970];
         NSArray<NSString *> *endpoints = self.latencies.allKeys;
+
         for (NSString *key in endpoints) {
-            
             NSMutableArray *outdatedLatencies = [NSMutableArray new];
             NSMutableArray<NSDictionary *> *latencies = self.latencies[key];
+
             for (NSDictionary *latencyInformation in latencies) {
                 NSNumber *latencyStoreDate = latencyInformation[kPNOperationDateKey];
+
                 if (date - latencyStoreDate.doubleValue > kPNOperationLatencyMaximumAge) {
                     [outdatedLatencies addObject:latencyInformation];
                 }
             }
             [latencies removeObjectsInArray:outdatedLatencies];
-            if (latencies.count == 0) { [self.latencies removeObjectForKey:key]; }
+            if (latencies.count == 0) {
+                [self.latencies removeObjectForKey:key];
+            }
         }
     });
 }

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -974,7 +974,6 @@ NS_ASSUME_NONNULL_END
     pn_lock(&_lock, ^{
         
         [_session invalidateAndCancel];
-        _sessionIdentifier = nil;
         _session = nil;
     });
 }
@@ -1322,12 +1321,14 @@ NS_ASSUME_NONNULL_END
         
         NSTimeInterval latency = [transaction.responseEndDate timeIntervalSince1970] - [transaction.requestStartDate timeIntervalSince1970];
         if (latency > 0.f) {
-            pn_lock(&_lock, ^{ 
-                    
+            pn_lock(&_lock, ^{
                 NSString *taskIdentifier = [self.sessionIdentifier stringByAppendingString:@(task.taskIdentifier).stringValue];
-                PNOperationType operationType = self.dataTaskToOperationMap[taskIdentifier].integerValue;
-                [self.dataTaskToOperationMap removeObjectForKey:taskIdentifier];
-                [self.client.telemetryManager setLatency:latency forOperation:operationType];
+
+                if (taskIdentifier) {
+                    PNOperationType operationType = self.dataTaskToOperationMap[taskIdentifier].integerValue;
+                    [self.dataTaskToOperationMap removeObjectForKey:taskIdentifier];
+                    [self.client.telemetryManager setLatency:latency forOperation:operationType];
+                }
             });
         }
     }];


### PR DESCRIPTION
* fixed thread-safety of telemetry data accessed from multiple threads
* fixed crash with client invalidation and late NSURLSession delegate call for metrics gathering
* adjusted precision for gathered latency information (10 digits after ".")