### PR TITLE
Unsubscribe after subscribe long-poll fix

### DIFF
--- a/PubNub/Core/PubNub+APNS.m
+++ b/PubNub/Core/PubNub+APNS.m
@@ -172,13 +172,6 @@ NS_ASSUME_NONNULL_END
 
     __weak __typeof(self) weakSelf = self;
     [self processOperation:operationType withParameters:parameters completionBlock:^(PNStatus *status){
-
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object method.
-        // In most cases if referenced object become 'nil' it mean what there is no more need in
-        // it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
             
             status.retryBlock = ^{
@@ -193,7 +186,6 @@ NS_ASSUME_NONNULL_END
                withCompletionBlock:NULL];
         }
         [weakSelf callBlock:block status:YES withResult:nil andStatus:status];
-        #pragma clang diagnostic pop
     }];
 }
 
@@ -216,13 +208,6 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self processOperation:PNPushNotificationEnabledChannelsOperation withParameters:parameters
            completionBlock:^(PNResult *result, PNStatus *status){
-
-               // Silence static analyzer warnings.
-               // Code is aware about this case and at the end will simply call on 'nil' object
-               // method. In most cases if referenced object become 'nil' it mean what there is no
-               // more need in it and probably whole client instance has been deallocated.
-               #pragma clang diagnostic push
-               #pragma clang diagnostic ignored "-Wreceiver-is-weak"
                if (status.isError) {
                     
                    status.retryBlock = ^{
@@ -232,7 +217,6 @@ NS_ASSUME_NONNULL_END
                    };
                }
                [weakSelf callBlock:block status:NO withResult:result andStatus:status];
-               #pragma clang diagnostic pop
            }];
 }
 

--- a/PubNub/Core/PubNub+ChannelGroup.m
+++ b/PubNub/Core/PubNub+ChannelGroup.m
@@ -98,19 +98,11 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self processOperation:operationType withParameters:parameters
            completionBlock:^(PNResult *result, PNStatus *status) {
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object
-        // method. In most cases if referenced object become 'nil' it mean what there is no
-        // more need in it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
 
             status.retryBlock = ^{ [weakSelf channelsForGroup:group withCompletion:block]; };
         }
         [weakSelf callBlock:block status:NO withResult:result andStatus:status];
-        #pragma clang diagnostic pop
     }];
 }
 
@@ -162,13 +154,6 @@ NS_ASSUME_NONNULL_END
 
     __weak __typeof(self) weakSelf = self;
     [self processOperation:operationType withParameters:parameters completionBlock:^(PNStatus *status){
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object
-        // method. In most cases if referenced object become 'nil' it mean what there is no
-        // more need in it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
 
             status.retryBlock = ^{
@@ -177,7 +162,6 @@ NS_ASSUME_NONNULL_END
             };
         }
         [weakSelf callBlock:block status:YES withResult:nil andStatus:status];
-        #pragma clang diagnostic pop
     }];
 }
 

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -350,15 +350,7 @@ NS_ASSUME_NONNULL_END
             __weak __typeof(self) weakSelf = self;
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)),
                            dispatch_get_main_queue(), ^{
-                               
-                // Silence static analyzer warnings.
-                // Code is aware about this case and at the end will simply call on 'nil' object
-                // method. In most cases if referenced object become 'nil' it mean what there is no
-                // more need in it and probably whole client instance has been deallocated.
-                #pragma clang diagnostic push
-                #pragma clang diagnostic ignored "-Wreceiver-is-weak"
                 [weakSelf.reachability startServicePing];
-                #pragma clang diagnostic pop
             });
         }
     }
@@ -393,7 +385,6 @@ NS_ASSUME_NONNULL_END
             // In most cases if referenced object become 'nil' it mean what there is no more need in
             // it and probably whole client instance has been deallocated.
             #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wreceiver-is-weak"
             #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
             [weakSelf.reachability stopServicePing];
             [weakSelf.subscriberManager restoreSubscriptionCycleIfRequiredWithCompletion:nil];

--- a/PubNub/Core/PubNub+History.m
+++ b/PubNub/Core/PubNub+History.m
@@ -253,13 +253,6 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self processOperation:operation withParameters:parameters 
            completionBlock:^(PNResult *result, PNStatus *status) {
-
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object
-        // method. In most cases if referenced object become 'nil' it mean what there is no
-        // more need in it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
 
             status.retryBlock = ^{
@@ -270,7 +263,6 @@ NS_ASSUME_NONNULL_END
             };
         }
         [weakSelf handleHistoryResult:result withStatus:status completion:block];
-        #pragma clang diagnostic pop
     }];
 }
 
@@ -314,13 +306,6 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self processOperation:PNDeleteMessageOperation withParameters:parameters 
            completionBlock:^(PNStatus *status) {
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object
-        // method. In most cases if referenced object become 'nil' it mean what there is no
-        // more need in it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
 
             status.retryBlock = ^{
@@ -330,7 +315,6 @@ NS_ASSUME_NONNULL_END
             };
         }
         [weakSelf callBlock:block status:YES withResult:nil andStatus:status];
-        #pragma clang diagnostic pop
     }];
 
 }

--- a/PubNub/Core/PubNub+Presence.m
+++ b/PubNub/Core/PubNub+Presence.m
@@ -170,13 +170,6 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self processOperation:operation withParameters:parameters 
            completionBlock:^(PNResult *result, PNStatus *status) {
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object
-        // method. In most cases if referenced object become 'nil' it mean what there is no
-        // more need in it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
 
             status.retryBlock = ^{
@@ -186,7 +179,6 @@ NS_ASSUME_NONNULL_END
             };
         }
         [weakSelf callBlock:block status:NO withResult:result andStatus:status];
-        #pragma clang diagnostic pop
     }];
 }
 
@@ -205,19 +197,11 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self processOperation:PNWhereNowOperation withParameters:parameters
            completionBlock:^(PNResult *result, PNStatus *status) {
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object
-        // method. In most cases if referenced object become 'nil' it mean what there is no
-        // more need in it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
 
             status.retryBlock = ^{ [weakSelf whereNowUUID:uuid withCompletion:block]; };
         }
         [weakSelf callBlock:block status:NO withResult:result andStatus:status];
-        #pragma clang diagnostic pop
     }];
 }
 
@@ -265,15 +249,7 @@ NS_ASSUME_NONNULL_END
             
             [self processOperation:PNHeartbeatOperation withParameters:parameters
                    completionBlock:^(PNStatus *status) {
-                       
-               // Silence static analyzer warnings.
-               // Code is aware about this case and at the end will simply call on 'nil' object
-               // method. In most cases if referenced object become 'nil' it mean what there is no
-               // more need in it and probably whole client instance has been deallocated.
-               #pragma clang diagnostic push
-               #pragma clang diagnostic ignored "-Wreceiver-is-weak"
                [weakSelf callBlock:block status:YES withResult:nil andStatus:status];
-               #pragma clang diagnostic pop
            }];
         }
     });

--- a/PubNub/Core/PubNub+Publish.m
+++ b/PubNub/Core/PubNub+Publish.m
@@ -412,13 +412,6 @@ NS_ASSUME_NONNULL_END
 
         [strongSelf processOperation:PNPublishOperation withParameters:parameters data:publishData
                      completionBlock:^(PNStatus *status) {
-                   
-           // Silence static analyzer warnings.
-           // Code is aware about this case and at the end will simply call on 'nil' object method.
-           // In most cases if referenced object become 'nil' it mean what there is no more need in
-           // it and probably whole client instance has been deallocated.
-           #pragma clang diagnostic push
-           #pragma clang diagnostic ignored "-Wreceiver-is-weak"
            if (status.isError) {
                 
                status.retryBlock = ^{
@@ -429,7 +422,6 @@ NS_ASSUME_NONNULL_END
                };
            }
            [weakSelf callBlock:block status:YES withResult:nil andStatus:status];
-           #pragma clang diagnostic pop
        }];
     });
 }
@@ -519,7 +511,6 @@ NS_ASSUME_NONNULL_END
             // In most cases if referenced object become 'nil' it mean what there is no more need in
             // it and probably whole client instance has been deallocated.
             #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wreceiver-is-weak"
             #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
             // Encrypt message in case if serialization to JSON was successful.
             if (!publishError) {

--- a/PubNub/Core/PubNub+State.m
+++ b/PubNub/Core/PubNub+State.m
@@ -175,13 +175,6 @@ NS_ASSUME_NONNULL_END
         
         [strongSelf processOperation:PNSetStateOperation withParameters:parameters
                      completionBlock:^(PNStatus *status) {
-                   
-           // Silence static analyzer warnings.
-           // Code is aware about this case and at the end will simply call on 'nil' object method.
-           // In most cases if referenced object become 'nil' it mean what there is no more need in
-           // it and probably whole client instance has been deallocated.
-           #pragma clang diagnostic push
-           #pragma clang diagnostic ignored "-Wreceiver-is-weak"
            if (status.isError) {
                 
                status.retryBlock = ^{
@@ -192,7 +185,6 @@ NS_ASSUME_NONNULL_END
            }
            [weakSelf handleSetStateStatus:(PNClientStateUpdateStatus *)status
                                   forUUID:uuid atObject:object withCompletion:block];
-           #pragma clang diagnostic pop
        }];
     });
 }
@@ -234,13 +226,6 @@ NS_ASSUME_NONNULL_END
     [self processOperation:(onChannel ? PNStateForChannelOperation : PNStateForChannelGroupOperation)
             withParameters:parameters 
            completionBlock:^(PNResult *result, PNStatus *status) {
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object method.
-        // In most cases if referenced object become 'nil' it mean what there is no more need in
-        // it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) {
             
             status.retryBlock = ^{
@@ -250,7 +235,6 @@ NS_ASSUME_NONNULL_END
         }
         [weakSelf handleStateResult:(PNChannelClientStateResult *)result withStatus:status
                             forUUID:uuid atChannel:onChannel object:object withCompletion:block];
-        #pragma clang diagnostic pop
     }];
 }
 

--- a/PubNub/Core/PubNub+Subscribe.m
+++ b/PubNub/Core/PubNub+Subscribe.m
@@ -253,7 +253,8 @@ static NSString * const kPNSubscribeAPIPrefix = @"/v2/subscribe/";
     }
     
     if (channels.count || groups.count) {
-        
+
+        [self cancelSubscribeOperations];
         [self.subscriberManager unsubscribeFromChannels:channels groups:groups completion:block];
     }
     else if (block) { pn_dispatch_async(self.callbackQueue, ^{ block(nil); }); }
@@ -263,11 +264,13 @@ static NSString * const kPNSubscribeAPIPrefix = @"/v2/subscribe/";
     
     channels = [PNChannel presenceChannelsFrom:channels];
     [self.subscriberManager removePresenceChannels:channels];
+    [self cancelSubscribeOperations];
     [self.subscriberManager unsubscribeFromChannels:channels groups:nil completion:nil];
 }
 
 - (void)unsubscribeFromAll {
-    
+
+    [self cancelSubscribeOperations];
     [self.subscriberManager unsubscribeFromAll];
 }
 

--- a/PubNub/Core/PubNub+Time.m
+++ b/PubNub/Core/PubNub+Time.m
@@ -40,16 +40,8 @@
     __weak __typeof(self) weakSelf = self;
     [self processOperation:PNTimeOperation withParameters:[PNRequestParameters new]
            completionBlock:^(PNResult *result, PNStatus *status) {
-               
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object method.
-        // In most cases if referenced object become 'nil' it mean what there is no more need in
-        // it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         if (status.isError) { status.retryBlock = ^{ [weakSelf timeWithCompletion:block]; }; }
         [weakSelf callBlock:block status:NO withResult:result andStatus:status];
-        #pragma clang diagnostic pop
     }];
 }
 

--- a/PubNub/Data/Managers/PNClientState.m
+++ b/PubNub/Data/Managers/PNClientState.m
@@ -140,14 +140,7 @@ NS_ASSUME_NONNULL_END
             
             // Clean up state cache from objects on which client not subscribed at this moment.
             NSMutableArray *objects = [NSMutableArray arrayWithArray:[self.stateCache allKeys]];
-            // Silence static analyzer warnings.
-            // Code is aware about this case and at the end will simply call on 'nil' object method.
-            // In most cases if referenced object become 'nil' it mean what there is no more need in
-            // it and probably whole client instance has been deallocated.
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wreceiver-is-weak"
             [objects removeObjectsInArray:[self.client.subscriberManager allObjects]];
-            #pragma clang diagnostic pop
             [self removeStateForObjects:objects];
         });
     }

--- a/PubNub/Data/Managers/PNHeartbeat.m
+++ b/PubNub/Data/Managers/PNHeartbeat.m
@@ -138,7 +138,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     if (self.client.configuration.presenceHeartbeatInterval > 0) {
         
@@ -172,7 +171,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     if ([PNChannel objectsWithOutPresenceFrom:[self.client.subscriberManager allObjects]].count) {
         

--- a/PubNub/Data/Managers/PNStateListener.m
+++ b/PubNub/Data/Managers/PNStateListener.m
@@ -187,7 +187,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     pn_dispatch_async(self.client.callbackQueue, ^{
         
@@ -207,7 +206,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     pn_dispatch_async(self.client.callbackQueue, ^{
         
@@ -240,7 +238,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     pn_dispatch_async(self.client.callbackQueue, ^{
         

--- a/PubNub/Data/Managers/PNSubscriber.m
+++ b/PubNub/Data/Managers/PNSubscriber.m
@@ -784,7 +784,6 @@ NS_ASSUME_NONNULL_END
             // method. In most cases if referenced object become 'nil' it mean what there is no
             // more need in it and probably whole client instance has been deallocated.
             #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wreceiver-is-weak"
             #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
             [self.client.listenersManager notifyWithBlock:^{
                 
@@ -890,7 +889,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     if ([self allObjects].count) {
 
@@ -1019,8 +1017,7 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
-#pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
+    #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     [self.client.clientStateManager removeStateForObjects:channels];
     [self.client.clientStateManager removeStateForObjects:groups];
     NSArray *channelsWithOutPresence = nil;
@@ -1120,15 +1117,7 @@ NS_ASSUME_NONNULL_END
     dispatch_queue_t timerQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     dispatch_source_t timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, timerQueue);
     dispatch_source_set_event_handler(timer, ^{
-        
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object method.
-        // In most cases if referenced object become 'nil' it mean what there is no more need in
-        // it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         [weakSelf continueSubscriptionCycleIfRequiredWithCompletion:nil];
-        #pragma clang diagnostic pop
     });
     dispatch_time_t start = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kPubNubSubscriptionRetryInterval * NSEC_PER_SEC));
     dispatch_source_set_timer(timer, start, (uint64_t)(kPubNubSubscriptionRetryInterval * NSEC_PER_SEC), NSEC_PER_SEC);
@@ -1167,7 +1156,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     if (status.data.timetoken != nil && status.clientRequest.URL != nil) {
         
@@ -1202,7 +1190,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     // Looks like subscription request has been cancelled.
     // Cancelling can happen because of: user changed subscriber sensitive configuration or
@@ -1315,7 +1302,6 @@ NS_ASSUME_NONNULL_END
         // In most cases if referenced object become 'nil' it mean what there is no more need in
         // it and probably whole client instance has been deallocated.
         #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
         if (initialSubscription) {
             
@@ -1393,13 +1379,6 @@ NS_ASSUME_NONNULL_END
     NSUInteger eventsCount = events.count;
     NSUInteger messageCountThreshold = self.client.configuration.requestMessageCountThreshold;
     if (events.count) {
-        
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object method.
-        // In most cases if referenced object become 'nil' it mean what there is no more need in
-        // it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
         [self.client.listenersManager notifyWithBlock:^{
             
             // Check whether after initial subscription client should use user-provided timetoken to catch up on
@@ -1439,7 +1418,6 @@ NS_ASSUME_NONNULL_END
                 }
             }
         }];
-        #pragma clang diagnostic pop
     }
     [status updateData:[status.serviceData dictionaryWithValuesForKeys:@[@"timetoken", @"region"]]];
 }
@@ -1466,7 +1444,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     if (status) { [self.client.listenersManager notifyStatusChange:(id)status]; }
     else if (data) { [self.client.listenersManager notifyMessage:data]; }
@@ -1485,7 +1462,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     // Check whether state modification event arrived or not.
     // In case of state modification event for current client it should be applied on local storage.
@@ -1517,7 +1493,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     NSDictionary *mergedState = [self.client.clientStateManager stateMergedWith:state
                                                                      forObjects:fullObjectsList];

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -703,20 +703,12 @@ NS_ASSUME_NONNULL_END
     __block NSURLSessionDataTask *task = nil;
     __weak __typeof(self) weakSelf = self;
     NSURLSessionDataTaskCompletion handler = ^(NSData *data, NSURLResponse *response, NSError *error) {
-        
-        // Silence static analyzer warnings.
-        // Code is aware about this case and at the end will simply call on 'nil' object method.
-        // In most cases if referenced object become 'nil' it mean what there is no more need in
-        // it and probably whole client instance has been deallocated.
-        #pragma clang diagnostic push
-        #pragma clang diagnostic ignored "-Wreceiver-is-weak"
 #if !PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
         NSString *taskIdentifier = [self.sessionIdentifier stringByAppendingString:@(task.taskIdentifier).stringValue];
         [weakSelf.client.telemetryManager stopLatencyMeasureFor:operationType withIdentifier:taskIdentifier];
 #endif
         [weakSelf handleData:data loadedWithTask:task error:(error?: task.error)
                 usingSuccess:success failure:failure];
-        #pragma clang diagnostic pop
     };
     pn_lock(&_lock, ^{
         
@@ -812,12 +804,6 @@ NS_ASSUME_NONNULL_END
                     data:(NSData *)data completionBlock:(id)block {
     
     [self appendRequiredParametersTo:parameters];
-    // Silence static analyzer warnings.
-    // Code is aware about this case and at the end will simply call on 'nil' object method.
-    // In most cases if referenced object become 'nil' it mean what there is no more need in
-    // it and probably whole client instance has been deallocated.
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     NSURL *requestURL = [PNURLBuilder URLForOperation:operationType withParameters:parameters];
     if (requestURL) {
         
@@ -861,7 +847,6 @@ NS_ASSUME_NONNULL_END
             else { ((PNStatusBlock)block)(badRequestStatus); }
         }
     }
-    #pragma clang diagnostic pop
 }
 
 - (void)parseData:(id)data withParser:(Class <PNParser>)parser 
@@ -875,15 +860,7 @@ NS_ASSUME_NONNULL_END
             block(processedData, (parser == [PNErrorParser class]));
         }
         else {
-            
-            // Silence static analyzer warnings.
-            // Code is aware about this case and at the end will simply call on 'nil' object method.
-            // In most cases if referenced object become 'nil' it mean what there is no more need in
-            // it and probably whole client instance has been deallocated.
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wreceiver-is-weak"
             [weakSelf parseData:data withParser:[PNErrorParser class] completion:[block copy]];
-            #pragma clang diagnostic pop
         }
     };
     
@@ -1184,17 +1161,9 @@ NS_ASSUME_NONNULL_END
     __weak __typeof(self) weakSelf = self;
     [self parseData:responseObject withParser:[self parserForOperation:operation]
          completion:^(NSDictionary *parsedData, BOOL parseError) {
-
-             // Silence static analyzer warnings.
-             // Code is aware about this case and at the end will simply call on 'nil' object method.
-             // In most cases if referenced object become 'nil' it mean what there is no more need in
-             // it and probably whole client instance has been deallocated.
-             #pragma clang diagnostic push
-             #pragma clang diagnostic ignored "-Wreceiver-is-weak"
              [weakSelf handleParsedData:parsedData loadedWithTask:task forOperation:operation
                           parsedAsError:parseError processingError:task.error
                         completionBlock:[block copy]];
-             #pragma clang diagnostic pop
          }];
 }
 
@@ -1285,7 +1254,6 @@ NS_ASSUME_NONNULL_END
     // In most cases if referenced object become 'nil' it mean what there is no more need in
     // it and probably whole client instance has been deallocated.
     #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wreceiver-is-weak"
     #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
     if (result) { [self.client appendClientInformation:result]; }
     if (status) { [self.client appendClientInformation:status]; }


### PR DESCRIPTION
Fixed bug, because of which, if client unsubscribe from all channels or from some (and there is pretty low traffic on rest of channels), presence `leave` request is stuck because of active subscribe long-poll.