### PR TITLE
Added 'suppressLeaveEvents' parameter to PNConfiguration

### DIFF
--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -153,6 +153,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) PNHeartbeatNotificationOptions heartbeatNotificationOptions;
 
 /**
+ * @brief      Stores whether client shouldn't send presence \c leave events during unsubscription process.
+ * @discussion If this option is set to \c YES client will simply remove unsubscribed channels/groups from subscription
+ *             loop w/o notifying remote subscribers about leave.
+ *
+ * @since 4.7.3
+ */
+@property (nonatomic, assign, getter = shouldSuppressLeaveEvents) BOOL suppressLeaveEvents NS_SWIFT_NAME(suppressLeaveEvents);
+
+/**
  @brief   Stores whether client should communicate with \b PubNub services using secured connection or not.
  
  @default By default client use \b YES to secure communication with \b PubNub services.

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -158,6 +158,7 @@ NS_ASSUME_NONNULL_END
         _nonSubscribeRequestTimeout = kPNDefaultNonSubscribeRequestTimeout;
         _TLSEnabled = kPNDefaultIsTLSEnabled;
         _heartbeatNotificationOptions = kPNDefaultHeartbeatNotificationOptions;
+        _suppressLeaveEvents = kPNDefaultShouldSuppressLeaveEvents;
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
         _requestMessageCountThreshold = kPNDefaultRequestMessageCountThreshold;
@@ -185,8 +186,9 @@ NS_ASSUME_NONNULL_END
     configuration.nonSubscribeRequestTimeout = self.nonSubscribeRequestTimeout;
     configuration.presenceHeartbeatValue = self.presenceHeartbeatValue;
     configuration.presenceHeartbeatInterval = self.presenceHeartbeatInterval;
-    configuration.TLSEnabled = self.isTLSEnabled;
     configuration.heartbeatNotificationOptions = self.heartbeatNotificationOptions;
+    configuration.suppressLeaveEvents = self.shouldSuppressLeaveEvents;
+    configuration.TLSEnabled = self.isTLSEnabled;
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
     configuration.applicationExtensionSharedGroupIdentifier = self.applicationExtensionSharedGroupIdentifier;

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -48,6 +48,7 @@ static NSTimeInterval const kPNDefaultNonSubscribeRequestTimeout = 10.0f;
 
 static BOOL const kPNDefaultIsTLSEnabled = YES;
 static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptions = PNHeartbeatNotifyFailure;
+static BOOL const kPNDefaultShouldSuppressLeaveEvents = NO;
 static BOOL const kPNDefaultShouldKeepTimeTokenOnListChange = YES;
 static BOOL const kPNDefaultShouldTryCatchUpOnSubscriptionRestore = YES;
 static BOOL const kPNDefaultRequestMessageCountThreshold = 0;


### PR DESCRIPTION
This option allow to suppress presence leave API call on unsubscription from channels and groups.