### PR TITLE
Multiple subscribe requests fix.

### DIFF
--- a/PubNub/Data/Managers/PNSubscriber.m
+++ b/PubNub/Data/Managers/PNSubscriber.m
@@ -1173,7 +1173,6 @@ NS_ASSUME_NONNULL_END
     
     [self handleLiveFeedEvents:status forInitialSubscription:isInitialSubscription 
              overrideTimeToken:overrideTimeToken];
-    [self continueSubscriptionCycleIfRequiredWithCompletion:nil];
     
     // Because client received new event from service, it can restart reachability timer with
     // new interval.
@@ -1398,6 +1397,7 @@ NS_ASSUME_NONNULL_END
             
             // Remove message duplicates from received events list.
             [self deDuplicateMessages:events];
+            [self continueSubscriptionCycleIfRequiredWithCompletion:nil];
             
             // Check whether number of messages exceed specified threshold or not.
             if (messageCountThreshold > 0 && eventsCount >= messageCountThreshold) {
@@ -1426,6 +1426,8 @@ NS_ASSUME_NONNULL_END
                 }
             }
         }];
+    } else {
+        [self continueSubscriptionCycleIfRequiredWithCompletion:nil];
     }
     [status updateData:[status.serviceData dictionaryWithValuesForKeys:@[@"timetoken", @"region"]]];
 }

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -153,6 +153,15 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) PNHeartbeatNotificationOptions heartbeatNotificationOptions;
 
 /**
+ * @brief      Stores whether client shouldn't send presence \c leave events during unsubscription process.
+ * @discussion If this option is set to \c YES client will simply remove unsubscribed channels/groups from subscription
+ *             loop w/o notifying remote subscribers about leave.
+ *
+ * @since 4.7.3
+ */
+@property (nonatomic, assign, getter = shouldSuppressLeaveEvents) BOOL suppressLeaveEvents NS_SWIFT_NAME(suppressLeaveEvents);
+
+/**
  @brief   Stores whether client should communicate with \b PubNub services using secured connection or not.
  
  @default By default client use \b YES to secure communication with \b PubNub services.

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -158,6 +158,7 @@ NS_ASSUME_NONNULL_END
         _nonSubscribeRequestTimeout = kPNDefaultNonSubscribeRequestTimeout;
         _TLSEnabled = kPNDefaultIsTLSEnabled;
         _heartbeatNotificationOptions = kPNDefaultHeartbeatNotificationOptions;
+        _suppressLeaveEvents = kPNDefaultShouldSuppressLeaveEvents;
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
         _requestMessageCountThreshold = kPNDefaultRequestMessageCountThreshold;
@@ -185,8 +186,9 @@ NS_ASSUME_NONNULL_END
     configuration.nonSubscribeRequestTimeout = self.nonSubscribeRequestTimeout;
     configuration.presenceHeartbeatValue = self.presenceHeartbeatValue;
     configuration.presenceHeartbeatInterval = self.presenceHeartbeatInterval;
-    configuration.TLSEnabled = self.isTLSEnabled;
     configuration.heartbeatNotificationOptions = self.heartbeatNotificationOptions;
+    configuration.suppressLeaveEvents = self.shouldSuppressLeaveEvents;
+    configuration.TLSEnabled = self.isTLSEnabled;
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;
     configuration.catchUpOnSubscriptionRestore = self.shouldTryCatchUpOnSubscriptionRestore;
     configuration.applicationExtensionSharedGroupIdentifier = self.applicationExtensionSharedGroupIdentifier;

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -48,6 +48,7 @@ static NSTimeInterval const kPNDefaultNonSubscribeRequestTimeout = 10.0f;
 
 static BOOL const kPNDefaultIsTLSEnabled = YES;
 static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptions = PNHeartbeatNotifyFailure;
+static BOOL const kPNDefaultShouldSuppressLeaveEvents = NO;
 static BOOL const kPNDefaultShouldKeepTimeTokenOnListChange = YES;
 static BOOL const kPNDefaultShouldTryCatchUpOnSubscriptionRestore = YES;
 static BOOL const kPNDefaultRequestMessageCountThreshold = 0;


### PR DESCRIPTION
Root of issue was listeners notification code position. Listeners has been notified about new event on real-time channels before new subscription cycle has been started.
If user in response on event started new subscription, check on existing subscribe requests returned empty list (subscription loop didn't have a chance to call it's continuation) and created new request.
With fix, code which continue subscription cycle has been moved in different place to be triggered before event listeners will be notified. This give SDK time to try to start new request and check for running tasks will detect it and cancel if required.