### PR TITLE
Added PubNub's client logger disable macro

### DIFF
--- a/PubNub/Misc/Logger/Core/PNLLogger.m
+++ b/PubNub/Misc/Logger/Core/PNLLogger.m
@@ -562,7 +562,8 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 #pragma mark - Logging
 
 - (void)log:(NSUInteger)level format:(NSString *)format, ... {
-    
+
+#ifndef PUBNUB_DISABLE_LOGGER
     __block BOOL shouldHandleLog = NO;
     pn_trylock(&_accessLock, ^{ shouldHandleLog = (_logLevel & level); });
     if (shouldHandleLog && format.length) {
@@ -572,10 +573,12 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
         [self log:level message:[[NSString alloc] initWithFormat:format arguments:args]];
         va_end(args);
     }
+#endif
 }
 
 - (void)log:(NSUInteger)level message:(NSString *)message {
-    
+
+#ifndef PUBNUB_DISABLE_LOGGER
     if (self.enabled || level == 0) {
         
         NSString *threadID = [self currentThreadID];
@@ -625,6 +628,7 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
             }
         });
     }
+#endif
 }
 
 


### PR DESCRIPTION
To completely disable PubNub's logger (even debug messages on client initialization) it is possible to set `Preprocessing Macros` in _Build Settings_: `PUBNUB_DISABLE_LOGGER` (just add keys itself w/o any values will work).
After macro added, code which is responsible for data output to stdout and file won't be compiled and calls to logger won't do anything.

If project has been added with CocoaPods, it is possible to add this macro automatically, if next code will be added into `Podfile`:    

```ruby
post_install do |installer|
    installer.pods_project.targets.each do |target|
        target.build_configurations.each do |config|
            config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)', 'PUBNUB_DISABLE_LOGGER'] if target.name =~ /^PubNub/
        end
    end
end
```

This _hook_ will add macro for you, when dependency will be installed on `pod install` or `pod update` call.