### PR TITLE
Presence management API fix

### DIFF
--- a/PubNub/Core/PubNub+Presence.m
+++ b/PubNub/Core/PubNub+Presence.m
@@ -5,6 +5,7 @@
  */
 #import "PubNub+PresencePrivate.h"
 #import "PNAPICallBuilder+Private.h"
+#import "PubNub+SubscribePrivate.h"
 #import "PNPrivateStructures.h"
 #import "PNRequestParameters.h"
 #import "PubNub+CorePrivate.h"
@@ -341,8 +342,10 @@ NS_ASSUME_NONNULL_END
             [self heartbeatWithCompletion:block];
             [self.heartbeatManager startHeartbeatIfRequired];
         } else {
+            [self cancelSubscribeOperations];
             [self.subscriberManager unsubscribeFromChannels:presenceChannels
                                                      groups:presenceChannelGroups
+                                          informingListener:NO
                                                  completion:^(PNSubscribeStatus *status) {
 
                 if (block) {

--- a/PubNub/Core/PubNub+SubscribePrivate.h
+++ b/PubNub/Core/PubNub+SubscribePrivate.h
@@ -4,6 +4,7 @@
  @copyright © 2009-2017 PubNub, Inc.
  */
 #import "PubNub+Subscribe.h"
+#import "PNSubscriber.h"
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/PubNub/Data/Managers/PNSubscriber.h
+++ b/PubNub/Data/Managers/PNSubscriber.h
@@ -242,6 +242,24 @@ typedef void(^PNSubscriberCompletionBlock)(PNSubscribeStatus * _Nullable status)
                          groups:(nullable NSArray<NSString *> *)groups
                      completion:(nullable PNSubscriberCompletionBlock)block;
 
+/**
+ * @brief      Perform unsubscription operation.
+ * @discussion If suitable objects has been passed, then client will ask \b PubNub presence service
+ *             to trigger \c 'leave' presence events on passed objects.
+ *
+ * @param channels             List of channels from which client should unsubscribe.
+ * @param groups               List of channel groups from which client should unsubscribe.
+ * @param shouldInformListener Whether listener should be informed at the end of operation or not.
+ * @param block                Reference on unsubscription completion block which is used to notify
+ *                             code.
+ *
+ * @since 4.7.6
+ */
+- (void)unsubscribeFromChannels:(nullable NSArray<NSString *> *)channels
+                         groups:(nullable NSArray<NSString *> *)groups
+              informingListener:(BOOL)shouldInformListener
+                     completion:(nullable PNSubscriberCompletionBlock)block;
+
 #pragma mark -
 
 


### PR DESCRIPTION
Commit include:  

* fixed issue, because of which presence leave didn't sent in attempt to `disconnect` user. This issue also caused `timeout` event for channel, from which user had to be `disconnected`.  
* fixed unsubscribe flow, where `connected` event has been sent for rest of channels on which client still subscribed. This event should be sent only if there is changes in list of channels on which client has been subscribed.