### PR TITLE
Fixed timeout for presence only channels and/or groups.

### DIFF
--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceHeartbeatAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceHeartbeatAPICallBuilder.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @discussion On block call return block which consume (\b required) presence change completion block
  *             which pass only one argument - operation processing status object.
  */
-@property (nonatomic, readonly, strong) void(^performWithCompletion)(PNStatusBlock block);
+@property (nonatomic, readonly, strong) void(^performWithCompletion)(PNStatusBlock __nullable block);
 
 #pragma mark -
 

--- a/PubNub/Data/Managers/PNHeartbeat.h
+++ b/PubNub/Data/Managers/PNHeartbeat.h
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  @since 4.0
  */
-- (void)stopHeartbeatIfPossible;
+- (BOOL)stopHeartbeatIfPossible;
 
 #pragma mark -
 

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_END
     _presenceHeartbeatValue = presenceHeartbeatValue;
     if (self.presenceHeartbeatInterval == 0) { 
         
-        _presenceHeartbeatInterval = (NSInteger)(_presenceHeartbeatValue * 0.5f);
+        _presenceHeartbeatInterval = (NSInteger)(_presenceHeartbeatValue * 0.5f) - 1;
     }
 }
 


### PR DESCRIPTION
Fixed issue, because of which `subscription` loop were able to reschedule timer, which sent heartbeat request each time, when new event received. This rescheduling affects channels and/or groups which has been added to `heartbeat` loop only.

Fix allow to keep active timer if there is any channels and/or groups which is registered only with `presence` loop. This doesn't affect `subscription` loop, because subscribe request itself act as `presence` trigger.