### PR TITLE
Manual presence list management

### DIFF
--- a/PubNub/Core/PubNub+Subscribe.h
+++ b/PubNub/Core/PubNub+Subscribe.h
@@ -121,6 +121,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  @brief      Stores reference on subscribe API access \c builder construction block.
  @discussion On block call return builder which allow to configure parameters for subscribe API access.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channels and/or channel groups to presence heartbeat list.
  
  @since 4.5.4
  */
@@ -143,6 +145,8 @@ NS_ASSUME_NONNULL_BEGIN
  @brief      Try subscribe on specified set of channels.
  @discussion Using subscribe API client is able to subscribe of remote data objects live feed and listen for 
              new events from them.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channels to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -165,6 +169,8 @@ self.client = [PubNub clientWithConfiguration:configuration];
              new events from them.
  @discussion Extension to \c -subscribeToChannels:withPresence: and allow to specify arbitrarily which should 
              be used during subscription.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channels to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -190,6 +196,8 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
              new events from them.
  @discussion Extension to \c -subscribeToChannels:withPresence: and allow to specify client state information 
              which should be passed to \b PubNub service along with subscription.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channels to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -216,6 +224,8 @@ self.client = [PubNub clientWithConfiguration:configuration];
              new events from them.
  @discussion Extension to \c -subscribeToChannels:withPresence:usingTimeToken: and allow to specify client 
              state information which should be passed to \b PubNub service along with subscription.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channels to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -243,6 +253,8 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
  @brief      Try subscribe on specified set of channel groups.
  @discussion Using subscribe API client is able to subscribe of remote data objects live feed and listen for 
              new events from them.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channel groups to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -265,6 +277,8 @@ self.client = [PubNub clientWithConfiguration:configuration];
              new events from them.
  @discussion Extension to \c -subscribeToChannelGroups:withPresence: and allow to specify arbitrarily which 
              should be used during subscription.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channel groups to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -290,6 +304,8 @@ NSNumber *timeToken = @([[NSDate dateWithTimeIntervalSinceNow:-2.0] timeInterval
              new events from them.
  @discussion Extension to \c -subscribeToChannelGroups:withPresence: and allow to specify client state 
              information which should be passed to \b PubNub service along with subscription.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channel groups to presence heartbeat list.
  @discussion \b Example:
  
  @code
@@ -316,6 +332,8 @@ self.client = [PubNub clientWithConfiguration:configuration];
              new events from them.
  @discussion Extension to \c -subscribeToChannelGroups:withPresence:usingTimeToken: and allow to specify 
              client state information which should be passed to \b PubNub service along with subscription.
+ @discussion \b Important: since \b 4.8.0 if \c managePresenceListManually client configuration property is set to \c YES this API won't
+             add channel groups to presence heartbeat list.
  @discussion \b Example:
  
  @code

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceAPICallBuilder.h
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
  *             for access to client's connected presence state management.
  * @discussion On block call return block which consume client's \c connected state flag and
  *             provide interface to access client's connected presence state management.
+ * @discussion \b Important: since \b 4.8.0 this API work only if \c managePresenceListManually client configuration property is set to
+ *             \c YES.
  *
  * @since 4.7.5
  */

--- a/PubNub/Data/Managers/PNHeartbeat.h
+++ b/PubNub/Data/Managers/PNHeartbeat.h
@@ -68,28 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSString *> *)channelGroups;
 
 /**
- * @brief      Remove from presence channels list passed channels.
- * @discussion This method used during clean up operation to make sure what presence channels list
- *             doesn't contain any channels on which client currently subscribed.
- *
- * @param channels Reference on list of channels which should be removed.
- *
- * @since 4.7.5
- */
-- (void)removeChannels:(NSArray<NSString *> *)channels;
-
-/**
- * @brief      Remove from presence channel groups list passed channel groups.
- * @discussion This method used during clean up operation to make sure what presence channel groups
- *             list doesn't contain any channel groups on which client currently subscribed.
- *
- * @param channelGroups Reference on list of channel groups which should be removed.
- *
- * @since 4.7.5
- */
-- (void)removeChannelGroups:(NSArray<NSString *> *)channelGroups;
-
-/**
  * @brief      Update client's presence connected state for \c channels.
  * @discussion Mark client as \c connected or \c leaved for remote subscribers which is listening for
  *             events on \c channels.

--- a/PubNub/Data/Managers/PNHeartbeat.m
+++ b/PubNub/Data/Managers/PNHeartbeat.m
@@ -181,24 +181,6 @@ NS_ASSUME_NONNULL_END
     return channelGroups;
 }
 
-- (void)removeChannels:(NSArray<NSString *> *)channels {
-
-    if ([channels isKindOfClass:[NSArray class]]) {
-        pn_safe_property_write(self.resourceAccessQueue, ^{
-            [self->_presenceChannels removeObjectsInArray:channels];
-        });
-    }
-}
-
-- (void)removeChannelGroups:(NSArray<NSString *> *)channelGroups {
-
-    if ([channelGroups isKindOfClass:[NSArray class]]) {
-        pn_safe_property_write(self.resourceAccessQueue, ^{
-            [self->_presenceChannelGroups removeObjectsInArray:channelGroups];
-        });
-    }
-}
-
 - (void)setConnected:(BOOL)connected forChannels:(NSArray<NSString *> *)channels {
 
     if ([channels isKindOfClass:[NSArray class]]) {

--- a/PubNub/Data/Managers/PNPublishSequence.m
+++ b/PubNub/Data/Managers/PNPublishSequence.m
@@ -204,7 +204,7 @@ NS_ASSUME_NONNULL_END
 - (NSUInteger)sequenceNumber {
     
     __block NSUInteger sequenceNumber = 0;
-    pn_lock(&_lock, ^{ sequenceNumber = _sequenceNumber; });
+    pn_lock(&_lock, ^{ sequenceNumber = self->_sequenceNumber; });
     
     return sequenceNumber;
 }
@@ -213,8 +213,8 @@ NS_ASSUME_NONNULL_END
     
     __block NSUInteger sequenceNumber = 0;
     pn_lock(&_lock, ^{
-        sequenceNumber = (_sequenceNumber == NSUIntegerMax ? 1 : _sequenceNumber + 1);
-        if (shouldUpdateCurrent) { _sequenceNumber = sequenceNumber; }
+        sequenceNumber = (self->_sequenceNumber == NSUIntegerMax ? 1 : self->_sequenceNumber + 1);
+        if (shouldUpdateCurrent) { self->_sequenceNumber = sequenceNumber; }
     });
     
     return sequenceNumber;
@@ -274,7 +274,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)reset {
     
-    pn_lock(&_lock, ^{ _sequenceNumber = 0; });
+    pn_lock(&_lock, ^{ self->_sequenceNumber = 0; });
     [self saveToPersistentStorage];
 }
 
@@ -291,7 +291,7 @@ NS_ASSUME_NONNULL_END
             NSMutableDictionary *sequenceData = [(mutableSequences[self.publishKey]?: @{}) mutableCopy];
             NSNumber *sequenceNumber = (NSNumber *)sequenceData[PNPublishSequenceData.sequence];
             sequenceData[PNPublishSequenceData.lastSaveDate] = @([NSDate date].timeIntervalSince1970);
-            _sequenceNumber = sequenceNumber.unsignedIntegerValue;
+            self->_sequenceNumber = sequenceNumber.unsignedIntegerValue;
             [PNKeychain storeValue:mutableSequences forKey:kPNPublishSequenceDataKey
                withCompletionBlock:^(BOOL stored) { completion(); }];
         }];

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -162,6 +162,16 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, getter = shouldSuppressLeaveEvents) BOOL suppressLeaveEvents NS_SWIFT_NAME(suppressLeaveEvents);
 
 /**
+ * @brief      Stores whether heartbeat list managed manually or not.
+ * @discussion By default client automatically manage list of channels and/or groups used in heartbeat requests when
+ *             subscribe or unsubscribe.
+ *             With manual management special methods can be used to add channels and/or groups to heartbeat list.
+ *
+ * @since 4.8.0
+ */
+@property (nonatomic, assign, getter = shouldManagePresenceListManually) BOOL managePresenceListManually NS_SWIFT_NAME(managePresenceListManually);
+
+/**
  @brief   Stores whether client should communicate with \b PubNub services using secured connection or not.
  
  @default By default client use \b YES to secure communication with \b PubNub services.

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -159,6 +159,7 @@ NS_ASSUME_NONNULL_END
         _TLSEnabled = kPNDefaultIsTLSEnabled;
         _heartbeatNotificationOptions = kPNDefaultHeartbeatNotificationOptions;
         _suppressLeaveEvents = kPNDefaultShouldSuppressLeaveEvents;
+        _managePresenceListManually = kPNDefaultShouldManagePresenceListManually;
         _keepTimeTokenOnListChange = kPNDefaultShouldKeepTimeTokenOnListChange;
         _catchUpOnSubscriptionRestore = kPNDefaultShouldTryCatchUpOnSubscriptionRestore;
         _requestMessageCountThreshold = kPNDefaultRequestMessageCountThreshold;
@@ -187,6 +188,7 @@ NS_ASSUME_NONNULL_END
     configuration.presenceHeartbeatValue = self.presenceHeartbeatValue;
     configuration.presenceHeartbeatInterval = self.presenceHeartbeatInterval;
     configuration.heartbeatNotificationOptions = self.heartbeatNotificationOptions;
+    configuration.managePresenceListManually = self.shouldManagePresenceListManually;
     configuration.suppressLeaveEvents = self.shouldSuppressLeaveEvents;
     configuration.TLSEnabled = self.isTLSEnabled;
     configuration.keepTimeTokenOnListChange = self.shouldKeepTimeTokenOnListChange;

--- a/PubNub/Misc/Logger/Core/PNLLogger.m
+++ b/PubNub/Misc/Logger/Core/PNLLogger.m
@@ -373,27 +373,27 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 - (BOOL)writeToConsole {
     
     __block BOOL writeToConsole = NO;
-    pn_lock(&_accessLock, ^{ writeToConsole = _writeToConsole; });
+    pn_lock(&_accessLock, ^{ writeToConsole = self->_writeToConsole; });
     
     return writeToConsole;
 }
 
 - (void)setWriteToConsole:(BOOL)writeToConsole {
     
-    pn_lock(&_accessLock, ^{ _writeToConsole = writeToConsole; });
+    pn_lock(&_accessLock, ^{ self->_writeToConsole = writeToConsole; });
 }
 
 - (BOOL)writeToFile {
     
     __block BOOL writeToFile = NO;
-    pn_lock(&_accessLock, ^{ writeToFile = _writeToFile; });
+    pn_lock(&_accessLock, ^{ writeToFile = self->_writeToFile; });
     
     return writeToFile;
 }
 
 - (void)setWriteToFile:(BOOL)writeToFile {
     
-    pn_lock(&_accessLock, ^{ _writeToFile = writeToFile; });
+    pn_lock(&_accessLock, ^{ self->_writeToFile = writeToFile; });
 }
 
 - (void)setMaximumLogFileSize:(NSUInteger)maximumLogFileSize {
@@ -401,8 +401,8 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     __block BOOL changed = NO;
     pn_lock(&_accessLock, ^{
         
-        changed = (_maximumLogFileSize != maximumLogFileSize);
-        _maximumLogFileSize = maximumLogFileSize;
+        changed = (self->_maximumLogFileSize != maximumLogFileSize);
+        self->_maximumLogFileSize = maximumLogFileSize;
     });
     if (changed) { dispatch_async(self.queue, ^{ @autoreleasepool { [self rollRecentLogFileIfRequired]; }}); }
 }
@@ -411,8 +411,8 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     
     __block BOOL changed = NO;
     pn_lock(&_accessLock, ^{
-        changed = (_maximumNumberOfLogFiles != maximumNumberOfLogFiles);
-        _maximumNumberOfLogFiles = maximumNumberOfLogFiles;
+        changed = (self->_maximumNumberOfLogFiles != maximumNumberOfLogFiles);
+        self->_maximumNumberOfLogFiles = maximumNumberOfLogFiles;
     });
     if (changed) { dispatch_async(self.queue, ^{ @autoreleasepool { [self deleteOldLogsIfRequired]; }}); }
 }
@@ -421,20 +421,20 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     
     pn_trylock(&_accessLock, ^{
         
-        if (_currentLogInformation == nil) {
+        if (self->_currentLogInformation == nil) {
             
             [self rollRecentLogFileIfRequired];
             PNLLogFileInformation *recentLogInfomration = self.logFilesInformation.firstObject;
             if (recentLogInfomration && !recentLogInfomration.isArchived) {
                 
-                _currentLogInformation = recentLogInfomration;
+                self->_currentLogInformation = recentLogInfomration;
             }
             else {
                 
                 NSString *logFilePath = [self createLogFile];
                 PNLLogFileInformation *information = [PNLLogFileInformation informationForFileAtPath:logFilePath];
-                _currentLogInformation = information;
-                [self.logFilesInformation insertObject:_currentLogInformation atIndex:0];
+                self->_currentLogInformation = information;
+                [self.logFilesInformation insertObject:self->_currentLogInformation atIndex:0];
             }
         }
     });
@@ -446,22 +446,22 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     
     pn_trylock(&_accessLock, ^{
         
-        if (_currentLogHandler == nil) {
+        if (self->_currentLogHandler == nil) {
             
-            _currentLogHandler = [NSFileHandle fileHandleForWritingAtPath:self.currentLogInformation.path];
-            [_currentLogHandler seekToEndOfFile];
-            if (_currentLogHandler) {
+            self->_currentLogHandler = [NSFileHandle fileHandleForWritingAtPath:self.currentLogInformation.path];
+            [self->_currentLogHandler seekToEndOfFile];
+            if (self->_currentLogHandler) {
                 
-                _logFileWatchdog = dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE, 
-                                                          [_currentLogHandler fileDescriptor], 
+                self->_logFileWatchdog = dispatch_source_create(DISPATCH_SOURCE_TYPE_VNODE,
+                                                                [self->_currentLogHandler fileDescriptor],
                                                           DISPATCH_VNODE_DELETE | DISPATCH_VNODE_RENAME, 
-                                                          _queue);
-                dispatch_source_set_event_handler(_logFileWatchdog, ^{
+                                                                self->_queue);
+                dispatch_source_set_event_handler(self->_logFileWatchdog, ^{
                     
                     @autoreleasepool { [self rollCurrentLogFileOnMove:YES]; }
                 });
                 
-                dispatch_resume(_logFileWatchdog);
+                dispatch_resume(self->_logFileWatchdog);
             }
         }
     });
@@ -533,16 +533,16 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 
 - (void)setEnabled:(BOOL)enabled {
     
-    pn_lock(&_accessLock, ^{ _enabled = enabled; });
+    pn_lock(&_accessLock, ^{ self->_enabled = enabled; });
 }
 
 - (void)enableLogLevel:(NSUInteger)level {
     
     pn_lock(&_accessLock, ^{
         
-        BOOL notifyChange = (_logLevel != (_logLevel | level) && _logLevelChangeHandler);
-        _logLevel |= level;
-        if (notifyChange) { dispatch_async(dispatch_get_main_queue(), _logLevelChangeHandler); }
+        BOOL notifyChange = (self->_logLevel != (self->_logLevel | level) && self->_logLevelChangeHandler);
+        self->_logLevel |= level;
+        if (notifyChange) { dispatch_async(dispatch_get_main_queue(), self->_logLevelChangeHandler); }
     });
 }
 
@@ -550,9 +550,9 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     
     pn_lock(&_accessLock, ^{
         
-        BOOL notifyChange = (_logLevel != (_logLevel & ~level) && _logLevelChangeHandler);
-        _logLevel &= ~level;
-        if (notifyChange) { dispatch_async(dispatch_get_main_queue(), _logLevelChangeHandler); }
+        BOOL notifyChange = (self->_logLevel != (self->_logLevel & ~level) && self->_logLevelChangeHandler);
+        self->_logLevel &= ~level;
+        if (notifyChange) { dispatch_async(dispatch_get_main_queue(), self->_logLevelChangeHandler); }
     });
 }
 
@@ -560,10 +560,10 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     
     pn_lock(&_accessLock, ^{
         
-        BOOL notifyChange = (_logLevel != level && _logLevelChangeHandler);
-        _logLevel = level;
-        if (level == 0) { _enabled = NO; }
-        if (notifyChange) { dispatch_async(dispatch_get_main_queue(), _logLevelChangeHandler); }
+        BOOL notifyChange = (self->_logLevel != level && self->_logLevelChangeHandler);
+        self->_logLevel = level;
+        if (level == 0) { self->_enabled = NO; }
+        if (notifyChange) { dispatch_async(dispatch_get_main_queue(), self->_logLevelChangeHandler); }
     });
 }
 
@@ -574,7 +574,7 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
 
 #ifndef PUBNUB_DISABLE_LOGGER
     __block BOOL shouldHandleLog = NO;
-    pn_lock(&_accessLock, ^{ shouldHandleLog = (_logLevel & level); });
+    pn_lock(&_accessLock, ^{ shouldHandleLog = (self->_logLevel & level); });
     if (shouldHandleLog && format.length) {
         
         va_list args;
@@ -610,9 +610,9 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
                 struct iovec vector[10];
                 vector[0] = (struct iovec){.iov_base = timestamp, .iov_len = timestampLength};
                 vector[1] = (struct iovec){.iov_base = " ", .iov_len = 1};
-                vector[2] = (struct iovec){.iov_base = _applicationCName, .iov_len = _applicationNameLength};
+                vector[2] = (struct iovec){.iov_base = self->_applicationCName, .iov_len = self->_applicationNameLength};
                 vector[3] = (struct iovec){.iov_base = "[", .iov_len = 1};
-                vector[4] = (struct iovec){.iov_base = _applicationProcessCID, .iov_len = _applicationProcessIDLength};
+                vector[4] = (struct iovec){.iov_base = self->_applicationProcessCID, .iov_len = self->_applicationProcessIDLength};
                 vector[5] = (struct iovec){.iov_base = ":", .iov_len = 1};
                 vector[6] = (struct iovec){.iov_base = tid, .iov_len = threadIDLength};
                 vector[7] = (struct iovec){.iov_base = "] ", .iov_len = 2};
@@ -626,7 +626,7 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
             if (self.writeToFile) {
                 
                 NSString *formattedMessage = [NSString stringWithFormat:@"%s %@[%@:%@] %@%@", timestamp, 
-                                              _applicationName, _applicationProcessID, threadID, message,
+                                              self->_applicationName, self->_applicationProcessID, threadID, message,
                                               ([message hasSuffix:@"\n"] ? @"" : @"\n")];
                 NSData *messageData = [formattedMessage dataUsingEncoding:NSUTF8StringEncoding];
                 @try {
@@ -712,10 +712,10 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
         PNLLogFileInformation *recentLogInfomration = self.logFilesInformation.firstObject;
         if (recentLogInfomration && !recentLogInfomration.archived) {
             
-            BOOL isCurrentLog = (_currentLogInformation && [_currentLogInformation isEqual:recentLogInfomration]);
+            BOOL isCurrentLog = (self->_currentLogInformation && [self->_currentLogInformation isEqual:recentLogInfomration]);
             unsigned long long size = recentLogInfomration.size;
-            if (isCurrentLog && _currentLogHandler) { size = _currentLogHandler.offsetInFile; }
-            if (_maximumLogFileSize > 0 && size >= _maximumLogFileSize) {
+            if (isCurrentLog && self->_currentLogHandler) { size = self->_currentLogHandler.offsetInFile; }
+            if (self->_maximumLogFileSize > 0 && size >= self->_maximumLogFileSize) {
                 
                 if (isCurrentLog) { [self rollCurrentLogFileOnMove:NO]; }
                 else { recentLogInfomration.archived = YES; }
@@ -728,25 +728,25 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     
     pn_trylock(&_accessLock, ^{
         
-        if (_currentLogHandler) {
+        if (self->_currentLogHandler) {
             
-            unsigned long long logFileSize = _currentLogHandler.offsetInFile;
-            [_currentLogHandler synchronizeFile];
-            [_currentLogHandler closeFile];
-            _currentLogHandler = nil;
+            unsigned long long logFileSize = self->_currentLogHandler.offsetInFile;
+            [self->_currentLogHandler synchronizeFile];
+            [self->_currentLogHandler closeFile];
+            self->_currentLogHandler = nil;
             
             if (!rollOnFileMove) {
                 
-                _currentLogInformation.size = logFileSize;
-                _currentLogInformation.archived = YES;
+                self->_currentLogInformation.size = logFileSize;
+                self->_currentLogInformation.archived = YES;
             }
-            else { [self.logFilesInformation removeObject:_currentLogInformation]; }
-            _currentLogInformation = nil;
+            else { [self.logFilesInformation removeObject:self->_currentLogInformation]; }
+            self->_currentLogInformation = nil;
             
-            if (_logFileWatchdog) {
+            if (self->_logFileWatchdog) {
                 
-                dispatch_source_cancel(_logFileWatchdog);
-                _logFileWatchdog = NULL;
+                dispatch_source_cancel(self->_logFileWatchdog);
+                self->_logFileWatchdog = NULL;
             }
         }
     });
@@ -757,10 +757,10 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
     pn_trylock(&_accessLock, ^{
         
         NSMutableArray<PNLLogFileInformation *> *informationsForRemoval = [NSMutableArray new];
-        if (_maximumNumberOfLogFiles > 0 && self.logFilesInformation.count >= _maximumNumberOfLogFiles) {
+        if (self->_maximumNumberOfLogFiles > 0 && self.logFilesInformation.count >= self->_maximumNumberOfLogFiles) {
             
             NSUInteger filesCount = self.logFilesInformation.count;
-            for (NSUInteger infoIndex = _maximumNumberOfLogFiles - 1; infoIndex < filesCount; infoIndex++) {
+            for (NSUInteger infoIndex = self->_maximumNumberOfLogFiles - 1; infoIndex < filesCount; infoIndex++) {
                 
                 PNLLogFileInformation *informationForRemoval = self.logFilesInformation[infoIndex];
                 [[NSFileManager defaultManager] removeItemAtPath:informationForRemoval.path error:nil];
@@ -773,21 +773,21 @@ static NSString * const kPNLDefaultLogFileExtension = @"txt";
         if (self.logFilesInformation.count) {
             
             NSNumber *logsFileSize = [self.logFilesInformation valueForKeyPath:@"@sum.size"];
-            if ([logsFileSize compare:@(_logFilesDiskQuota)] == NSOrderedDescending) {
+            if ([logsFileSize compare:@(self->_logFilesDiskQuota)] == NSOrderedDescending) {
                 
                 NSUInteger filesCount = self.logFilesInformation.count;
                 unsigned long long currentLogsFileSize = logsFileSize.unsignedLongLongValue;
                 for (NSInteger infoIndex = filesCount - 1; infoIndex >= 0; infoIndex--) {
                     
                     PNLLogFileInformation *informationForRemoval = self.logFilesInformation[infoIndex];
-                    if (!_currentLogInformation || ![informationForRemoval isEqual:_currentLogInformation]) {
+                    if (!self->_currentLogInformation || ![informationForRemoval isEqual:self->_currentLogInformation]) {
                         
                         currentLogsFileSize -= informationForRemoval.size;
                         [[NSFileManager defaultManager] removeItemAtPath:informationForRemoval.path error:nil];
                         [informationsForRemoval addObject:informationForRemoval];
                     }
                     
-                    if (currentLogsFileSize < _logFilesDiskQuota) { break; }
+                    if (currentLogsFileSize < self->_logFilesDiskQuota) { break; }
                 }
                 [self.logFilesInformation removeObjectsInArray:informationsForRemoval];
             }

--- a/PubNub/Misc/Logger/Data/PNLLogFileInformation.m
+++ b/PubNub/Misc/Logger/Data/PNLLogFileInformation.m
@@ -108,9 +108,9 @@ static NSString * const kPNLArchivedFileAttributeName = @"com.pubnub.logger.arch
 - (NSDictionary *)attributes {
 
     pn_lock(&_accessLock, ^{
-        if (!_attributes) {
+        if (!self->_attributes) {
 
-            _attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:self.path error:nil];
+            self->_attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:self.path error:nil];
         }
     });
     

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -45,6 +45,7 @@ static NSString * const kPNDefaultOrigin = @"ps.pndsn.com";
 
 static NSTimeInterval const kPNDefaultSubscribeMaximumIdleTime = 310.0f;
 static NSTimeInterval const kPNDefaultNonSubscribeRequestTimeout = 10.0f;
+static BOOL const kPNDefaultShouldManagePresenceListManually = NO;
 
 static BOOL const kPNDefaultIsTLSEnabled = YES;
 static PNHeartbeatNotificationOptions const kPNDefaultHeartbeatNotificationOptions = PNHeartbeatNotifyFailure;

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -735,7 +735,7 @@ NS_ASSUME_NONNULL_END
 
         BOOL isApplicationExtension = NO;
         if (@available(macOS 10.10, iOS 8.0, *)) {
-            isApplicationExtension = _configuration.applicationExtensionSharedGroupIdentifier != nil;
+            isApplicationExtension = self->_configuration.applicationExtensionSharedGroupIdentifier != nil;
         }
 
         if (isApplicationExtension) {
@@ -978,8 +978,8 @@ NS_ASSUME_NONNULL_END
     
     pn_lock(&_lock, ^{
         
-        [_session invalidateAndCancel];
-        _session = nil;
+        [self->_session invalidateAndCancel];
+        self->_session = nil;
     });
 }
 
@@ -1328,7 +1328,7 @@ NS_ASSUME_NONNULL_END
         
         NSTimeInterval latency = [transaction.responseEndDate timeIntervalSince1970] - [transaction.requestStartDate timeIntervalSince1970];
         if (latency > 0.f) {
-            pn_lock(&_lock, ^{
+            pn_lock(&self->_lock, ^{
                 NSString *taskIdentifier = [self.sessionIdentifier stringByAppendingString:@(task.taskIdentifier).stringValue];
 
                 if (taskIdentifier) {


### PR DESCRIPTION
Added new property to client configuration object (`PNConfiguration`) called `managePresenceListManually` - this property allow to instruct **PubNub** client on whether list of channels and groups used in heartbeat should be managed manually (with previously added API) or automatically during subscribe/unsubscribe API calls.