### PR TITLE
Added ability to use multiple channels and groups with presence state

### DIFF
--- a/Framework/PubNub Framework.xcodeproj/project.pbxproj
+++ b/Framework/PubNub Framework.xcodeproj/project.pbxproj
@@ -1573,6 +1573,18 @@
 		79E2D0F71C56434700BAA244 /* PNKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 79E2D0ED1C56434700BAA244 /* PNKeychain.m */; };
 		79E2D0F81C56434700BAA244 /* PNKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 79E2D0ED1C56434700BAA244 /* PNKeychain.m */; };
 		79E2D0F91C56434700BAA244 /* PNKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 79E2D0ED1C56434700BAA244 /* PNKeychain.m */; };
+		79F857FA219640A200BFD0B1 /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
+		79F857FB219640A200BFD0B1 /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
+		79F857FC219640A300BFD0B1 /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
+		79F857FD219640AA00BFD0B1 /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
+		79F857FE219640AB00BFD0B1 /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
+		79F857FF219640C200BFD0B1 /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
+		79F85800219640C500BFD0B1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F85801219640C900BFD0B1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F85802219640CA00BFD0B1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F85803219640CA00BFD0B1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F85804219640CA00BFD0B1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		79F85805219640CB00BFD0B1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79F90F191FDEC1BA007132A3 /* PNPresenceHeartbeatAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 79F90F171FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.m */; };
 		79F90F1A1FDEC1BA007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F90F181FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		79F90F1B1FDEC1C6007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 79F90F181FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1587,6 +1599,8 @@
 		79F90F241FDEC1DE007132A3 /* PNPresenceHeartbeatAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 79F90F171FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.m */; };
 		79F90F251FDEC1DE007132A3 /* PNPresenceHeartbeatAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 79F90F171FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.m */; };
 		79F90F261FDEC1DE007132A3 /* PNPresenceHeartbeatAPICallBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 79F90F171FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.m */; };
+		DD71B9872595DE1337983CE1 /* PNClientStateGetResult.h in Headers */ = {isa = PBXBuildFile; fileRef = DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DD71BCFC02D4AB87E006CBBB /* PNClientStateGetResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DD71B20066E72A597492173C /* PNClientStateGetResult.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -1851,6 +1865,8 @@
 		79E2D0ED1C56434700BAA244 /* PNKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNKeychain.m; sourceTree = "<group>"; };
 		79F90F171FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNPresenceHeartbeatAPICallBuilder.m; sourceTree = "<group>"; };
 		79F90F181FDEC1B9007132A3 /* PNPresenceHeartbeatAPICallBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PNPresenceHeartbeatAPICallBuilder.h; sourceTree = "<group>"; };
+		DD71B20066E72A597492173C /* PNClientStateGetResult.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PNClientStateGetResult.m; sourceTree = "<group>"; };
+		DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PNClientStateGetResult.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2255,6 +2271,8 @@
 				79CBB09A1BD03DE4001FC34D /* PNResult+Private.h */,
 				79CBB09B1BD03DE4001FC34D /* PNResult.h */,
 				79CBB09C1BD03DE4001FC34D /* PNResult.m */,
+				DD71BDF55F5AC37C145971EC /* PNClientStateGetResult.h */,
+				DD71B20066E72A597492173C /* PNClientStateGetResult.m */,
 			);
 			path = "Service Objects";
 			sourceTree = "<group>";
@@ -2528,6 +2546,7 @@
 				7915827B1BD709C60084FC70 /* PNJSON.h in Headers */,
 				791582751BD709C60084FC70 /* PubNub.h in Headers */,
 				791582761BD709C60084FC70 /* PNAES.h in Headers */,
+				DD71B9872595DE1337983CE1 /* PNClientStateGetResult.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2550,6 +2569,7 @@
 				791582FF1BD709D10084FC70 /* PNChannelGroupChannelsResult.h in Headers */,
 				79F90F1C1FDEC1C7007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */,
 				791583311BD709D10084FC70 /* PNNetworkResponseSerializer.h in Headers */,
+				79F85801219640C900BFD0B1 /* PNClientStateGetResult.h in Headers */,
 				791583001BD709D10084FC70 /* PNAPNSEnabledChannelsResult.h in Headers */,
 				791583021BD709D10084FC70 /* PNChannelClientStateResult.h in Headers */,
 				79E20D261C8AEFF2001BC9CC /* PNSubscribeStatus+Private.h in Headers */,
@@ -2716,6 +2736,7 @@
 				798842A91C18F2D4003E8948 /* PNHeartbeatParser.h in Headers */,
 				798842771C18F208003E8948 /* PNSubscribeStatus.h in Headers */,
 				79A0D87B1DC22F230039A264 /* PNAPICallBuilder.h in Headers */,
+				79F85804219640CA00BFD0B1 /* PNClientStateGetResult.h in Headers */,
 				7988424B1C18F173003E8948 /* PNResult+Private.h in Headers */,
 				79A0D89F1DC22F850039A264 /* PNAPNSModificationAPICallBuilder.h in Headers */,
 				798842741C18F1FB003E8948 /* PNStatus+Private.h in Headers */,
@@ -2851,6 +2872,7 @@
 				7988434D1C191579003E8948 /* PNPublishStatus.h in Headers */,
 				798843811C191579003E8948 /* PubNub+Publish.h in Headers */,
 				7988437A1C191579003E8948 /* PNReachability.h in Headers */,
+				79F85805219640CB00BFD0B1 /* PNClientStateGetResult.h in Headers */,
 				798843791C191579003E8948 /* PubNub+History.h in Headers */,
 				7988437D1C191579003E8948 /* PNClientState.h in Headers */,
 				79F90F201FDEC1C9007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */,
@@ -2922,6 +2944,7 @@
 				79A8BC6C1C58F93900015BDE /* PNChannelGroupChannelsResult.h in Headers */,
 				79F90F1B1FDEC1C6007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */,
 				79A8BC9F1C58F93900015BDE /* PNNetworkResponseSerializer.h in Headers */,
+				79F85800219640C500BFD0B1 /* PNClientStateGetResult.h in Headers */,
 				79A8BC6D1C58F93900015BDE /* PNAPNSEnabledChannelsResult.h in Headers */,
 				79A8BC6F1C58F93900015BDE /* PNChannelClientStateResult.h in Headers */,
 				79E20D251C8AEFF1001BC9CC /* PNSubscribeStatus+Private.h in Headers */,
@@ -3100,6 +3123,7 @@
 				79ACC4461C11BC4D0056523A /* PubNub+Presence.h in Headers */,
 				79ACC4631C11BC4D0056523A /* PNReachability.h in Headers */,
 				79ACC44B1C11BC4D0056523A /* PubNub+History.h in Headers */,
+				79F85803219640CA00BFD0B1 /* PNClientStateGetResult.h in Headers */,
 				79ACC4471C11BC4D0056523A /* PubNub+Publish.h in Headers */,
 				79ACC46F1C11BC4D0056523A /* PNLeaveParser.h in Headers */,
 				79F90F1E1FDEC1C7007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */,
@@ -3171,6 +3195,7 @@
 				79CBB1221BD03DE4001FC34D /* PNChannelGroupChannelsResult.h in Headers */,
 				79F90F1D1FDEC1C7007132A3 /* PNPresenceHeartbeatAPICallBuilder.h in Headers */,
 				79CBB1881BD03DE4001FC34D /* PNNetworkResponseSerializer.h in Headers */,
+				79F85802219640CA00BFD0B1 /* PNClientStateGetResult.h in Headers */,
 				79CBB11E1BD03DE4001FC34D /* PNAPNSEnabledChannelsResult.h in Headers */,
 				79CBB1201BD03DE4001FC34D /* PNChannelClientStateResult.h in Headers */,
 				79E20D271C8AEFF2001BC9CC /* PNSubscribeStatus+Private.h in Headers */,
@@ -4172,6 +4197,7 @@
 				7915820E1BD709C60084FC70 /* PNData.m in Sources */,
 				791582141BD709C60084FC70 /* PNGZIP.m in Sources */,
 				791582381BD709C60084FC70 /* PNAES.m in Sources */,
+				DD71BCFC02D4AB87E006CBBB /* PNClientStateGetResult.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4265,6 +4291,7 @@
 				791582D11BD709D10084FC70 /* PNChannel.m in Sources */,
 				7925DB901D3FFCAC00857C0D /* PNLLogger.m in Sources */,
 				791582F11BD709D10084FC70 /* PNResult.m in Sources */,
+				79F857FB219640A200BFD0B1 /* PNClientStateGetResult.m in Sources */,
 				791582EC1BD709D10084FC70 /* PNStatus.m in Sources */,
 				79A0D9201DC2309F0039A264 /* PNStateAuditAPICallBuilder.m in Sources */,
 				793887081BEAD4DE00DCC662 /* PNNumber.m in Sources */,
@@ -4369,6 +4396,7 @@
 				798842A01C18F2C2003E8948 /* PNNetwork.m in Sources */,
 				7925DB931D3FFCAC00857C0D /* PNLLogger.m in Sources */,
 				7988426E1C18F1E3003E8948 /* PNResult.m in Sources */,
+				79F857FE219640AB00BFD0B1 /* PNClientStateGetResult.m in Sources */,
 				798842701C18F1E3003E8948 /* PNStatus.m in Sources */,
 				79A0D9231DC230A00039A264 /* PNStateAuditAPICallBuilder.m in Sources */,
 				798842921C18F292003E8948 /* PNString.m in Sources */,
@@ -4454,6 +4482,7 @@
 				79A0D8D61DC230110039A264 /* PNPresenceAPICallBuilder.m in Sources */,
 				7988431D1C191579003E8948 /* PNTimeResult.m in Sources */,
 				798843051C191579003E8948 /* PubNub+State.m in Sources */,
+				79F857FF219640C200BFD0B1 /* PNClientStateGetResult.m in Sources */,
 				798843031C191579003E8948 /* PNDictionary.m in Sources */,
 				7988433E1C191579003E8948 /* PubNub+Core.m in Sources */,
 				79650C401E775EA200006F66 /* PNLockSupport.m in Sources */,
@@ -4578,6 +4607,7 @@
 				79A8BC3D1C58F93900015BDE /* PNChannel.m in Sources */,
 				7925DB8F1D3FFCAC00857C0D /* PNLLogger.m in Sources */,
 				79A8BC5E1C58F93900015BDE /* PNResult.m in Sources */,
+				79F857FA219640A200BFD0B1 /* PNClientStateGetResult.m in Sources */,
 				79A8BC591C58F93900015BDE /* PNStatus.m in Sources */,
 				79A0D91F1DC2309F0039A264 /* PNStateAuditAPICallBuilder.m in Sources */,
 				79A8BC521C58F93900015BDE /* PNNumber.m in Sources */,
@@ -4663,6 +4693,7 @@
 				79A0D8D41DC230100039A264 /* PNPresenceAPICallBuilder.m in Sources */,
 				79ACC4131C11BC4D0056523A /* PNURLRequest.m in Sources */,
 				79ACC3FE1C11BC4D0056523A /* PubNub+State.m in Sources */,
+				79F857FD219640AA00BFD0B1 /* PNClientStateGetResult.m in Sources */,
 				79ACC3F11C11BC4D0056523A /* PNDictionary.m in Sources */,
 				79ACC4011C11BC4D0056523A /* PNHeartbeat.m in Sources */,
 				79650C3E1E775EA100006F66 /* PNLockSupport.m in Sources */,
@@ -4787,6 +4818,7 @@
 				79CBB14B1BD03DE4001FC34D /* PNChannel.m in Sources */,
 				7925DB911D3FFCAC00857C0D /* PNLLogger.m in Sources */,
 				793887091BEAD4E100DCC662 /* PNNumber.m in Sources */,
+				79F857FC219640A300BFD0B1 /* PNClientStateGetResult.m in Sources */,
 				79CBB1581BD03DE4001FC34D /* PNString.m in Sources */,
 				79A0D9211DC2309F0039A264 /* PNStateAuditAPICallBuilder.m in Sources */,
 				79CBB1411BD03DE4001FC34D /* PNStatus.m in Sources */,

--- a/Framework/PubNub/PubNub.h
+++ b/Framework/PubNub/PubNub.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @version 4.2.0
- @copyright © 2009-2016 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 #import "PNClientStateUpdateStatus.h"
 #import "PNPresenceWhereNowResult.h"
 #import "PNAcknowledgmentStatus.h"
+#import "PNClientStateGetResult.h"
 #import "PNChannelGroupsResult.h"
 #import "PNClientInformation.h"
 #import "PNSubscriberResults.h"

--- a/PubNub/Core/PubNub+APNS.h
+++ b/PubNub/Core/PubNub+APNS.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (APNS)
 

--- a/PubNub/Core/PubNub+APNS.m
+++ b/PubNub/Core/PubNub+APNS.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+APNS.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Core/PubNub+ChannelGroup.h
+++ b/PubNub/Core/PubNub+ChannelGroup.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (ChannelGroup)
 

--- a/PubNub/Core/PubNub+ChannelGroup.m
+++ b/PubNub/Core/PubNub+ChannelGroup.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+ChannelGroup.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Core/PubNub+Core.h
+++ b/PubNub/Core/PubNub+Core.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub : NSObject
 

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+CorePrivate.h"
 #define PN_CORE_PROTOCOLS PNObjectEventListener

--- a/PubNub/Core/PubNub+CorePrivate.h
+++ b/PubNub/Core/PubNub+CorePrivate.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (Private)
 

--- a/PubNub/Core/PubNub+FAB.h
+++ b/PubNub/Core/PubNub+FAB.h
@@ -10,7 +10,7 @@
  
  @author Sergey Mamontov
  @since 4.2.2
- @copyright © 2009-2016 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (FAB)
 

--- a/PubNub/Core/PubNub+FAB.m
+++ b/PubNub/Core/PubNub+FAB.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.2.2
- @copyright © 2009-2016 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+FAB.h"
 #import "PNConfiguration.h"

--- a/PubNub/Core/PubNub+History.h
+++ b/PubNub/Core/PubNub+History.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (History)
 

--- a/PubNub/Core/PubNub+History.m
+++ b/PubNub/Core/PubNub+History.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+History.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Core/PubNub+Presence.h
+++ b/PubNub/Core/PubNub+Presence.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (Presence)
 

--- a/PubNub/Core/PubNub+Presence.m
+++ b/PubNub/Core/PubNub+Presence.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+PresencePrivate.h"
 #import "PNAPICallBuilder+Private.h"
@@ -361,7 +361,7 @@ NS_ASSUME_NONNULL_END
 
     if (states != nil) {
         for (NSString *object in allPresenceObjects) {
-            [self.clientStateManager setState:states[object] forObject:object];
+            [self.clientStateManager setState:states[object] forObjects:@[object]];
         }
     }
 

--- a/PubNub/Core/PubNub+PresencePrivate.h
+++ b/PubNub/Core/PubNub+PresencePrivate.h
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+Presence.h"
 

--- a/PubNub/Core/PubNub+Publish.h
+++ b/PubNub/Core/PubNub+Publish.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (Publish)
 

--- a/PubNub/Core/PubNub+Publish.m
+++ b/PubNub/Core/PubNub+Publish.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+Publish.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Core/PubNub+State.h
+++ b/PubNub/Core/PubNub+State.h
@@ -8,7 +8,7 @@
 #pragma mark Class forward
 
 @class PNChannelGroupClientStateResult, PNChannelClientStateResult, PNClientStateUpdateStatus,
-       PNErrorStatus;
+       PNClientStateGetResult, PNErrorStatus;
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (State)
 

--- a/PubNub/Core/PubNub+Subscribe.h
+++ b/PubNub/Core/PubNub+Subscribe.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (Subscribe)
 

--- a/PubNub/Core/PubNub+Subscribe.m
+++ b/PubNub/Core/PubNub+Subscribe.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+Subscribe.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Core/PubNub+SubscribePrivate.h
+++ b/PubNub/Core/PubNub+SubscribePrivate.h
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+Subscribe.h"
 #import "PNSubscriber.h"

--- a/PubNub/Core/PubNub+Time.h
+++ b/PubNub/Core/PubNub+Time.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PubNub (Time)
 

--- a/PubNub/Core/PubNub+Time.m
+++ b/PubNub/Core/PubNub+Time.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PubNub+Time.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSAPICallBuilder.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAPNSAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAPNSAPICallBuilder.h"
 #import "PNAPNSModificationAPICallBuilder.h"

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAPNSAuditAPICallBuilder : PNAPNSAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAPNSAuditAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAPNSModificationAPICallBuilder : PNAPNSAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAPNSModificationAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/History/PNDeleteMessageAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/History/PNDeleteMessageAPICallBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.7.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNDeleteMessageAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/History/PNDeleteMessageAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/History/PNDeleteMessageAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.7.0
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNDeleteMessageAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNHistoryAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNHistoryAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceAPICallBuilder.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceAPICallBuilder.h"
 #import "PNPresenceHeartbeatAPICallBuilder.h"

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelGroupHereNowAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelGroupHereNowAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceChannelGroupHereNowAPICallBuilder : PNPresenceHereNowAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelGroupHereNowAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelGroupHereNowAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceChannelGroupHereNowAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelHereNowAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelHereNowAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceChannelHereNowAPICallBuilder : PNPresenceHereNowAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelHereNowAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceChannelHereNowAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceChannelHereNowAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceHeartbeatAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceHeartbeatAPICallBuilder.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.7.5
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 
 @interface PNPresenceHeartbeatAPICallBuilder : PNPresenceAPICallBuilder

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceHeartbeatAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceHeartbeatAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.7.5
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceHeartbeatAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceHereNowAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceHereNowAPICallBuilder.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceHereNowAPICallBuilder : PNPresenceAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceHereNowAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceHereNowAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceHereNowAPICallBuilder.h"
 #import "PNPresenceChannelGroupHereNowAPICallBuilder.h"

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceWhereNowAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceWhereNowAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceWhereNowAPICallBuilder : PNPresenceAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Presence/PNPresenceWhereNowAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Presence/PNPresenceWhereNowAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceWhereNowAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPublishAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPublishAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Publish/PNPublishSizeAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Publish/PNPublishSizeAPICallBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPublishSizeAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Publish/PNPublishSizeAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Publish/PNPublishSizeAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPublishSizeAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/State/PNStateAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/State/PNStateAPICallBuilder.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStateAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/State/PNStateAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/State/PNStateAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStateAPICallBuilder.h"
 #import "PNStateModificationAPICallBuilder.h"

--- a/PubNub/Data/Builders/API Call/State/PNStateAuditAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/State/PNStateAuditAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStateAuditAPICallBuilder : PNStateAPICallBuilder
 
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Unique user identifier addition block.
  *
- * @param uuid Unique user identifier for which state should be retrieved.
+ * @param uuid Unique user identifier for which state should be retrieved. Current \b {PubNub} user
+ *     id will be used by default if not set or set to \c nil.
  *
  * @return API call configuration builder.
  *
@@ -33,9 +34,23 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return API call configuration builder.
  *
- * @since 4.5.4
+ * @deprecated 4.8.3
  */
-@property (nonatomic, readonly, strong) PNStateAuditAPICallBuilder * (^channel)(NSString *channel);
+@property (nonatomic, readonly, strong) PNStateAuditAPICallBuilder * (^channel)(NSString *channel)
+    DEPRECATED_MSG_ATTRIBUTE("This method deprecated since 4.8.3. Please use 'channels' "
+                             "method instead.");
+
+/**
+ * @brief Channel names addition block.
+ *
+ * @param channel List of the channel names from which state information for \c uuid will be
+ *     pulled out.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 4.8.3
+ */
+@property (nonatomic, readonly, strong) PNStateAuditAPICallBuilder * (^channels)(NSArray<NSString *> *channels);
 
 /**
  * @brief Channel group name addition block.
@@ -45,9 +60,23 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @return API call configuration builder.
  *
- * @since 4.5.4
+ * @deprecated 4.8.3
  */
-@property (nonatomic, readonly, strong) PNStateAuditAPICallBuilder * (^channelGroup)(NSString *channelGroup);
+@property (nonatomic, readonly, strong) PNStateAuditAPICallBuilder * (^channelGroup)(NSString *channelGroup)
+    DEPRECATED_MSG_ATTRIBUTE("This method deprecated since 4.8.3. Please use 'channelGroups' "
+                             "method instead.");
+
+/**
+ * @brief Channel group names addition block.
+ *
+ * @param channelGroup List of channel group names from which state information for \c uuid will be
+ *     pulled out.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 4.8.3
+ */
+@property (nonatomic, readonly, strong) PNStateAuditAPICallBuilder * (^channelGroups)(NSArray<NSString *> *channelGroups);
 
 
 #pragma mark - Execution
@@ -59,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @since 4.5.4
  */
-@property (nonatomic, readonly, strong) void(^performWithCompletion)(PNChannelStateCompletionBlock block);
+@property (nonatomic, readonly, strong) void(^performWithCompletion)(PNGetStateCompletionBlock block);
 
 
 #pragma mark - Misc

--- a/PubNub/Data/Builders/API Call/State/PNStateAuditAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/State/PNStateAuditAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStateAuditAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"
@@ -28,9 +28,16 @@
 }
 
 - (PNStateAuditAPICallBuilder * (^)(NSString *channel))channel {
-    
+
     return ^PNStateAuditAPICallBuilder * (NSString *channel) {
-        [self setValue:channel forParameter:NSStringFromSelector(_cmd)];
+        return self.channels(@[channel]);
+    };
+}
+
+- (PNStateAuditAPICallBuilder * (^)(NSArray<NSString *> *channels))channels {
+
+    return ^PNStateAuditAPICallBuilder * (NSArray<NSString *> *channels) {
+        [self setValue:channels forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }
@@ -38,7 +45,14 @@
 - (PNStateAuditAPICallBuilder * (^)(NSString *channelGroup))channelGroup {
     
     return ^PNStateAuditAPICallBuilder * (NSString *channelGroup) {
-        [self setValue:channelGroup forParameter:NSStringFromSelector(_cmd)];
+        return self.channelGroups(@[channelGroup]);
+    };
+}
+
+- (PNStateAuditAPICallBuilder * (^)(NSArray<NSString *> *channelGroups))channelGroups {
+
+    return ^PNStateAuditAPICallBuilder * (NSArray<NSString *> *channelGroups) {
+        [self setValue:channelGroups forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }
@@ -46,9 +60,9 @@
 
 #pragma mark - Execution
 
-- (void(^)(PNChannelStateCompletionBlock block))performWithCompletion {
+- (void(^)(PNGetStateCompletionBlock block))performWithCompletion {
     
-    return ^(PNChannelStateCompletionBlock block) {
+    return ^(PNGetStateCompletionBlock block) {
         [super performWithBlock:block];
     };
 }

--- a/PubNub/Data/Builders/API Call/State/PNStateModificationAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/State/PNStateModificationAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStateModificationAPICallBuilder : PNStateAPICallBuilder
 
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Unique user identifier addition block.
  *
- * @param uuid Unique user identifier for which state should be bound.
+ * @param uuid Unique user identifier for which state should be bound. Current \b {PubNub} user id
+ *     will be used by default if not set or set to \c nil.
  *
  * @return API call configuration builder.
  *
@@ -41,9 +42,20 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param channel Name of the channel which will store provided state information for \c uuid.
  *
- * @since 4.5.4
+ * @deprecated 4.8.3
  */
-@property (nonatomic, readonly, strong) PNStateModificationAPICallBuilder * (^channel)(NSString *channel);
+@property (nonatomic, readonly, strong) PNStateModificationAPICallBuilder * (^channel)(NSString *channel)
+    DEPRECATED_MSG_ATTRIBUTE("This method deprecated since 4.8.3. Please use 'channels' "
+                             "method instead.");
+
+/**
+ * @brief Channel names addition block.
+ *
+ * @param channel List of the channel names which will store provided state information for \c uuid.
+ *
+ * @since 4.8.3
+ */
+@property (nonatomic, readonly, strong) PNStateModificationAPICallBuilder * (^channels)(NSArray<NSString *> *channels);
 
 /**
  * @brief Channel group name addition block.
@@ -51,9 +63,21 @@ NS_ASSUME_NONNULL_BEGIN
  * @param channelGroup Name of channel group which will store provided state information for
  *     \c uuid.
  *
- * @since 4.5.4
+ * @deprecated 4.8.3
  */
-@property (nonatomic, readonly, strong) PNStateModificationAPICallBuilder * (^channelGroup)(NSString *channelGroup);
+@property (nonatomic, readonly, strong) PNStateModificationAPICallBuilder * (^channelGroup)(NSString *channelGroup)
+    DEPRECATED_MSG_ATTRIBUTE("This method deprecated since 4.8.3. Please use 'channelGroups' "
+                             "method instead.");
+
+/**
+ * @brief Channel group names addition block.
+ *
+ * @param channelGroups List of channel group names which will store provided state information for
+ *     \c uuid.
+ *
+ * @since 4.8.3
+ */
+@property (nonatomic, readonly, strong) PNStateModificationAPICallBuilder * (^channelGroups)(NSArray<NSString *> *channelGroups);
 
 
 #pragma mark - Execution

--- a/PubNub/Data/Builders/API Call/State/PNStateModificationAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/State/PNStateModificationAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStateModificationAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"
@@ -36,9 +36,16 @@
 }
 
 - (PNStateModificationAPICallBuilder * (^)(NSString *channel))channel {
-    
+
     return ^PNStateModificationAPICallBuilder * (NSString *channel) {
-        [self setValue:channel forParameter:NSStringFromSelector(_cmd)];
+        return self.channels(@[channel]);
+    };
+}
+
+- (PNStateModificationAPICallBuilder * (^)(NSArray<NSString *> *channels))channels {
+
+    return ^PNStateModificationAPICallBuilder * (NSArray<NSString *> *channels) {
+        [self setValue:channels forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }
@@ -46,7 +53,14 @@
 - (PNStateModificationAPICallBuilder * (^)(NSString *channelGroup))channelGroup {
     
     return ^PNStateModificationAPICallBuilder * (NSString *channelGroup) {
-        [self setValue:channelGroup forParameter:NSStringFromSelector(_cmd)];
+        return self.channelGroups(@[channelGroup]);
+    };
+}
+
+- (PNStateModificationAPICallBuilder * (^)(NSArray<NSString *> *channelGroups))channelGroups {
+
+    return ^PNStateModificationAPICallBuilder * (NSArray<NSString *> *channelGroups) {
+        [self setValue:channelGroups forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }

--- a/PubNub/Data/Builders/API Call/Stream/PNStreamAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Stream/PNStreamAPICallBuilder.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStreamAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Stream/PNStreamAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Stream/PNStreamAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStreamAPICallBuilder.h"
 #import "PNStreamModificationAPICallBuilder.h"

--- a/PubNub/Data/Builders/API Call/Stream/PNStreamAuditAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Stream/PNStreamAuditAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStreamAuditAPICallBuilder : PNStreamAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Stream/PNStreamAuditAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Stream/PNStreamAuditAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStreamAuditAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Stream/PNStreamModificationAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Stream/PNStreamModificationAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStreamModificationAPICallBuilder : PNStreamAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Stream/PNStreamModificationAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Stream/PNStreamModificationAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStreamModificationAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeAPIBuilder.h
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeAPIBuilder.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscribeAPIBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeAPIBuilder.m
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeAPIBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscribeAPIBuilder.h"
 #import "PNSubscribeChannelsOrGroupsAPIBuilder.h"

--- a/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeChannelsOrGroupsAPIBuilder.h
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeChannelsOrGroupsAPIBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscribeChannelsOrGroupsAPIBuilder : PNSubscribeAPIBuilder
 

--- a/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeChannelsOrGroupsAPIBuilder.m
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNSubscribeChannelsOrGroupsAPIBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscribeChannelsOrGroupsAPIBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeAPICallBuilder.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNUnsubscribeAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNUnsubscribeAPICallBuilder.h"
 #import "PNUnsubscribeChannelsOrGroupsAPICallBuilder.h"

--- a/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeChannelsOrGroupsAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeChannelsOrGroupsAPICallBuilder.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNUnsubscribeChannelsOrGroupsAPICallBuilder : PNUnsubscribeAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeChannelsOrGroupsAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Subscribe/PNUnsubscribeChannelsOrGroupsAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNUnsubscribeChannelsOrGroupsAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/API Call/Time/PNTimeAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Time/PNTimeAPICallBuilder.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNTimeAPICallBuilder : PNAPICallBuilder
 

--- a/PubNub/Data/Builders/API Call/Time/PNTimeAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Time/PNTimeAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNTimeAPICallBuilder.h"
 #import "PNAPICallBuilder+Private.h"

--- a/PubNub/Data/Builders/PNAPICallBuilder+Private.h
+++ b/PubNub/Data/Builders/PNAPICallBuilder+Private.h
@@ -1,7 +1,7 @@
 /**
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAPICallBuilder.h"
 

--- a/PubNub/Data/Builders/PNAPICallBuilder.h
+++ b/PubNub/Data/Builders/PNAPICallBuilder.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @author Serhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAPICallBuilder : NSObject
 

--- a/PubNub/Data/Builders/PNAPICallBuilder.m
+++ b/PubNub/Data/Builders/PNAPICallBuilder.m
@@ -1,7 +1,7 @@
 /**
  * @author SErhii Mamontov
  * @since 4.5.4
- * @copyright © 2009-2017 PubNub, Inc.
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAPICallBuilder+Private.h"
 #import <objc/runtime.h>

--- a/PubNub/Data/Managers/PNClientState.h
+++ b/PubNub/Data/Managers/PNClientState.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNClientState : NSObject
 
@@ -91,11 +91,12 @@ NS_ASSUME_NONNULL_BEGIN
  @brief  Overwrite client state information bound to specified \c object.
 
  @param state  State which should replace cached information.
- @param object Name of the object for which new data should be applied.
+ @param objects List of object names for which new data should be applied.
 
- @since 4.0
+ @since 4.8.3
  */
-- (void)setState:(nullable NSDictionary<NSString *, id> *)state forObject:(NSString *)object;
+- (void)setState:(nullable NSDictionary<NSString *, id> *)state
+      forObjects:(NSArray<NSString *> *)objects;
 
 /**
  @brief  Clear client state cache from specified objects data.

--- a/PubNub/Data/Managers/PNClientState.m
+++ b/PubNub/Data/Managers/PNClientState.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNClientState.h"
 #import "PubNub+CorePrivate.h"
@@ -147,12 +147,17 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-- (void)setState:(NSDictionary<NSString *, id> *)state forObject:(NSString *)object {
+- (void)setState:(nullable NSDictionary<NSString *, id> *)state
+      forObjects:(NSArray<NSString *> *)objects {
 
     dispatch_barrier_async(self.resourceAccessQueue, ^{
-        
-        if (state.count) { self.stateCache[object] = state; }
-        else { [self.stateCache removeObjectForKey:object]; }
+        for (NSString *object in objects) {
+            if (state.count) {
+                self.stateCache[object] = state;
+            } else {
+                [self.stateCache removeObjectForKey:object];
+            }
+        }
     });
 }
 

--- a/PubNub/Data/Managers/PNHeartbeat.h
+++ b/PubNub/Data/Managers/PNHeartbeat.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNHeartbeat : NSObject
 

--- a/PubNub/Data/Managers/PNHeartbeat.m
+++ b/PubNub/Data/Managers/PNHeartbeat.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNHeartbeat.h"
 #import "PubNub+PresencePrivate.h"

--- a/PubNub/Data/Managers/PNPublishSequence.h
+++ b/PubNub/Data/Managers/PNPublishSequence.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.5.2
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPublishSequence : NSObject
 

--- a/PubNub/Data/Managers/PNStateListener.h
+++ b/PubNub/Data/Managers/PNStateListener.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStateListener : NSObject
 

--- a/PubNub/Data/Managers/PNStateListener.m
+++ b/PubNub/Data/Managers/PNStateListener.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStateListener.h"
 #import "PNObjectEventListener.h"

--- a/PubNub/Data/Managers/PNSubscriber.h
+++ b/PubNub/Data/Managers/PNSubscriber.h
@@ -28,7 +28,7 @@ typedef void(^PNSubscriberCompletionBlock)(PNSubscribeStatus * _Nullable status)
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscriber : NSObject
 

--- a/PubNub/Data/Managers/PNSubscriber.m
+++ b/PubNub/Data/Managers/PNSubscriber.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscriber.h"
 #import "PNSubscribeStatus+Private.h"
@@ -1535,7 +1535,7 @@ NS_ASSUME_NONNULL_END
         // Check whether state has been changed for current client or not.
         if ([data.data.presence.uuid isEqualToString:self.client.configuration.uuid]) {
             
-            [self.client.clientStateManager setState:data.data.presence.state forObject:data.data.channel];
+            [self.client.clientStateManager setState:data.data.presence.state forObjects:@[data.data.channel]];
         }
     }
     [self.client.listenersManager notifyPresenceEvent:data];

--- a/PubNub/Data/Managers/PNTelemetry.h
+++ b/PubNub/Data/Managers/PNTelemetry.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.6.2
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNTelemetry : NSObject
 

--- a/PubNub/Data/Managers/PNTelemetry.m
+++ b/PubNub/Data/Managers/PNTelemetry.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.6.1
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNTelemetry.h"
 #import "PNPrivateStructures.h"

--- a/PubNub/Data/PNAES.h
+++ b/PubNub/Data/PNAES.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAES : NSObject
 

--- a/PubNub/Data/PNAES.m
+++ b/PubNub/Data/PNAES.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAES.h"
 #import <CommonCrypto/CommonCryptor.h>

--- a/PubNub/Data/PNClientInformation.h
+++ b/PubNub/Data/PNClientInformation.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0.5
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNClientInformation : NSObject
 

--- a/PubNub/Data/PNClientInformation.m
+++ b/PubNub/Data/PNClientInformation.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0.5
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNClientInformation.h"
 #import "PNConstants.h"

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNConfiguration : NSObject
 
@@ -189,21 +189,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.0
  */
-@property (nonatomic, assign, getter = shouldKeepTimeTokenOnListChange) BOOL keepTimeTokenOnListChange NS_SWIFT_NAME(keepTimeTokenOnListChange);
-
-/**
- @brief      Stores whether client should restore subscription on remote data objects live feed after network 
-             connection restoring or not.
- @discussion If set to \c YES as soon as network connection will be restored client will restore subscription
-             to previously subscribed remote data objects live feeds.
- 
- @default    By default client use \b YES to restore subscription on remote data objects live feeds.
- 
- @since 4.0
- */
-@property (nonatomic, assign, getter = shouldRestoreSubscription) BOOL restoreSubscription NS_SWIFT_NAME(restoreSubscription) 
-          DEPRECATED_MSG_ATTRIBUTE("This option will be deprecated in upcoming releases. Client will restore "
-                                   "it's subscription after network issues automatically.");
+@property (nonatomic, assign, getter = shouldKeepTimeTokenOnListChange) BOOL keepTimeTokenOnListChange
+    NS_SWIFT_NAME(keepTimeTokenOnListChange);
 
 /**
  @brief      Stores whether client should try to catch up for events which occurred on previously subscribed 
@@ -219,7 +206,8 @@ NS_ASSUME_NONNULL_BEGIN
  
  @since 4.0
  */
-@property (nonatomic, assign, getter = shouldTryCatchUpOnSubscriptionRestore) BOOL catchUpOnSubscriptionRestore NS_SWIFT_NAME(catchUpOnSubscriptionRestore);
+@property (nonatomic, assign, getter = shouldTryCatchUpOnSubscriptionRestore) BOOL catchUpOnSubscriptionRestore
+    NS_SWIFT_NAME(catchUpOnSubscriptionRestore);
 
 /**
  @brief      Stores reference on group identifier which is used to share request cache between application 

--- a/PubNub/Data/PNConfiguration.m
+++ b/PubNub/Data/PNConfiguration.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 #if TARGET_OS_IOS

--- a/PubNub/Data/PNEnvelopeInformation.h
+++ b/PubNub/Data/PNEnvelopeInformation.h
@@ -8,7 +8,7 @@
 
  @author Sergey Mamontov
  @since 4.3.0
- @copyright © 2009-15 PubNub Inc.
+ @copyright © 2010-2018 PubNub Inc.
  */
 @interface PNEnvelopeInformation : NSObject
 

--- a/PubNub/Data/PNEnvelopeInformation.m
+++ b/PubNub/Data/PNEnvelopeInformation.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.3.0
- @copyright © 2009-15 PubNub Inc.
+ @copyright © 2010-2018 PubNub Inc.
  */
 #import "PNEnvelopeInformation.h"
 #import "PNJSON.h"

--- a/PubNub/Data/PNKeychain.h
+++ b/PubNub/Data/PNKeychain.h
@@ -6,7 +6,7 @@
  
  @author Sergey Mamontov
  @since 4.x.1
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNKeychain : NSObject
 

--- a/PubNub/Data/PNKeychain.m
+++ b/PubNub/Data/PNKeychain.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.x.1
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNKeychain.h"
 #import <Security/Security.h>

--- a/PubNub/Data/Service Objects/PNAPNSEnabledChannelsResult.h
+++ b/PubNub/Data/Service Objects/PNAPNSEnabledChannelsResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAPNSEnabledChannelsData : PNServiceData
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAPNSEnabledChannelsResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNAPNSEnabledChannelsResult.m
+++ b/PubNub/Data/Service Objects/PNAPNSEnabledChannelsResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAPNSEnabledChannelsResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNAcknowledgmentStatus.h
+++ b/PubNub/Data/Service Objects/PNAcknowledgmentStatus.h
@@ -7,7 +7,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNAcknowledgmentStatus : PNErrorStatus
 

--- a/PubNub/Data/Service Objects/PNAcknowledgmentStatus.m
+++ b/PubNub/Data/Service Objects/PNAcknowledgmentStatus.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNAcknowledgmentStatus.h"
 

--- a/PubNub/Data/Service Objects/PNChannelClientStateResult.h
+++ b/PubNub/Data/Service Objects/PNChannelClientStateResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelClientStateData : PNServiceData
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelClientStateResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNChannelClientStateResult.m
+++ b/PubNub/Data/Service Objects/PNChannelClientStateResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNChannelClientStateResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNChannelGroupChannelsResult.h
+++ b/PubNub/Data/Service Objects/PNChannelGroupChannelsResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupChannelsData : PNServiceData
 
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupChannelsResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNChannelGroupChannelsResult.m
+++ b/PubNub/Data/Service Objects/PNChannelGroupChannelsResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNChannelGroupChannelsResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNChannelGroupClientStateResult.h
+++ b/PubNub/Data/Service Objects/PNChannelGroupClientStateResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupClientStateData : PNServiceData
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupClientStateResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNChannelGroupClientStateResult.m
+++ b/PubNub/Data/Service Objects/PNChannelGroupClientStateResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNChannelGroupClientStateResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNChannelGroupsResult.h
+++ b/PubNub/Data/Service Objects/PNChannelGroupsResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupsData : PNServiceData
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupsResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNClientStateGetResult.h
+++ b/PubNub/Data/Service Objects/PNClientStateGetResult.h
@@ -1,0 +1,52 @@
+#import "PNResult.h"
+#import "PNServiceData.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * @brief Class which allow to get access to client state for channel / groups processed result.
+ *
+ * @author Serhii Mamontov
+ * @since 4.8.3
+ * @copyright © 2010-2018 PubNub, Inc.
+ */
+@interface PNClientStateData : PNServiceData
+
+
+#pragma mark Information
+
+/**
+ * @brief State information for each channel from requested channels / chanel groups channels.
+ */
+@property (nonatomic, readonly, strong) NSDictionary<NSString *, NSDictionary *> *channels;
+
+#pragma mark -
+
+
+@end
+
+
+/**
+ * @brief Class which is used to provide access to request processing results.
+ *
+ * @author Serhii Mamontov
+ * @since 4.8.3
+ * @copyright © 2010-2018 PubNub, Inc.
+ */
+@interface PNClientStateGetResult : PNResult
+
+
+#pragma mark - Information
+
+/**
+ * @brief Client state processing information for channels / chanel groups channels.
+ */
+@property (nonatomic, readonly, strong) PNClientStateData *data;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubNub/Data/Service Objects/PNClientStateGetResult.m
+++ b/PubNub/Data/Service Objects/PNClientStateGetResult.m
@@ -1,0 +1,65 @@
+/**
+ * @author Serhii Mamontov
+ * @since 4.8.3
+ * @copyright © 2010-2018 PubNub, Inc.
+ */
+#import "PNClientStateGetResult.h"
+#import "PNServiceData+Private.h"
+#import "PNResult+Private.h"
+
+
+#pragma mark Interface implementation
+
+@implementation PNClientStateData
+
+
+#pragma mark - Information
+
+- (NSDictionary<NSString *, NSDictionary *> *)channels {
+
+    return (self.serviceData[@"channels"] ?: @{});
+}
+
+#pragma mark -
+
+@end
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Private interface declaration
+
+@interface PNClientStateGetResult ()
+
+
+#pragma mark - Information
+
+@property (nonatomic, nonnull, strong) PNClientStateData *data;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+
+#pragma mark - Interface implementation
+
+@implementation PNClientStateGetResult
+
+
+#pragma mark - Information
+
+- (PNClientStateData *)data {
+
+    if (!_data) {
+        _data = [PNClientStateData dataWithServiceResponse:self.serviceData];
+    }
+
+    return _data;
+}
+
+#pragma mark -
+
+@end

--- a/PubNub/Data/Service Objects/PNClientStateUpdateStatus.h
+++ b/PubNub/Data/Service Objects/PNClientStateUpdateStatus.h
@@ -7,7 +7,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNClientStateUpdateData : PNChannelClientStateData
 
@@ -23,7 +23,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNClientStateUpdateStatus : PNErrorStatus
 

--- a/PubNub/Data/Service Objects/PNClientStateUpdateStatus.m
+++ b/PubNub/Data/Service Objects/PNClientStateUpdateStatus.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNClientStateUpdateStatus.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNErrorStatus.h
+++ b/PubNub/Data/Service Objects/PNErrorStatus.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNErrorData : PNServiceData
 
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNErrorStatus : PNStatus
 

--- a/PubNub/Data/Service Objects/PNErrorStatus.m
+++ b/PubNub/Data/Service Objects/PNErrorStatus.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNErrorStatus+Private.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNHistoryResult.h
+++ b/PubNub/Data/Service Objects/PNHistoryResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNHistoryData : PNServiceData
 
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNHistoryResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNHistoryResult.m
+++ b/PubNub/Data/Service Objects/PNHistoryResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNHistoryResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNPresenceChannelGroupHereNowResult.h
+++ b/PubNub/Data/Service Objects/PNPresenceChannelGroupHereNowResult.h
@@ -6,7 +6,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceChannelGroupHereNowData : PNPresenceGlobalHereNowData
 
@@ -22,7 +22,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceChannelGroupHereNowResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNPresenceChannelGroupHereNowResult.m
+++ b/PubNub/Data/Service Objects/PNPresenceChannelGroupHereNowResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceChannelGroupHereNowResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNPresenceChannelHereNowResult.h
+++ b/PubNub/Data/Service Objects/PNPresenceChannelHereNowResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceChannelHereNowData : PNServiceData
 
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceChannelHereNowResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNPresenceChannelHereNowResult.m
+++ b/PubNub/Data/Service Objects/PNPresenceChannelHereNowResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceChannelHereNowResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNPresenceGlobalHereNowResult.h
+++ b/PubNub/Data/Service Objects/PNPresenceGlobalHereNowResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceGlobalHereNowData : PNServiceData
 
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceGlobalHereNowResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNPresenceGlobalHereNowResult.m
+++ b/PubNub/Data/Service Objects/PNPresenceGlobalHereNowResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceGlobalHereNowResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNPresenceWhereNowResult.h
+++ b/PubNub/Data/Service Objects/PNPresenceWhereNowResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceWhereNowData : PNServiceData
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceWhereNowResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNPresenceWhereNowResult.m
+++ b/PubNub/Data/Service Objects/PNPresenceWhereNowResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceWhereNowResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Data/Service Objects/PNPublishStatus.h
+++ b/PubNub/Data/Service Objects/PNPublishStatus.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPublishData : PNServiceData
 
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPublishStatus : PNAcknowledgmentStatus
 

--- a/PubNub/Data/Service Objects/PNResult+Private.h
+++ b/PubNub/Data/Service Objects/PNResult+Private.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNResult.h"
 #import "PNStructures.h"

--- a/PubNub/Data/Service Objects/PNResult.h
+++ b/PubNub/Data/Service Objects/PNResult.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNResult: NSObject
 

--- a/PubNub/Data/Service Objects/PNResult.m
+++ b/PubNub/Data/Service Objects/PNResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNResult+Private.h"
 #import "PNPrivateStructures.h"

--- a/PubNub/Data/Service Objects/PNServiceData.h
+++ b/PubNub/Data/Service Objects/PNServiceData.h
@@ -7,7 +7,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNServiceData : NSObject
 

--- a/PubNub/Data/Service Objects/PNServiceData.m
+++ b/PubNub/Data/Service Objects/PNServiceData.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNServiceData+Private.h"
 

--- a/PubNub/Data/Service Objects/PNStatus+Private.h
+++ b/PubNub/Data/Service Objects/PNStatus+Private.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStatus.h"
 

--- a/PubNub/Data/Service Objects/PNStatus.h
+++ b/PubNub/Data/Service Objects/PNStatus.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNStatus : PNResult
 

--- a/PubNub/Data/Service Objects/PNStatus.m
+++ b/PubNub/Data/Service Objects/PNStatus.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStatus+Private.h"
 #import "PNNetworkResponseSerializer.h"

--- a/PubNub/Data/Service Objects/PNSubscribeStatus+Private.h
+++ b/PubNub/Data/Service Objects/PNSubscribeStatus+Private.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscribeStatus.h"
 #import "PNEnvelopeInformation.h"

--- a/PubNub/Data/Service Objects/PNSubscribeStatus.h
+++ b/PubNub/Data/Service Objects/PNSubscribeStatus.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscriberData : PNServiceData
 
@@ -31,22 +31,6 @@ NS_ASSUME_NONNULL_BEGIN
  @since 4.5.2
  */
 @property (nonatomic, nullable, readonly, strong) NSString *subscription;
-
-/**
- @brief  Name of regular channel or channel group.
- 
- @since 4.0
- */
-@property (nonatomic, nullable, readonly, strong) NSString *subscribedChannel 
-          DEPRECATED_MSG_ATTRIBUTE("Property will be removed soon. Use 'subscription' property instead.");
-
-/**
- @brief  Name of channel in case if \c -subscribedChannel represent channel group.
- 
- @since 4.0
- */
-@property (nonatomic, nullable, readonly, strong) NSString *actualChannel 
-          DEPRECATED_MSG_ATTRIBUTE("Property will be removed soon. Use 'channel' property instead.");
 
 /**
  @brief  Time at which event arrived.
@@ -73,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscribeStatus : PNErrorStatus
 

--- a/PubNub/Data/Service Objects/PNSubscribeStatus.m
+++ b/PubNub/Data/Service Objects/PNSubscribeStatus.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscribeStatus+Private.h"
 #import "PNEnvelopeInformation.h"
@@ -24,16 +24,6 @@
 - (NSString *)subscription {
     
     return self.serviceData[@"subscription"];
-}
-
-- (NSString *)subscribedChannel {
-    
-    return self.subscription;
-}
-
-- (NSString *)actualChannel {
-    
-    return self.channel;
 }
 
 - (NSNumber *)timetoken {

--- a/PubNub/Data/Service Objects/PNSubscriberResults.h
+++ b/PubNub/Data/Service Objects/PNSubscriberResults.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceDetailsData : PNSubscriberData
 
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceEventData : PNSubscriberData
 
@@ -139,7 +139,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNMessageData : PNSubscriberData
 
@@ -176,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNMessageResult : PNResult
 
@@ -203,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceEventResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNSubscriberResults.m
+++ b/PubNub/Data/Service Objects/PNSubscriberResults.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscriberResults.h"
 #import "PNSubscribeStatus+Private.h"

--- a/PubNub/Data/Service Objects/PNTimeResult.h
+++ b/PubNub/Data/Service Objects/PNTimeResult.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNTimeData : PNServiceData
 
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNTimeResult : PNResult
 

--- a/PubNub/Data/Service Objects/PNTimeResult.m
+++ b/PubNub/Data/Service Objects/PNTimeResult.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNTimeResult.h"
 #import "PNServiceData+Private.h"

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.h
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface NSURLSessionConfiguration (PNConfiguration)
 

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.m
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfiguration.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "NSURLSessionConfiguration+PNConfigurationPrivate.h"
 #if TARGET_OS_IOS || TARGET_OS_TV

--- a/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfigurationPrivate.h
+++ b/PubNub/Misc/Categories/NSURLSessionConfiguration+PNConfigurationPrivate.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "NSURLSessionConfiguration+PNConfiguration.h"
 

--- a/PubNub/Misc/Helpers/PNArray.h
+++ b/PubNub/Misc/Helpers/PNArray.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNArray : NSObject
 

--- a/PubNub/Misc/Helpers/PNArray.m
+++ b/PubNub/Misc/Helpers/PNArray.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNArray.h"
 

--- a/PubNub/Misc/Helpers/PNChannel.h
+++ b/PubNub/Misc/Helpers/PNChannel.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannel : NSObject
 

--- a/PubNub/Misc/Helpers/PNChannel.m
+++ b/PubNub/Misc/Helpers/PNChannel.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNChannel.h"
 #import "PNString.h"

--- a/PubNub/Misc/Helpers/PNData.h
+++ b/PubNub/Misc/Helpers/PNData.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNData : NSObject
 

--- a/PubNub/Misc/Helpers/PNData.m
+++ b/PubNub/Misc/Helpers/PNData.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNData.h"
 

--- a/PubNub/Misc/Helpers/PNDefines.h
+++ b/PubNub/Misc/Helpers/PNDefines.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.5.15
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #ifndef PNDefines_h
 #define PNDefines_h

--- a/PubNub/Misc/Helpers/PNDictionary.h
+++ b/PubNub/Misc/Helpers/PNDictionary.h
@@ -6,7 +6,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNDictionary : NSObject
 

--- a/PubNub/Misc/Helpers/PNDictionary.m
+++ b/PubNub/Misc/Helpers/PNDictionary.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNDictionary.h"
 #import "PNString.h"

--- a/PubNub/Misc/Helpers/PNGZIP.h
+++ b/PubNub/Misc/Helpers/PNGZIP.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNGZIP : NSObject
 

--- a/PubNub/Misc/Helpers/PNGZIP.m
+++ b/PubNub/Misc/Helpers/PNGZIP.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNGZIP.h"
 #import <zlib.h>

--- a/PubNub/Misc/Helpers/PNHelpers.h
+++ b/PubNub/Misc/Helpers/PNHelpers.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #ifndef PNHelpers_h
 #define PNHelpers_h

--- a/PubNub/Misc/Helpers/PNJSON.h
+++ b/PubNub/Misc/Helpers/PNJSON.h
@@ -6,7 +6,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNJSON : NSObject
 

--- a/PubNub/Misc/Helpers/PNJSON.m
+++ b/PubNub/Misc/Helpers/PNJSON.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNJSON.h"
 

--- a/PubNub/Misc/Helpers/PNLockSupport.h
+++ b/PubNub/Misc/Helpers/PNLockSupport.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.5.15
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 #import "PNDefines.h"

--- a/PubNub/Misc/Helpers/PNLockSupport.m
+++ b/PubNub/Misc/Helpers/PNLockSupport.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.5.15
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNLockSupport.h"
 

--- a/PubNub/Misc/Helpers/PNNumber.h
+++ b/PubNub/Misc/Helpers/PNNumber.h
@@ -6,7 +6,7 @@
  
  @author Sergey Mamontov
  @since 4.2.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNNumber : NSObject
 

--- a/PubNub/Misc/Helpers/PNNumber.m
+++ b/PubNub/Misc/Helpers/PNNumber.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.2
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNNumber.h"
 

--- a/PubNub/Misc/Helpers/PNString.h
+++ b/PubNub/Misc/Helpers/PNString.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNString : NSObject
 

--- a/PubNub/Misc/Helpers/PNString.m
+++ b/PubNub/Misc/Helpers/PNString.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNString.h"
 #import <CommonCrypto/CommonCryptor.h>

--- a/PubNub/Misc/Helpers/PNURLRequest.h
+++ b/PubNub/Misc/Helpers/PNURLRequest.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNURLRequest : NSObject
 

--- a/PubNub/Misc/Helpers/PNURLRequest.m
+++ b/PubNub/Misc/Helpers/PNURLRequest.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNURLRequest.h"
 

--- a/PubNub/Misc/Logger/Core/PNLLogger.h
+++ b/PubNub/Misc/Logger/Core/PNLLogger.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.5.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNLLogger : NSObject
 

--- a/PubNub/Misc/Logger/Core/PNLLogger.m
+++ b/PubNub/Misc/Logger/Core/PNLLogger.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.5.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNLLogger.h"
 #import "PNLLogFileInformation.h"

--- a/PubNub/Misc/Logger/Data/PNLLogFileInformation.h
+++ b/PubNub/Misc/Logger/Data/PNLLogFileInformation.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.5.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNLLogFileInformation : NSObject
 

--- a/PubNub/Misc/Logger/Data/PNLLogFileInformation.m
+++ b/PubNub/Misc/Logger/Data/PNLLogFileInformation.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.5.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNLLogFileInformation.h"
 #import "PNLockSupport.h"

--- a/PubNub/Misc/Logger/PNLogMacro.h
+++ b/PubNub/Misc/Logger/PNLogMacro.h
@@ -4,7 +4,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNLLogger.h"
 #import "PNDefines.h"

--- a/PubNub/Misc/PNConstants.h
+++ b/PubNub/Misc/PNConstants.h
@@ -3,7 +3,7 @@
 
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 #import "PNStructures.h"

--- a/PubNub/Misc/PNErrorCodes.h
+++ b/PubNub/Misc/PNErrorCodes.h
@@ -3,7 +3,7 @@
 
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 

--- a/PubNub/Misc/PNPrivateStructures.h
+++ b/PubNub/Misc/PNPrivateStructures.h
@@ -3,7 +3,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNStructures.h"
 
@@ -21,7 +21,7 @@ extern NSString * const kPNConfigurationUUIDKey;
 
  @since 4.0
  */
-static NSString * const PNOperationTypeStrings[24] = {
+static NSString * const PNOperationTypeStrings[25] = {
     [PNSubscribeOperation] = @"Subscribe",
     [PNUnsubscribeOperation] = @"Unsubscribe",
     [PNPublishOperation] = @"Publish",
@@ -34,6 +34,7 @@ static NSString * const PNOperationTypeStrings[24] = {
     [PNHereNowForChannelGroupOperation] = @"Here Now for Channel Group",
     [PNHeartbeatOperation] = @"Heartbeat",
     [PNSetStateOperation] = @"Set State",
+    [PNGetStateOperation] = @"Get State for Channels and / or Channel Groups",
     [PNStateForChannelOperation] = @"Get State for Channel",
     [PNStateForChannelGroupOperation] = @"Get State for Channel Group",
     [PNAddChannelsToGroupOperation] = @"Add Channels To Group",
@@ -48,13 +49,14 @@ static NSString * const PNOperationTypeStrings[24] = {
     [PNTimeOperation] = @"Time",
 };
 
-static NSString * const PNOperationResultClasses[24] = {
+static NSString * const PNOperationResultClasses[25] = {
     [PNHistoryOperation] = @"PNHistoryResult",
     [PNHistoryForChannelsOperation] = @"PNHistoryResult",
     [PNWhereNowOperation] = @"PNPresenceWhereNowResult",
     [PNHereNowGlobalOperation] = @"PNPresenceGlobalHereNowResult",
     [PNHereNowForChannelOperation] = @"PNPresenceChannelHereNowResult",
     [PNHereNowForChannelGroupOperation] = @"PNPresenceChannelGroupHereNowResult",
+    [PNGetStateOperation] = @"PNClientStateGetResult",
     [PNStateForChannelOperation] = @"PNChannelClientStateResult",
     [PNStateForChannelGroupOperation] = @"PNChannelGroupClientStateResult",
     [PNChannelGroupsOperation] = @"PNChannelGroupsResult",
@@ -63,7 +65,7 @@ static NSString * const PNOperationResultClasses[24] = {
     [PNTimeOperation] = @"PNTimeResult",
 };
 
-static NSString * const PNOperationStatusClasses[24] = {
+static NSString * const PNOperationStatusClasses[25] = {
     [PNSubscribeOperation] = @"PNSubscribeStatus",
     [PNUnsubscribeOperation] = @"PNAcknowledgmentStatus",
     [PNPublishOperation] = @"PNPublishStatus",
@@ -76,6 +78,7 @@ static NSString * const PNOperationStatusClasses[24] = {
     [PNHereNowForChannelGroupOperation] = @"PNErrorStatus",
     [PNHeartbeatOperation] = @"PNAcknowledgmentStatus",
     [PNSetStateOperation] = @"PNClientStateUpdateStatus",
+    [PNGetStateOperation] = @"PNErrorStatus",
     [PNStateForChannelOperation] = @"PNErrorStatus",
     [PNStateForChannelGroupOperation] = @"PNErrorStatus",
     [PNAddChannelsToGroupOperation] = @"PNAcknowledgmentStatus",

--- a/PubNub/Misc/PNStructures.h
+++ b/PubNub/Misc/PNStructures.h
@@ -3,7 +3,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 #import "PNDefines.h"
@@ -11,38 +11,15 @@
 
 #pragma mark Class forward
 
-@class PNPresenceChannelGroupHereNowResult, PNChannelGroupClientStateResult, PNPresenceChannelHereNowResult; 
-@class PNPresenceGlobalHereNowResult, PNAPNSEnabledChannelsResult, PNChannelGroupChannelsResult;
-@class PNPresenceWhereNowResult, PNChannelClientStateResult, PNClientStateUpdateStatus;
-@class PNAcknowledgmentStatus, PNChannelGroupsResult, PNHistoryResult, PNAPICallBuilder, PNPublishStatus;
-@class PNErrorStatus, PNTimeResult, PNResult, PNStatus;
+@class PNPresenceChannelGroupHereNowResult, PNChannelGroupClientStateResult;
+@class PNPresenceChannelHereNowResult, PNPresenceGlobalHereNowResult, PNAPNSEnabledChannelsResult;
+@class PNChannelGroupChannelsResult, PNPresenceWhereNowResult, PNChannelClientStateResult;
+@class PNClientStateGetResult, PNClientStateUpdateStatus, PNAcknowledgmentStatus;
+@class PNChannelGroupsResult, PNHistoryResult, PNAPICallBuilder, PNPublishStatus, PNErrorStatus;
+@class PNTimeResult, PNResult, PNStatus;
 
 #ifndef PNStructures_h
 #define PNStructures_h
-
-/**
- @breif      Description of define to shorten builder constructors declaration.
- @discussion Define describe block with specified \c protocol which provide interface for concrete API methods
-             family.
- 
- @since 4.5.4
- 
- @param _protocol_ Reference on protocol for which \c builder should provide interface.
- */
-#define PNBuilder(_protocol_) PNBuilderWithArgument(_protocol_, void)
-
-/**
- @breif      Description of define to shorten builder constructors declaration.
- @discussion Define describe block with specified \c protocol which provide interface for concrete API methods
-             family.
- 
- @since 4.5.4
- 
- @param _protocol_ Reference on protocol for which \c builder should provide interface.
- @param _argument_ Reference on argument type (including nullability) which is expected from user and will be
-                   passed later by builder to corresponding API call. 
- */
-#define PNBuilderWithArgument(_protocol_, _argument_) PNAPICallBuilder <_protocol_> * (^)( _argument_ )
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -244,6 +221,17 @@ typedef void(^PNMessageSizeCalculationCompletionBlock)(NSInteger size);
 typedef void(^PNSetStateCompletionBlock)(PNClientStateUpdateStatus *status);
 
 /**
+ * @brief Channels / channel groups channels state audition completion block.
+ *
+ * @param result Result object state audit request results.
+ * @param status Status instance which hold information about processing error.
+ *
+ * @since 4.8.3
+ */
+typedef void(^PNGetStateCompletionBlock)(PNClientStateGetResult * _Nullable result,
+                                         PNErrorStatus * _Nullable status);
+
+/**
  @brief  Channel state audition completion block.
  
  @param result Reference on result object which describe service response on channel state audit request.
@@ -433,6 +421,7 @@ typedef NS_ENUM(NSInteger, PNOperationType){
     PNHereNowForChannelGroupOperation,
     PNHeartbeatOperation,
     PNSetStateOperation,
+    PNGetStateOperation,
     PNStateForChannelOperation,
     PNStateForChannelGroupOperation,
     PNAddChannelsToGroupOperation,

--- a/PubNub/Misc/Protocols/PNObjectEventListener.h
+++ b/PubNub/Misc/Protocols/PNObjectEventListener.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @protocol PNObjectEventListener <NSObject>
 

--- a/PubNub/Misc/Protocols/PNParser.h
+++ b/PubNub/Misc/Protocols/PNParser.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @protocol PNParser <NSObject>
 

--- a/PubNub/Network/PNNetwork.h
+++ b/PubNub/Network/PNNetwork.h
@@ -10,122 +10,117 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- @brief      Class which translate \b PubNub operations to request for \b PubNub network.
- @discussion Intermediate layer between \b PubNub client operations and networking which is used to send 
-             network request to \b PubNub service.
- 
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ * @brief Class which translate \b PubNub operations to request for \b PubNub network.
+ *
+ * @discussion Intermediate layer between \b PubNub client operations and networking which is used
+ * to send network request to \b PubNub service.
+ *
+ * @author Serhii Mamontov
+ * @since 4.0
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNNetwork : NSObject
 
 
-///------------------------------------------------
-/// @name Initialization and Configuration
-///------------------------------------------------
+#pragma mark - Initialization and Configuration
 
 /**
- @brief  Construct \b PubNub network manager with predefined options.
- 
- @param client             Reference on client for which this network manager is creating.
- @param timeout            Maximum time which manager should wait for response on request.
- @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
- @param longPollEnabled    Whether \b PubNub network manager should be configured for long-poll requests or 
-                           not. This option affect the way how network manager handle reset.
- 
- @return 4.0
- 
- @since Constructed and ready to use \b PubNub network manager.
+ * @brief Create and configure \b PubNub network manager with predefined options.
+ *
+ * @param client \b {PubNub} client for which this network manager will be created.
+ * @param timeout Maximum time which manager should wait for response on request.
+ * @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
+ * @param longPollEnabled Whether \b PubNub network manager should be configured for long-poll
+ *     requests or not. This option affect the way how network manager handle reset.
+ *
+ * @return Constructed and ready to use \b PubNub network manager.
  */
-+ (instancetype)networkForClient:(PubNub *)client requestTimeout:(NSTimeInterval)timeout
-              maximumConnections:(NSInteger)maximumConnections longPoll:(BOOL)longPollEnabled;
++ (instancetype)networkForClient:(PubNub *)client
+                  requestTimeout:(NSTimeInterval)timeout
+              maximumConnections:(NSInteger)maximumConnections
+                        longPoll:(BOOL)longPollEnabled;
 
 
-///------------------------------------------------
-/// @name Request processing
-///------------------------------------------------
+#pragma mark - Request processing
 
 /**
- @brief      Process passed operation using set of parameters.
- @discussion Translate client operation to actual request to \b PubNub network.
- 
- @param operationType One of \b PNOperationType enumerator fields which describe what kind of operation should
-                      be executed by client.
- @param parameters    Request parameters representation object.
- @param data          Reference on binary data which should be pushed to \b PubNub network along with request.
- @param block         Depending on operation type it can be \b PNResultBlock, \b PNStatusBlock or
-                      \b PNCompletionBlock blocks.`
- 
- @since 4.0
+ * @brief Process passed operation using set of parameters.
+ *
+ * @discussion Translate client operation to actual request to \b PubNub network.
+ *
+ * @param operationType One of \b {operation PNOperationType} enumerator fields which describe what
+ *     kind of operation should be executed by client.
+ * @param parameters Request parameters representation object.
+ * @param data Binary data which should be pushed to \b PubNub network along with request.
+ * @param block Depending on operation type it can be \b {result PNResultBlock},
+ *     \b {status PNStatusBlock} or \b {completion PNCompletionBlock} blocks.`
  */
 - (void)processOperation:(PNOperationType)operationType
-          withParameters:(PNRequestParameters *)parameters data:(nullable NSData *)data
+          withParameters:(PNRequestParameters *)parameters
+                    data:(nullable NSData *)data
          completionBlock:(id)block;
 
 /**
- @brief  Fetch list of active requests (filtered by API path prefix if passed) and cancel their processing.
- 
- @param prefix Reference on string which represent specific API endpoint path prefix. If passed, all data 
-               tasks which is created against such API endpoint will be cancelled.
- 
- @since 4.6.2
+ * @brief Fetch list of active requests (filtered by API path prefix if passed) and cancel their
+ * processing.
+ *
+ * @param prefix String which represent specific API endpoint path prefix. If passed, all data tasks
+ *     which is created against such API endpoint will be cancelled.
+ *
+ * @since 4.6.2
  */
 - (void)cancelAllOperationsWithURLPrefix:(nullable NSString *)prefix;
 
 /**
- @brief  Invalidate network communication layer.
- 
- @since 4.1.1
+ * @brief Invalidate network communication layer.
+ *
+ * @since 4.1.1
  */
 - (void)invalidate;
 
 
-///------------------------------------------------
-/// @name Handlers
-///------------------------------------------------
+#pragma mark - Handlers
 
 #if TARGET_OS_IOS
-
 /**
- @brief      Handle \b PubNub client transition to inactive satate.
- @discussion Depending from network manager configuration it may request from system more time to complete 
-             already scheduled data tasks.
- 
- @since 4.5.0
+ * @brief Handle \b {PubNub} client transition to inactive state.
+ *
+ * @discussion Depending from network manager configuration it may request from system more time to
+ * complete already scheduled data tasks.
+ *
+ * @since 4.5.0
  */
 - (void)handleClientWillResignActive;
 
 /**
- @brief      Handle \b PubNub client transition to active satate.
- @discussion If network manager requested from system more time to complete tasks processing it will cancel 
-             this request.
- 
- @since 4.5.0
+ * @brief Handle \b {PubNub} client transition to active state.
+ *
+ * @discussion If network manager requested from system more time to complete tasks processing it
+ * will cancel this request.
+ *
+ * @since 4.5.0
  */
 - (void)handleClientDidBecomeActive;
 
 #endif // TARGET_OS_IOS
 
 
-///------------------------------------------------
-/// @name Operation information
-///------------------------------------------------
+#pragma mark - Operation information
 
 /**
- @brief  Calculate actual size of packet for passed \c operationType which will be sent to \b PubNub network.
- 
- @param operationType One of \b PNOperationType enum fields which specify for what kind of operation packet 
-                      size should be calculated.
- @param parameters    List of passed parameters which should be passed to URL builder.
- @param data          Data which can be pushed along with request to \b PubNub network if required.
- 
- @return Size of the packet which include request string, host, headers and HTTP post body.
- 
- @since 4.0
+ * @brief Calculate actual size of packet for passed \c operationType which will be sent to
+ * \b PubNub network.
+ *
+ * @param operationType One of \b {operation PNOperationType} enum fields which specify for what
+ *     kind of operation packet size should be calculated.
+ * @param parameters List of passed parameters which should be passed to URL builder.
+ * @param data Data which can be pushed along with request to \b PubNub network if required.
+ *
+ * @return Size of the packet which include request string, host, headers and HTTP post body.
  */
 - (NSInteger)packetSizeForOperation:(PNOperationType)operationType
-                     withParameters:(PNRequestParameters *)parameters data:(NSData *)data;
+                     withParameters:(PNRequestParameters *)parameters
+                               data:(NSData *)data;
 
 #pragma mark -
 

--- a/PubNub/Network/PNNetwork.m
+++ b/PubNub/Network/PNNetwork.m
@@ -1,7 +1,7 @@
 /**
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @since 4.0
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNNetwork.h"
 #import "NSURLSessionConfiguration+PNConfigurationPrivate.h"
@@ -26,38 +26,43 @@
 #pragma mark Types
 
 /**
- @brief  Definition for block which is used as NSURLSessionDataTask completion handler (passed during task 
-         creation.
- 
- @param data     Actual raw data which has been received from \b PubNub service in response.
- @param response HTTP response instance which hold metadata about response.
- @param error    Reference on error instance in case of any processing issues.
- 
- @since 4.0.2
+ * @brief Definition for block which is used as NSURLSessionDataTask completion handler (passed
+ * during task creation.
+ *
+ * @param data Actual raw data which has been received from \b PubNub service in response.
+ * @param response HTTP response instance which hold metadata about response.
+ * @param error Error instance in case of any processing issues.
+ *
+ * @since 4.0.2
  */
-typedef void(^NSURLSessionDataTaskCompletion)(NSData * _Nullable data, NSURLResponse * _Nullable response, 
+typedef void(^NSURLSessionDataTaskCompletion)(NSData * _Nullable data,
+                                              NSURLResponse * _Nullable response,
                                               NSError * _Nullable error);
 
 /**
- @brief  Definition for block which is used by \b PubNub SDK to process successfully completed request with
-         pre-processed response.
- 
- @param task           Reference on data load task which has been used to communicate with \b PubNub network.
- @param responseObject Serialized \b PubNub service response.
- 
- @since 4.0.2
+ * @brief Definition for block which is used by \b PubNub SDK to process successfully completed
+ * request with pre-processed response.
+ *
+ * @param task Reference on data load task which has been used to communicate with \b PubNub
+ *     network.
+ * @param responseObject Serialized \b PubNub service response.
+ *
+ * @since 4.0.2
  */
-typedef void(^NSURLSessionDataTaskSuccess)(NSURLSessionDataTask * _Nullable task, id _Nullable responseObject);
+typedef void(^NSURLSessionDataTaskSuccess)(NSURLSessionDataTask * _Nullable task,
+                                           id _Nullable responseObject);
 
 /**
- @brief  Definition for block which is used by \b PubNub SDK to process failed request.
- 
- @param task  Reference on data load task which has been used to communicate with \b PubNub network.
- @param error Reference on error instance in case of any processing issues.
- 
- @since 4.0.2
+ * @brief Definition for block which is used by \b PubNub SDK to process failed request.
+ *
+ * @param task Reference on data load task which has been used to communicate with \b PubNub
+ *     network.
+ * @param error Reference on error instance in case of any processing issues.
+ *
+ * @since 4.0.2
  */
-typedef void(^NSURLSessionDataTaskFailure)(NSURLSessionDataTask * _Nullable task, NSError * _Nullable error);
+typedef void(^NSURLSessionDataTaskFailure)(NSURLSessionDataTask * _Nullable task,
+                                           NSError * _Nullable error);
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -70,128 +75,120 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Information
 
 /**
- @brief  Stores reference on client for which this network manager provide functionality.
- 
- @since 4.0
+ * @brief Client for which this network manager provide functionality.
  */
 @property (nonatomic, weak) PubNub *client;
 
 /**
- @brief  Stores reference on \b PubNub client configuration which define network manager behavior as well.
- 
- @since 4.0
+ * @brief Configuration which define network manager behavior.
  */
 @property (nonatomic, strong) PNConfiguration *configuration;
 
 /**
- @brief  Stores reference on unique \b PubNub network manager instance identifier.
- 
- @since 4.4.1
+ * @brief Unique \b {PubNub} network manager instance identifier.
+ *
+ * @since 4.4.1
  */
 @property (nonatomic, copy) NSString *identifier;
 
 /**
- @brief      Stores whether \b PubNub network manager configured for long-poll request processing or not.
- @discussion This property taken into account when manager need to invalidate underlying \a NSURLSession and 
-             dictate whether all scheduled requests should be completed or terminated.
- 
- @since 4.0
+ * @brief Whether \b PubNub network manager configured for long-poll request processing or not.
+ *
+ * @discussion This property taken into account when manager need to invalidate underlying
+ * \a NSURLSession and dictate whether all scheduled requests should be completed or terminated.
  */
 @property (nonatomic, assign) BOOL forLongPollRequests;
 
 /**
- @brief      Stores value which should be as timeout interval for request.
- @discussion This property also used when session instance should be re-created.
- 
- @since 4.0.2
+ * @brief Session's request timeout interval.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, assign) NSTimeInterval requestTimeout;
 
 /**
- @brief      Stores value which should be as maximum simultaneous requests.
- @discussion This property also used when session instance should be re-created.
- 
- @since 4.0.2
+ * @brief Maximum simultaneous requests.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, assign) NSInteger maximumConnections;
 
-
 /**
- @brief  Stores reference on session instance which is used to send network requests.
- 
- @since 4.0.2
+ * @brief Session which is used to send network requests.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, strong, nullable) NSURLSession *session;
 
 /**
- @brief  Stores unique session identifier which is used by telemetry.
- 
- @since 4.6.1
+ * @brief Unique session identifier which is used by telemetry.
+ *
+ * @since 4.6.1
  */
 @property (nonatomic, copy) NSString *sessionIdentifier;
 
 /**
- @brief      Stores reference on data task completion block which should be used to notify caller about task 
-             completion.
- @discussion This property used along with background session in application extension execution context.
- 
- @since 4.5.4
+ * @brief Data task completion block which should be used to notify caller about task completion.
+ *
+ * @discussion Used along with background session in application extension execution context.
+ *
+ * @since 4.5.4
  */
 @property (nonatomic, nullable, copy) NSURLSessionDataTaskCompletion previousDataTaskCompletionHandler;
 
 /**
- @brief      Stores reference on object which is able to store received service response.
- @discussion This property used along with background session in application extension execution context.
- 
- @since 4.5.4
+ * @brief Object which is able to store received service response.
+ *
+ * @discussion Used along with background session in application extension execution context.
+ *
+ * @since 4.5.4
  */
 @property (nonatomic, nullable, strong) NSMutableData *fetchedData;
 
 /**
- @brief  Stores reference on base URL which should be appeanded with reasource path to perform network
-         request.
- 
- @since 4.0.2
+ * @brief Base URL which should be appended with resources path to perform network request.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, strong) NSURL *baseURL;
 
 /**
- @brief  Stores reference on serializer used to pre-process service responses.
- 
- @since 4.0.2
+ * @brief Serializer used to pre-process service responses.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, strong) PNNetworkResponseSerializer *serializer;
 
 /**
- @brief  Stores refeference on set of key/value pairs which is used in API endpoint path and common for all 
-         endpoints.
- 
- @since 4.5.4
+ * @brief Set of key/value pairs which is used in API endpoint path and common for all endpoints.
+ *
+ * @since 4.5.4
  */
 @property (nonatomic, strong) NSDictionary *defaultPathComponents;
 
 /**
- @brief  Stores refeference on set of key/value pairs which is used in API endpoint query and common for all 
-         endpoints.
- 
- @since 4.5.4
+ * @brief Set of key/value pairs which is used in API endpoint query and common for all endpoints.
+ *
+ * @since 4.5.4
  */
 @property (nonatomic, strong) NSDictionary *defaultQueryComponents;
 
 #if PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
 /**
- @brief      Stores reference on linkage of scheduled data task and it's operation type.
- @discussion NSURLSession metrics arrive through callbacs and there is no information about type of operation 
-             which has been processed by task. This map allow to link tasks to API operation type.
- 
+ * @brief Linkage of scheduled data task and it's operation type.
+ *
+ * @discussion \a NSURLSession metrics arrive through callbacks and there is no information about
+ * type of operation which has been processed by task. This map allow to link tasks to API operation
+ * type.
+ *
  @since 4.6.2
  */
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSNumber *> *dataTaskToOperationMap;
 #endif
 
 /**
- * @brief  Stores whether system version for which client is running doesn't support native metrics
- *         information gathering.
+ * @brief Whether system version for which client is running doesn't support native metrics
+ * information gathering or not.
  *
  * @since 4.7.5
  */
@@ -200,48 +197,50 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_IOS
 
 /**
- @brief      Stores reference on list of currently scheduled data tasks.
- @discussion List allow to get information about active data task synchronously at any moment 
-             (when \c NSURLSession allow to get this information only from block which will be scheduled on
-             processing queue).
- 
- @since 4.5.0
+ * @brief Stores reference on list of currently scheduled data tasks.
+ *
+ * @discussion List allow to get information about active data task synchronously at any moment
+ * (when \a NSURLSession allow to get this information only from block which will be scheduled on
+ * processing queue).
+ *
+ * @since 4.5.0
  */
 @property (nonatomic, strong) NSMutableArray<NSURLSessionDataTask *> *scheduledDataTasks;
 
 /**
- @brief  Stores reference on identifier which has been used to request from system more time to complete
-         pending tasks when client resign active.
- 
- @since 4.5.0
+ * @brief Identifier which has been used to request from system more time to complete pending tasks
+ * when client resign active.
+ *
+ * @since 4.5.0
  */
 @property (nonatomic, assign) UIBackgroundTaskIdentifier tasksCompletionIdentifier;
 
 #endif // TARGET_OS_IOS
 
 /**
- @brief  Stores reference on queue which should be used by session to call callbacks and completion blocks on
-         \c PNNetwork instance.
- 
- @since 4.0.2
+ * @brief Queue which should be used by session to call callbacks and completion blocks on
+ * \b {PNNetwork} instance.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, strong) NSOperationQueue *delegateQueue;
 
 /**
- @brief      Stores reference on queue which is used to call \b PNNetwork response processing on another 
-             queue.
- @discussion Response processing involves data parsing which is most time consuming operation. Dispatching 
-             response processing on side queue allow to keep requests sending unaffected by processing delays.
- 
- @since 4.0.2
+ * @brief Queue which is used to call \b {PNNetwork} response processing on another queue.
+ *
+ * @discussion Response processing involves data parsing which is most time consuming
+ * operation. Dispatching response processing on side queue allow to keep requests sending
+ * unaffected by processing delays.
+ *
+ * @since 4.0.2
  */
 @property (nonatomic, strong) dispatch_queue_t processingQueue;
 
 /**
- @brief  Stores reference on spin-lock which is used to protect access to session instance which can be 
-         changed at any moment (invalidated instances can't be used and SDK should instantiate new instance).
- 
- @since 4.0.2
+ * @brief Spin-lock which is used to protect access to session instance which can be  changed at any
+ * moment (invalidated instances can't be used and SDK should instantiate new instance).
+ *
+ * @since 4.0.2
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
@@ -252,67 +251,64 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Initialization and Configuration
 
 /**
- @brief  Initialize \b PubNub network manager with predefined options.
- 
- @param client             Reference on client for which this network manager is creating.
- @param timeout            Maximum time which manager should wait for response on request.
- @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
- @param longPollEnabled    Whether \b PubNub network manager should be configured for long-poll requests or 
-                           not. This option affect the way how network manager handle reset.
- 
- @return 4.0
- 
- @since Initialized and ready to use \b PubNub network manager.
+ * @brief Initialize \b PubNub network manager with predefined options.
+ *
+ * @param client Client for which this network manager is creating.
+ * @param timeout Maximum time which manager should wait for response on request.
+ * @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
+ * @param longPollEnabled Whether \b PubNub network manager should be configured for long-poll
+ * requests or not. This option affect the way how network manager handle reset.
+ *
+ * @since Initialized and ready to use \b PubNub network manager.
  */
-- (instancetype)initForClient:(PubNub *)client requestTimeout:(NSTimeInterval)timeout
-           maximumConnections:(NSInteger)maximumConnections longPoll:(BOOL)longPollEnabled;
+- (instancetype)initForClient:(PubNub *)client
+               requestTimeout:(NSTimeInterval)timeout
+           maximumConnections:(NSInteger)maximumConnections
+                     longPoll:(BOOL)longPollEnabled;
 
 
 #pragma mark - Request helper
 
 /**
- @brief  Append additional parameters general for all requests.
- 
- @param parameters Reference on request parameters instance which should be updated with required set of 
-                   parameters.
- 
- @since 4.0
+ * @brief Append additional parameters general for all requests.
+ *
+ * @param parameters Parameters which should be updated with required set of parameters.
  */
 - (void)appendRequiredParametersTo:(PNRequestParameters *)parameters;
 
 /**
- @brief  Compose objects which is used to provide default values for requests.
- 
- @since 4.5.4
+ * @brief Compose objects which is used to provide default values for requests.
+ *
+ * @since 4.5.4
  */
 - (void)prepareRequiredParameters;
 
 /**
- @brief  Construct URL request suitable to send POST request (if required).
- 
- @param requestURL Reference on complete remote resource URL which should be used for request.
- @param method     Reference on string with HTTP method which should be used to send request.
- @param postData   Reference on data which should be sent as POST body (if passed).
- 
- @return Constructed and ready to use request object.
- 
- @since 4.0
+ * @brief Construct URL request suitable to send POST request (if required).
+ *
+ * @param requestURL Reference on complete remote resource URL which should be used for request.
+ * @param method Reference on string with HTTP method which should be used to send request.
+ * @param postData Reference on data which should be sent as POST body (if passed).
+ *
+ * @return Constructed and ready to use request object.
+ *
+ * @since 4.0
  */
-- (NSURLRequest *)requestWithURL:(NSURL *)requestURL method:(NSString *)method data:(NSData *)postData;
+- (NSURLRequest *)requestWithURL:(NSURL *)requestURL
+                          method:(NSString *)method
+                            data:(NSData *)postData;
 
 /**
- @brief  Construct data task which should be used to process provided request.
- 
- @param request       Reference on request which should be issued with data task to NSURL session.
- @param operationType One of \b PNOperationType enumerator fields which describe what kind of operation will 
-                      be performed by passed \c request.
- @param success       Reference on data task success handling block which will be called by network manager.
- @param failure       Reference on data task processing failure handling block which will be called by network 
-                      manager.
- 
- @return Constructed and ready to use data task.
- 
- @since 4.0
+ * @brief Construct data task which should be used to process provided request.
+ *
+ * @param request Request which should be issued with data task to NSURL session.
+ * @param operationType One of \b {operation PNOperationType} enumerator fields which describe what
+ *     kind of operation will be performed by passed \c request.
+ * @param success Data task success handling block which will be called by network manager.
+ * @param failure Data task processing failure handling block which will be called by network
+ *     manager.
+ *
+ * @return Constructed and ready to use data task.
  */
 - (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request 
                                  forOperation:(PNOperationType)operationType
@@ -323,73 +319,64 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Request processing
 
 /**
- @brief  Check whether specified operation is expecting result object or not.
- 
- @param operation Operation type against which check should be performed.
- 
- @return \c YES in case if this type of operation is expecting to receive in result object.
- 
- @since 4.0
+ * @brief Check whether specified operation is expecting result object or not.
+ *
+ * @param operation Operation type against which check should be performed.
+ *
+ * @return \c YES in case if this type of operation is expecting to receive in result object.
  */
 - (BOOL)operationExpectResult:(PNOperationType)operation;
 
 /**
- @brief  Retrieve reference on parser class which can be used to process received data for \c operation
- 
- @param operation Operation type for which suitable parser should be found.
- 
- @return Parser class which conforms to \b PNParser protocol.
- 
- @since 4.0
+ * @brief Retrieve parser class which can be used to process received data for \c operation
+ *
+ * @param operation Operation type for which suitable parser should be found.
+ *
+ * @return Parser class which conforms to \b {PNParser} protocol.
  */
 - (nullable Class <PNParser>)parserForOperation:(PNOperationType)operation;
 
 /**
- @brief  Retrieve reference on class which can be used to represent request processing results.
- 
- @param operation Type of operation which is expecting response from \b PubNub network.
- 
- @return Target class which should be used instead of \b PNResult (if non will be found \b PNResult).
- 
- @since 4.0
+ * @brief Retrieve class which can be used to represent request processing results.
+ *
+ * @param operation Type of operation which is expecting response from \b PubNub network.
+ *
+ * @return Target class which should be used instead of \b {PNResult} (if non will be found
+ * \b {PNResult}).
  */
 - (Class)resultClassForOperation:(PNOperationType)operation;
 
 /**
- @brief  Retrieve reference on class which can be used to represent request processing status.
- 
- @param operation Type of operation which is expecting status from \b PubNub network.
- 
- @return Target class which should be used instead of \b PNStatus (if non will be found \b PNStatus).
- 
- @since 4.0
+ * @brief Retrieve class which can be used to represent request processing status.
+ *
+ * @param operation Type of operation which is expecting status from \b PubNub network.
+ *
+ * @return Target class which should be used instead of \b {PNStatus} (if non will be found
+ * \b {PNStatus}).
  */
 - (Class)statusClassForOperation:(PNOperationType)operation;
 
 /**
- @brief  Try process \c data using parser suitable for operation for which data has been received.
- 
- @param data       Reference on data which has been received from \b PubNub network in response for operation.
- @param parser     Reference on class which should be used to parse data.
- @param block      Reference on block which should be called back at the end of parsing process.
- 
- @since 4.0
+ * @brief Try process \c data using parser suitable for operation for which data has been received.
+ *
+ * @param data Data which has been received from \b PubNub network in response for operation.
+ * @param parser Class which should be used to parse data.
+ * @param block Block which should be called back at the end of parsing process.
  */
-- (void)parseData:(nullable id)data withParser:(Class <PNParser>)parser
+- (void)parseData:(nullable id)data
+       withParser:(Class <PNParser>)parser
        completion:(void(^)(NSDictionary * _Nullable parsedData, BOOL parseError))block;
 
 #if TARGET_OS_IOS
 
 /**
- @brief  Complete processing of tasks which has been scheduled but not completelly processed before \b PubNub 
-         client resign active state.
- 
- @since 4.5.0
- 
- @param dataTasks    List of \c NSURLSession data tasks which didn't completed before \b PubNub client resign
-                     active state.
- @param onCompletion Whether list processed after another data task completed or right \b PubNub after client
-                     resign active state.
+ * @brief Complete processing of tasks which has been scheduled but not completely processed before
+ * \b PubNub client resign active state.
+ *
+ * @param dataTasks List of \a NSURLSession data tasks which didn't completed before \b {PubNub}
+ *     client resign active state.
+ * @param onCompletion Whether list processed after another data task completed or right \b {PubNub}
+ *     after client resign active state.
  */
 - (void)processIncompleteBeforeClientResignActiveTasks:(NSArray<NSURLSessionDataTask *> *)dataTasks
                                   onDataTaskCompletion:(BOOL)onCompletion;
@@ -400,58 +387,51 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Session constructor
 
 /**
- @brief  Complete AFNetworking/NSURLSession instantiation and configuration.
- 
- @param timeout            Maximum time which manager should wait for response on request.
- @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
- 
- @since 4.0
+ * @brief Complete \a NSURLSession instantiation and configuration.
+ *
+ * @param timeout Maximum time which manager should wait for response on request.
+ * @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
  */
 - (void)prepareSessionWithRequestTimeout:(NSTimeInterval)timeout
                       maximumConnections:(NSInteger)maximumConnections;
 
 /**
- @brief  Construct base NSURL session configuration.
- 
- @param timeout            Maximum time which manager should wait for response on request.
- @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
- 
- @return Constructed and ready to use session configuration.
- 
- @since 4.0
+ * @brief Construct base \a NSURL session configuration.
+ *
+ * @param timeout Maximum time which manager should wait for response on request.
+ * @param maximumConnections Maximum simultaneously connections (requests) which can be opened.
+ *
+ * @return Constructed and ready to use session configuration.
  */
 - (NSURLSessionConfiguration *)configurationWithRequestTimeout:(NSTimeInterval)timeout
                                             maximumConnections:(NSInteger)maximumConnections;
 
 /**
- @brief  Construct qaueue on which session will call delegate callbacks and completion blocks.
- 
- @param configuration Reference on session configuration instance which should be used to complete queue 
-                      configuration.
- 
- @return Initialized and ready to use operaiton queue.
- 
- @since 4.0.2
+ * @brief Construct queue on which session will call delegate callbacks and completion blocks.
+ *
+ * @param configuration Session configuration which should be used to complete queue configuration.
+ *
+ * @return Initialized and ready to use operation queue.
+ *
+ * @since 4.0.2
  */
 - (NSOperationQueue *)operationQueueWithConfiguration:(NSURLSessionConfiguration *)configuration;
 
 /**
- @brief  Construct NSURL session manager used to communicate with \b PubNub network.
- 
- @param configuration Reference on complete configuration which should be applied to NSURL session.
- 
- @return Constructed and ready to use NSURL session manager instance.
- 
- @since 4.0
+ * @brief Construct \a NSURL session manager used to communicate with \b PubNub network.
+ *
+ * @param configuration Complete configuration which should be applied to \a NSURL session.
+ *
+ * @return Constructed and ready to use \a NSURL session manager instance.
  */
 - (NSURLSession *)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration;
 
 /**
- @brief  Allow to construct base URL basing on network configuraiton.
- 
- @return Ready to use service URL.
- 
- @since 4.0.2
+ * @brief Allow to construct base URL basing on network configuration.
+ *
+ * @return Ready to use service URL.
+ *
+ * @since 4.0.2
  */
 - (NSURL *)requestBaseURL;
 
@@ -459,87 +439,93 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Handlers
 
 /**
- @brief      Serialize service response or handle error.
- @discussion Depending on received metadata and data code will call passed success or failure blocks after 
-             serialization process completion on secondary queue.
- 
- @param data         Reference on RAW data received from service.
- @param task         Reference on data task which has been used to communicate with \b PubNub network.
- @param requestError Reference on data/request processing error.
- @param success      Reference on data task success handling block which will be called by network manager.
- @param failure      Reference on data task processing failure handling block which will be called by network 
-                     manager.
- 
- @since 4.0
+ * @brief Serialize service response or handle error.
+ *
+ * @discussion Depending on received metadata and data code will call passed success or failure
+ * blocks after serialization process completion on secondary queue.
+ *
+ * @param data RAW data received from service.
+ * @param task Data task which has been used to communicate with \b PubNub network.
+ * @param requestError Data / request processing error.
+ * @param success Data task success handling block which will be called by network manager.
+ * @param failure Data task processing failure handling block which will be called by network
+ *     manager.
  */
-- (void)handleData:(nullable NSData *)data loadedWithTask:(nullable NSURLSessionDataTask *)task
-             error:(nullable NSError *)requestError usingSuccess:(NSURLSessionDataTaskSuccess)success
+- (void)handleData:(nullable NSData *)data
+    loadedWithTask:(nullable NSURLSessionDataTask *)task
+             error:(nullable NSError *)requestError
+      usingSuccess:(NSURLSessionDataTaskSuccess)success
            failure:(NSURLSessionDataTaskFailure)failure;
 
 /**
- @brief      Handle successful operation processing completion.
- @discussion Called when request for \b PubNub network successfully completed processing.
- 
- @param operation      Reference on operation type for which actual network request has been sent to \b PubNub
-                       network.
- @param task           Reference on data task which has been used to deliver operation to \b PubNub network.
- @param responseObject Reference on pre-processed \b PubNub network response (de-serialized JSON).
- @param block          Depending on operation type it can be \b PNResultBlock, \b PNStatusBlock or
-                       \b PNCompletionBlock blocks.`
- 
- @since 4.0
+ * @brief Handle successful operation processing completion.
+ *
+ * @discussion Called when request for \b PubNub network successfully completed processing.
+ *
+ * @param operation Operation type for which actual network request has been sent to \b PubNub
+ *     network.
+ * @param task Data task which has been used to deliver operation to \b PubNub network.
+ * @param responseObject Reference on pre-processed \b PubNub network response (de-serialized JSON).
+ * @param block Depending on operation type it can be \b {PNResultBlock}, \b {PNStatusBlock} or
+ *                       \b {PNCompletionBlock} blocks.
  */
-- (void)handleOperation:(PNOperationType)operation taskDidComplete:(nullable NSURLSessionDataTask *)task
-               withData:(nullable id)responseObject completionBlock:(id)block;
+- (void)handleOperation:(PNOperationType)operation
+        taskDidComplete:(nullable NSURLSessionDataTask *)task
+               withData:(nullable id)responseObject
+        completionBlock:(id)block;
 
 /**
- @brief      Handle operation failure.
- @discussion Called when request for \b PubNub network did fail to process or service respond with error.
- 
- @param operation Reference on operation type for which actual network request has been sent to \b PubNub 
-                  network.
- @param task      Reference on data task which has been used to deliver operation to \b PubNub network.
- @param error     Reference on \a NSError instance which describe what exactly went wrong during operation 
-                  processing.
- @param block     Depending on operation type it can be \b PNResultBlock, \b PNStatusBlock or
-                  \b PNCompletionBlock blocks.
- 
- @since 4.0
+ * @brief Handle operation failure.
+ *
+ * @discussion Called when request for \b PubNub network did fail to process or service respond with
+ * error.
+ *
+ * @param operation Operation type for which actual network request has been sent to \b PubNub
+ *     network.
+ * @param task Data task which has been used to deliver operation to \b PubNub network.
+ * @param error \a NSError which describe what exactly went wrong during operation processing.
+ * @param block Depending on operation type it can be \b {PNResultBlock}, \b {PNStatusBlock} or
+ *     \b {PNCompletionBlock} blocks.
  */
-- (void)handleOperation:(PNOperationType)operation taskDidFail:(nullable NSURLSessionDataTask *)task
-              withError:(nullable NSError *)error completionBlock:(id)block;
+- (void)handleOperation:(PNOperationType)operation
+            taskDidFail:(nullable NSURLSessionDataTask *)task
+              withError:(nullable NSError *)error
+        completionBlock:(id)block;
 
 /**
- @brief      Pre-processed service response handler.
- @discussion This method actually build result and status objects basing on pre-processed service response.
- 
- @param data      Pre-processed data, using parser.
- @param task      Reference on data task which has been used to communicate with \b PubNub network.
- @param operation One of \b PNOperationType enum fields which clarify what kind of request has been done to
-                  \b PubNub network and for which response has been processed.
- @param isError   Whether pre-processed data represent error or not.
- @param error     Reference on data/request processing error.
- @param block     Block which should be called at the end of pre-processed data wrapping into objects.
- 
- @since 4.0
+ * @brief Pre-processed service response handler.
+ *
+ * @discussion This method actually build result and status objects basing on pre-processed service
+ * response.
+ *
+ * @param data Pre-processed data, using parser.
+ * @param task Data task which has been used to communicate with \b PubNub network.
+ * @param operation One of \b {operation PNOperationType} enum fields which clarify what kind of
+ *     request has been done to \b PubNub network and for which response has been processed.
+ * @param isError Whether pre-processed data represent error or not.
+ * @param error Data / request processing error.
+ * @param block Block which should be called at the end of pre-processed data wrapping into objects.
  */
-- (void)handleParsedData:(nullable NSDictionary *)data loadedWithTask:(nullable NSURLSessionDataTask *)task
-            forOperation:(PNOperationType)operation parsedAsError:(BOOL)isError
-         processingError:(nullable NSError *)error completionBlock:(id)block;
+- (void)handleParsedData:(nullable NSDictionary *)data
+          loadedWithTask:(nullable NSURLSessionDataTask *)task
+            forOperation:(PNOperationType)operation
+           parsedAsError:(BOOL)isError
+         processingError:(nullable NSError *)error
+         completionBlock:(id)block;
 
 /**
- @brief  Used to handle prepared objects and pass them to the code.
- 
- @param operation One of \b PNOperationType enum fields which clarify for what kind of operation objects has
-                  been created.
- @param result    Reference on object which stores useful server response.
- @param status    Reference on request processing result (can be error or ACK response).
- @param block     Block which should be called at the end of pre-processed data wrapping into objects.
- 
- @since 4.0
+ * @brief Used to handle prepared objects and pass them to the code.
+ *
+ * @param operation One of \b {operation PNOperationType} enum fields which clarify for what kind of
+ *     operation objects has been created.
+ * @param result Object which stores useful server response.
+ * @param status Request processing result (can be error or ACK response).
+ * @param block Block which should be called at the end of pre-processed data wrapping into objects.
  */
-- (void)handleOperation:(PNOperationType)operation processingCompletedWithResult:(nullable PNResult *)result
-                 status:(nullable PNStatus *)status completionBlock:(id)block;
+- (void)handleOperation:(PNOperationType)operation
+    processingCompletedWithResult:(nullable PNResult *)result
+                           status:(nullable PNStatus *)status
+                  completionBlock:(id)block;
 
 
 #pragma mark - Misc
@@ -547,23 +533,24 @@ NS_ASSUME_NONNULL_BEGIN
 #if TARGET_OS_IOS
 
 /**
- @brief  Check whether there \c operation is in the list of passed \c tasks. 
- 
- @since 4.5.0
- 
- @param operation One of \b PNOperationType enum fields which is used during search.
- @param tasks     List of currently scheduled and pending / executing data tasks among which should be found 
-                  reference on \c operation.
- 
- @return \c YES in case if \c operation has been found in list of passed \c tasks.
+ * @brief Check whether there \c operation is in the list of passed \c tasks.
+ *
+ * @param operation One of \b {operation PNOperationType} enum fields which is used during search.
+ * @param tasks List of currently scheduled and pending / executing data tasks among which should be
+ *     found reference on \c operation.
+ *
+ * @return \c YES in case if \c operation has been found in list of passed \c tasks.
+ *
+ * @since 4.5.0
  */
-- (BOOL)hasOperation:(PNOperationType)operation inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks;
+- (BOOL)hasOperation:(PNOperationType)operation
+         inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks;
 
 /**
- @brief  Depending on current network manager state it may require to complete currently active tasks 
-         completion from background execution context.
- 
- @since 4.5.0
+ * @brief Depending on current network manager state it may require to complete currently active
+ * tasks completion from background execution context.
+ *
+ * @since 4.5.0
  */
 - (void)endBackgroundTasksCompletionIfRequired;
 
@@ -571,14 +558,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
 /**
- @brief  Compose string with important request metrics.
- 
- @since 4.5.13
- 
- @param transaction   Reference on object which contain useful metrics which can be used in debug purposes.
- @param isRedirection Whether metrics data has been provided for non-original request.
- 
- @return String with request metrics which can be printed into PubNub's log file/Xcode console.
+ * @brief Compose string with important request metrics.
+ *
+ * @param transaction Object which contain useful metrics which can be used in debug purposes.
+ * @param isRedirection Whether metrics data has been provided for non-original request.
+ *
+ * @return String with request metrics which can be printed into PubNub's log file / Xcode console.
+ *
+ * @since 4.5.13
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
@@ -588,9 +575,10 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 /**
- @brief  Print out any session configuration instance customizations which has been done by developer.
- 
- @since 4.4.0
+ * @brief Print out any session configuration instance customizations which has been done by
+ * developer.
+ *
+ * @since 4.4.0
  */
 - (void)printIfRequiredSessionCustomizationInformation;
 
@@ -609,22 +597,26 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Initialization and Configuration
 
-+ (instancetype)networkForClient:(PubNub *)client requestTimeout:(NSTimeInterval)timeout
-              maximumConnections:(NSInteger)maximumConnections longPoll:(BOOL)longPollEnabled {
++ (instancetype)networkForClient:(PubNub *)client
+                  requestTimeout:(NSTimeInterval)timeout
+              maximumConnections:(NSInteger)maximumConnections
+                        longPoll:(BOOL)longPollEnabled {
     
-    return [[self alloc] initForClient:client requestTimeout:timeout maximumConnections:maximumConnections 
+    return [[self alloc] initForClient:client
+                        requestTimeout:timeout
+                    maximumConnections:maximumConnections
                               longPoll:longPollEnabled];
 }
 
-- (instancetype)initForClient:(PubNub *)client requestTimeout:(NSTimeInterval)timeout
-           maximumConnections:(NSInteger)maximumConnections longPoll:(BOOL)longPollEnabled {
-    
-    // Check whether initialization was successful or not.
+- (instancetype)initForClient:(PubNub *)client
+               requestTimeout:(NSTimeInterval)timeout
+           maximumConnections:(NSInteger)maximumConnections
+                     longPoll:(BOOL)longPollEnabled {
+
     if ((self = [super init])) {
-        
         _client = client;
-        [_client.logger enableLogLevel:(PNRequestLogLevel|PNInfoLogLevel)];
-        _metricsNotSupportedByOS = pn_operating_system_version_is_lower_than(PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE_SINCE);
+        NSString *metricsMinVersion = PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE_SINCE;
+        _metricsNotSupportedByOS = pn_operating_system_version_is_lower_than(metricsMinVersion);
         _configuration = client.configuration;
         _forLongPollRequests = longPollEnabled;
 #if TARGET_OS_IOS
@@ -632,13 +624,15 @@ NS_ASSUME_NONNULL_END
         _tasksCompletionIdentifier = UIBackgroundTaskInvalid;
 #endif // TARGET_OS_IOS
         _identifier = [[NSString stringWithFormat:@"com.pubnub.network.%p", self] copy];
+        _processingQueue = dispatch_queue_create([_identifier UTF8String],
+                                                 DISPATCH_QUEUE_CONCURRENT);
 
-        _processingQueue = dispatch_queue_create([_identifier UTF8String], DISPATCH_QUEUE_CONCURRENT);
         if (@available(macOS 10.10, iOS 8.0, *)) {
             if (_configuration.applicationExtensionSharedGroupIdentifier) {
                 _processingQueue = dispatch_get_main_queue();
             }
         }
+
 #if PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
         _dataTaskToOperationMap = [NSMutableDictionary new];
 #endif // PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
@@ -648,6 +642,8 @@ NS_ASSUME_NONNULL_END
 #pragma clang diagnostic ignored "-Wpartial-availability"
         _lock = OS_UNFAIR_LOCK_INIT;
 #pragma clang diagnostic pop
+
+        [_client.logger enableLogLevel:(PNRequestLogLevel | PNInfoLogLevel)];
         [self prepareRequiredParameters];
         [self prepareSessionWithRequestTimeout:timeout maximumConnections:maximumConnections];
     }
@@ -663,14 +659,14 @@ NS_ASSUME_NONNULL_END
     [parameters addPathComponents:self.defaultPathComponents];
     [parameters addQueryParameters:self.defaultQueryComponents];
     [parameters addQueryParameters:[self.client.telemetryManager operationsLatencyForRequest]];
-    
-    // In case if we client used from tests environment unique request identifier should be excluded from
-    // default query components.
+
     static BOOL isTestEnvironment;
     static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ isTestEnvironment = NSClassFromString(@"XCTestExpectation") != nil; });
+    dispatch_once(&onceToken, ^{
+        isTestEnvironment = NSClassFromString(@"XCTestExpectation") != nil;
+    });
+
     if (!isTestEnvironment) {
-        
         [parameters addQueryParameter:[[NSUUID UUID] UUIDString] forFieldName:@"requestid"];
     }
 }
@@ -685,24 +681,28 @@ NS_ASSUME_NONNULL_END
         @"instanceid": self.client.instanceID,
         @"pnsdk":[NSString stringWithFormat:@"PubNub-%@%%2F%@", kPNClientName, kPNLibraryVersion]
     } mutableCopy];
+
     if (self.configuration.authKey.length) { 
         queryComponents[@"auth"] = [PNString percentEscapedString:self.configuration.authKey];
     }
+
     _defaultQueryComponents = [queryComponents copy];
 }
 
-- (NSURLRequest *)requestWithURL:(NSURL *)requestURL method:(NSString *)method data:(NSData *)postData {
+- (NSURLRequest *)requestWithURL:(NSURL *)requestURL
+                          method:(NSString *)method
+                            data:(NSData *)postData {
     
     NSURL *fullURL = [NSURL URLWithString:requestURL.absoluteString relativeToURL:self.baseURL];
     NSMutableURLRequest *httpRequest = [NSMutableURLRequest requestWithURL:fullURL];
     httpRequest.HTTPMethod = method;
+
     pn_lock(&_lock, ^{
-        
         httpRequest.cachePolicy = self.session.configuration.requestCachePolicy;
         httpRequest.allHTTPHeaderFields = self.session.configuration.HTTPAdditionalHeaders;
     });
+
     if (postData) {
-        
         NSMutableDictionary *allHeaders = [httpRequest.allHTTPHeaderFields mutableCopy];
         [allHeaders addEntriesFromDictionary:@{@"Content-Encoding":@"gzip",
                                                @"Content-Type":@"application/json;charset=UTF-8",
@@ -719,21 +719,29 @@ NS_ASSUME_NONNULL_END
                                  forOperation:(PNOperationType)operationType
                                       success:(NSURLSessionDataTaskSuccess)success
                                       failure:(NSURLSessionDataTaskFailure)failure {
-    
+
+    NSURLSessionDataTaskCompletion handler = nil;
     __block NSURLSessionDataTask *task = nil;
     __weak __typeof(self) weakSelf = self;
-    NSURLSessionDataTaskCompletion handler = ^(NSData *data, NSURLResponse *response, NSError *error) {
+    handler = ^(NSData *data, NSURLResponse *response, NSError *error) {
         if (self.isMetricsNotSupportByOS) {
-            NSString *taskIdentifier = [self.sessionIdentifier stringByAppendingString:@(task.taskIdentifier).stringValue];
-            [weakSelf.client.telemetryManager stopLatencyMeasureFor:operationType withIdentifier:taskIdentifier];
+            NSString *taskIdentifier = @(task.taskIdentifier).stringValue;
+            NSString *identifier = [self.sessionIdentifier stringByAppendingString:taskIdentifier];
+
+            [weakSelf.client.telemetryManager stopLatencyMeasureFor:operationType
+                                                     withIdentifier:identifier];
         }
 
-        [weakSelf handleData:data loadedWithTask:task error:(error?: task.error)
-                usingSuccess:success failure:failure];
+        [weakSelf handleData:data
+              loadedWithTask:task
+                       error:(error ?: task.error)
+                usingSuccess:success
+                     failure:failure];
     };
-    pn_lock(&_lock, ^{
 
+    pn_lock(&_lock, ^{
         BOOL isApplicationExtension = NO;
+
         if (@available(macOS 10.10, iOS 8.0, *)) {
             isApplicationExtension = self->_configuration.applicationExtensionSharedGroupIdentifier != nil;
         }
@@ -742,8 +750,9 @@ NS_ASSUME_NONNULL_END
             self.previousDataTaskCompletionHandler = handler;
             self.fetchedData = [NSMutableData new];
             task = [self.session dataTaskWithRequest:request];
+        } else {
+            task = [self.session dataTaskWithRequest:request completionHandler:[handler copy]];
         }
-        else { task = [self.session dataTaskWithRequest:request completionHandler:[handler copy]]; }
         
 #if TARGET_OS_IOS
         if (self.configuration.applicationExtensionSharedGroupIdentifier == nil && 
@@ -764,15 +773,15 @@ NS_ASSUME_NONNULL_END
     
     static NSArray *_resultExpectingOperations;
     static dispatch_once_t onceToken;
+
     dispatch_once(&onceToken, ^{
-        
         _resultExpectingOperations = @[
                    @(PNHistoryOperation), @(PNHistoryForChannelsOperation), @(PNWhereNowOperation), 
                    @(PNHereNowGlobalOperation), @(PNHereNowForChannelOperation), 
-                   @(PNHereNowForChannelGroupOperation), @(PNStateForChannelOperation), 
-                   @(PNStateForChannelGroupOperation), @(PNChannelGroupsOperation), 
-                   @(PNChannelsForGroupOperation), @(PNPushNotificationEnabledChannelsOperation), 
-                   @(PNTimeOperation)];
+                   @(PNHereNowForChannelGroupOperation), @(PNGetStateOperation),
+                   @(PNStateForChannelOperation), @(PNStateForChannelGroupOperation),
+                   @(PNChannelGroupsOperation), @(PNChannelsForGroupOperation),
+                   @(PNPushNotificationEnabledChannelsOperation), @(PNTimeOperation)];
     });
     
     return [_resultExpectingOperations containsObject:@(operation)];
@@ -782,22 +791,26 @@ NS_ASSUME_NONNULL_END
     
     static NSDictionary *_parsers;
     static dispatch_once_t onceToken;
+
     dispatch_once(&onceToken, ^{
-        
-        // Registering known PubNub service response parsers.
         NSArray<NSString *> *parserNames = @[
-            @"PNChannelGroupAuditionParser", @"PNChannelGroupModificationParser", @"PNClientStateParser", 
-            @"PNErrorParser", @"PNHeartbeatParser", @"PNHistoryParser", @"PNMessageDeleteParser",
-            @"PNLeaveParser", @"PNMessagePublishParser", @"PNPresenceHereNowParser",
-            @"PNPresenceWhereNowParser", @"PNPushNotificationsAuditParser",
-            @"PNPushNotificationsStateModificationParser", @"PNSubscribeParser",@"PNTimeParser"];
+            @"PNChannelGroupAuditionParser", @"PNChannelGroupModificationParser",
+            @"PNClientStateParser", @"PNErrorParser", @"PNHeartbeatParser", @"PNHistoryParser",
+            @"PNMessageDeleteParser", @"PNLeaveParser", @"PNMessagePublishParser",
+            @"PNPresenceHereNowParser", @"PNPresenceWhereNowParser",
+            @"PNPushNotificationsAuditParser", @"PNPushNotificationsStateModificationParser",
+            @"PNSubscribeParser",@"PNTimeParser"];
         NSMutableDictionary *parsers = [NSMutableDictionary new];
+
         for (NSString *className in parserNames) {
-            
             Class<PNParser> class = NSClassFromString(className);
             NSArray<NSNumber *> *operations = [class operations];
-            for (NSNumber *operationType in operations) { parsers[operationType] = class; }
+
+            for (NSNumber *operationType in operations) {
+                parsers[operationType] = class;
+            }
         }
+
         _parsers = [parsers copy];
     });
     
@@ -808,7 +821,6 @@ NS_ASSUME_NONNULL_END
     
     Class class = [PNResult class];
     if (PNOperationResultClasses[operation]) {
-        
         class = NSClassFromString(PNOperationResultClasses[operation]);
     }
     
@@ -819,102 +831,112 @@ NS_ASSUME_NONNULL_END
     
     Class class = [PNStatus class];
     if (PNOperationStatusClasses[operation]) {
-        
         class = NSClassFromString(PNOperationStatusClasses[operation]);
     }
     
     return class;
 }
 
-- (void)processOperation:(PNOperationType)operationType withParameters:(PNRequestParameters *)parameters 
-                    data:(NSData *)data completionBlock:(id)block {
+- (void)processOperation:(PNOperationType)operationType
+          withParameters:(PNRequestParameters *)parameters
+                    data:(NSData *)data
+         completionBlock:(id)block {
     
     [self appendRequiredParametersTo:parameters];
     NSURL *requestURL = [PNURLBuilder URLForOperation:operationType withParameters:parameters];
+
     if (requestURL) {
-        
         PNLogRequest(self.client.logger, @"<PubNub::Network> %@ %@", parameters.HTTPMethod,
-                     requestURL.absoluteString);
+            requestURL.absoluteString);
         
         __weak __typeof(self) weakSelf = self;
-        NSURLRequest *request = [self requestWithURL:requestURL method:parameters.HTTPMethod data:data];
-        NSURLSessionDataTask *task = [self dataTaskWithRequest:request forOperation:operationType
+        NSURLRequest *request = [self requestWithURL:requestURL
+                                              method:parameters.HTTPMethod
+                                                data:data];
+        NSURLSessionDataTask *task = [self dataTaskWithRequest:request
+                                                  forOperation:operationType
                                                        success:^(NSURLSessionDataTask *completedTask,
                                                                  id responseObject) {
                                                            
-            [weakSelf handleOperation:operationType taskDidComplete:completedTask withData:responseObject
+            [weakSelf handleOperation:operationType
+                      taskDidComplete:completedTask
+                             withData:responseObject
                       completionBlock:block];
         }
-                                                       failure:^(NSURLSessionDataTask *failedTask, id error) {
+                                                       failure:^(NSURLSessionDataTask *failedTask,
+                                                                 id error) {
 
-            [weakSelf handleOperation:operationType taskDidFail:failedTask withError:error
+            [weakSelf handleOperation:operationType
+                          taskDidFail:failedTask
+                            withError:error
                       completionBlock:block];
         }];
-        NSString *taskIdentifier = [self.sessionIdentifier stringByAppendingString:@(task.taskIdentifier).stringValue];
+
+        NSString *taskIdentifier = @(task.taskIdentifier).stringValue;
+        NSString *identifier = [self.sessionIdentifier stringByAppendingString:taskIdentifier];
+
         if (self.isMetricsNotSupportByOS) {
-            [self.client.telemetryManager startLatencyMeasureFor:operationType withIdentifier:taskIdentifier];
+            [self.client.telemetryManager startLatencyMeasureFor:operationType
+                                                  withIdentifier:identifier];
         } else {
 #if PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
-            pn_lock(&_lock, ^{ self.dataTaskToOperationMap[taskIdentifier] = @(operationType); });
+            pn_lock(&_lock, ^{
+                self.dataTaskToOperationMap[identifier] = @(operationType);
+            });
 #endif
         }
+
         [task resume];
-    }
-    else {
-        
+    } else {
         PNErrorStatus *badRequestStatus = [PNErrorStatus statusForOperation:operationType
                                                                    category:PNBadRequestCategory
                                                         withProcessingError:nil];
         [self.client appendClientInformation:badRequestStatus];
+
         if (block) {
-            
             if ([self operationExpectResult:operationType]) {
-                
                 ((PNCompletionBlock)block)(nil, badRequestStatus);
+            } else {
+                ((PNStatusBlock)block)(badRequestStatus);
             }
-            else { ((PNStatusBlock)block)(badRequestStatus); }
         }
     }
 }
 
-- (void)parseData:(id)data withParser:(Class <PNParser>)parser 
+- (void)parseData:(id)data
+       withParser:(Class <PNParser>)parser
        completion:(void(^)(NSDictionary *parsedData, BOOL parseError))block {
 
     __weak __typeof(self) weakSelf = self;
     void(^parseCompletion)(NSDictionary *) = ^(NSDictionary *processedData){
-        
         if (processedData || parser == [PNErrorParser class]) {
-            
             block(processedData, (parser == [PNErrorParser class]));
-        }
-        else {
+        } else {
             [weakSelf parseData:data withParser:[PNErrorParser class] completion:[block copy]];
         }
     };
     
     if (![parser requireAdditionalData]) {
-        
         parseCompletion(data ? [parser parsedServiceResponse:data] : nil);
-    }
-    else {
-
+    } else {
         NSMutableDictionary *additionalData = [NSMutableDictionary new];
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
         additionalData[@"stripMobilePayload"] = @(self.configuration.shouldStripMobilePayload);
 #pragma clang diagnostic pop
-        if ([self.configuration.cipherKey length]) {
 
+        if ([self.configuration.cipherKey length]) {
             additionalData[@"cipherKey"] = self.configuration.cipherKey;
         }
-        
-        // If additional data required client should assume what potentially additional calculations
-        // may be required and should temporarily shift to background queue.
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
 
+        /**
+         * If additional data required client should assume what potentially additional calculations
+         * may be required and should temporarily shift to background queue.
+         */
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
             NSDictionary *parsedData = [parser parsedServiceResponse:data withData:additionalData];
+
             pn_dispatch_async(self.processingQueue, ^{
-                
                 parseCompletion(parsedData);
             });
         });
@@ -927,24 +949,21 @@ NS_ASSUME_NONNULL_END
                                   onDataTaskCompletion:(BOOL)onCompletion {
     
     NSUInteger incompleteTasksCount = dataTasks.count;
+
     if (incompleteTasksCount > 0 && self.forLongPollRequests) {
-        
         if (![self hasOperation:PNUnsubscribeOperation inDataTasks:dataTasks]) {
-            
             incompleteTasksCount = 0;
         }
     }
     
     if (incompleteTasksCount == 0) {
-        
-        PNLogRequest(self.client.logger, @"<PubNub::Network> All tasks completed. There is no need in "
-                     "additional execution time in background context.");
+        PNLogRequest(self.client.logger, @"<PubNub::Network> All tasks completed. There is no need "
+            "in additional execution time in background context.");
         [self endBackgroundTasksCompletionIfRequired];
-    }
-    else if (!onCompletion) {
-        
-        PNLogRequest(self.client.logger, @"<PubNub::Network> There is %lu incompleted tasks. Required "
-                     "additional execution time in background context.", (unsigned long)incompleteTasksCount);
+    } else if (!onCompletion) {
+        PNLogRequest(self.client.logger, @"<PubNub::Network> There is %lu incomplete tasks. "
+            "Required additional execution time in background context.",
+            (unsigned long)incompleteTasksCount);
     }
 }
 #endif // TARGET_OS_IOS
@@ -965,10 +984,14 @@ NS_ASSUME_NONNULL_END
             
             if (prefix) {
                 for (NSURLSessionDataTask *dataTask in dataTasks) {
-                    if ([dataTask.originalRequest.URL.path hasPrefix:prefix]) { [dataTask cancel]; }
+                    if ([dataTask.originalRequest.URL.path hasPrefix:prefix]) {
+                        [dataTask cancel];
+                    }
                 }
+            } else {
+                [dataTasks makeObjectsPerformSelector:@selector(cancel)];
             }
-            else { [dataTasks makeObjectsPerformSelector:@selector(cancel)]; }
+
             complete();
         }];
     });
@@ -977,7 +1000,6 @@ NS_ASSUME_NONNULL_END
 - (void)invalidate {
     
     pn_lock(&_lock, ^{
-        
         [self->_session invalidateAndCancel];
         self->_session = nil;
     });
@@ -987,15 +1009,18 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Operation information
 
 - (NSInteger)packetSizeForOperation:(PNOperationType)operationType
-                     withParameters:(PNRequestParameters *)parameters data:(NSData *)data {
+                     withParameters:(PNRequestParameters *)parameters
+                               data:(NSData *)data {
     
     NSInteger size = -1;
     [self appendRequiredParametersTo:parameters];
     NSURL *requestURL = [PNURLBuilder URLForOperation:operationType withParameters:parameters];
+
     if (requestURL) {
-        
-        size = [PNURLRequest packetSizeForRequest:[self requestWithURL:requestURL method:parameters.HTTPMethod 
-                                                                  data:data]];
+        NSURLRequest *request = [self requestWithURL:requestURL
+                                              method:parameters.HTTPMethod
+                                                data:data];
+        size = [PNURLRequest packetSizeForRequest:request];
     }
     
     return size;
@@ -1014,27 +1039,26 @@ NS_ASSUME_NONNULL_END
     _delegateQueue = [self operationQueueWithConfiguration:config];
     _session = [self sessionWithConfiguration:config];
     _sessionIdentifier = [[NSUUID UUID] UUIDString];
+
     [self printIfRequiredSessionCustomizationInformation];
     
 }
 
 - (NSURLSessionConfiguration *)configurationWithRequestTimeout:(NSTimeInterval)timeout
                                             maximumConnections:(NSInteger)maximumConnections {
-    
-    // Prepare base configuration with predefined timeout values and maximum connections
-    // to same host (basically how many requests can be handled at once).
-    BOOL shouldUsepipelining = !self.forLongPollRequests;
+
+    BOOL shouldUsePipelining = !self.forLongPollRequests;
     NSURLSessionConfiguration *configuration = nil;
     configuration = [NSURLSessionConfiguration pn_ephemeralSessionConfigurationWithIdentifier:self.identifier];
     if (@available(macOS 10.10, iOS 8.0, *)) {
         if (self.configuration.applicationExtensionSharedGroupIdentifier) {
             configuration = [NSURLSessionConfiguration pn_backgroundSessionConfigurationWithIdentifier:self.identifier];
             configuration.sharedContainerIdentifier = _configuration.applicationExtensionSharedGroupIdentifier;
-            shouldUsepipelining = NO;
+            shouldUsePipelining = NO;
         }
     }
     
-    configuration.HTTPShouldUsePipelining = shouldUsepipelining;
+    configuration.HTTPShouldUsePipelining = shouldUsePipelining;
     configuration.timeoutIntervalForRequest = timeout;
     configuration.HTTPMaximumConnectionsPerHost = maximumConnections;
     
@@ -1050,9 +1074,9 @@ NS_ASSUME_NONNULL_END
 }
 
 - (NSURLSession *)sessionWithConfiguration:(NSURLSessionConfiguration *)configuration {
-    
-    // Construct sessions to process requests which should be sent to PubNub network.
-    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration delegate:self
+
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration
+                                                          delegate:self
                                                      delegateQueue:_delegateQueue];
     
     return session;
@@ -1072,30 +1096,20 @@ NS_ASSUME_NONNULL_END
 - (void)handleClientWillResignActive {
     
     if (self.configuration.applicationExtensionSharedGroupIdentifier == nil) {
-        
         pn_lock(&_lock, ^{
-            
             UIApplication *application = [UIApplication performSelector:NSSelectorFromString(@"sharedApplication")];
             if (self.tasksCompletionIdentifier == UIBackgroundTaskInvalid) {
-                
-                // Give manager some time to figure out whether background task should be used to complete all 
-                // scheduled data tasks or not.
                 __weak __typeof__(self) weakSelf = self;
                 self.tasksCompletionIdentifier = [application beginBackgroundTaskWithExpirationHandler:^{
-                    
                     [weakSelf endBackgroundTasksCompletionIfRequired];
                 }];
-                     
-                // Give some time before checking whether tasks has been scheduled for execution or not.
+
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3f * NSEC_PER_SEC)),
                                dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                                   
-                    // Get list of scheduled operation.
+
                     __strong __typeof__(weakSelf) strongSelf = weakSelf;
                     pn_lock(&strongSelf->_lock, ^{
-                        
                         if (strongSelf.tasksCompletionIdentifier != UIBackgroundTaskInvalid) {
-                            
                             [strongSelf processIncompleteBeforeClientResignActiveTasks:self.scheduledDataTasks
                                                                   onDataTaskCompletion:NO];
                         }
@@ -1117,9 +1131,7 @@ NS_ASSUME_NONNULL_END
 -(void)URLSession:(NSURLSession *)session didBecomeInvalidWithError:(NSError *)error {
     
     if (error) {
-        
         pn_lock(&_lock, ^{
-            // Clean up cached tasks if required.
 #if TARGET_OS_IOS
             if (self.configuration.applicationExtensionSharedGroupIdentifier == nil &&
                 self.configuration.shouldCompleteRequestsBeforeSuspension) {
@@ -1127,15 +1139,16 @@ NS_ASSUME_NONNULL_END
                 [self.scheduledDataTasks removeAllObjects];
             }
 #endif // TARGET_OS_IOS
-            
-            // Replace invalidated session with new one which can be used for next requests.
+
             [self prepareSessionWithRequestTimeout:self.requestTimeout
                                 maximumConnections:self.maximumConnections];
         });
     }
 }
 
-- (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
+- (void)URLSession:(NSURLSession *)session
+                    task:(NSURLSessionTask *)task
+    didCompleteWithError:(NSError *)error {
 
     BOOL isApplicationExtension = NO;
     BOOL isBackgroundProcessingError = NO;
@@ -1147,107 +1160,122 @@ NS_ASSUME_NONNULL_END
     }
 
     if (isApplicationExtension || isBackgroundProcessingError) {
-        
         if (isBackgroundProcessingError) {
-            
-            NSString *message = [NSString stringWithFormat:@"<PubNub::Network> NSURLSession activity in the "
-                                 "background requires you to set `applicationExtensionSharedGroupIdentifier` "
-                                 "in PNConfiguration."];
+            NSString *message = [NSString stringWithFormat:@"<PubNub::Network> NSURLSession "
+                                 "activity in the background requires you to set "
+                                 "`applicationExtensionSharedGroupIdentifier` in PNConfiguration."];
+
             [self.client.logger log:0 message:message];
         }
         
         NSData *fetchedData = [self.fetchedData copy];
-        self.fetchedData = nil; 
+        self.fetchedData = nil;
+
         if (self.previousDataTaskCompletionHandler) {
-            
             dispatch_async(dispatch_get_main_queue(), ^{
-                
                 self.previousDataTaskCompletionHandler(fetchedData, task.response, error);
             });
         }
     }
 }
 
-- (void)URLSession:(NSURLSession *)__unused session dataTask:(NSURLSessionDataTask *)__unused dataTask
+- (void)URLSession:(NSURLSession *)__unused session
+          dataTask:(NSURLSessionDataTask *)__unused dataTask
     didReceiveData:(NSData *)data {
 
     if (@available(macOS 10.10, iOS 8.0, *)) {
         if (self.configuration.applicationExtensionSharedGroupIdentifier != nil && data.length) {
-
             [self.fetchedData appendData:data];
         }
     }
 }
 
-- (void)handleData:(NSData *)data loadedWithTask:(NSURLSessionDataTask *)task error:(NSError *)requestError 
-      usingSuccess:(NSURLSessionDataTaskSuccess)success failure:(NSURLSessionDataTaskFailure)failure {
+- (void)handleData:(NSData *)data
+    loadedWithTask:(NSURLSessionDataTask *)task
+             error:(NSError *)requestError
+      usingSuccess:(NSURLSessionDataTaskSuccess)success
+           failure:(NSURLSessionDataTaskFailure)failure {
     
     dispatch_async(self.processingQueue, ^{
-        
         NSError *serializationError = nil;
         id processedObject = [self.serializer serializedResponse:(NSHTTPURLResponse *)task.response
                                                         withData:data error:&serializationError];
-        NSError *error = (requestError?: serializationError);
-        (!error ? success : failure)(task, (error?: processedObject));
+        NSError *error = (requestError ?: serializationError);
+
+        (!error ? success : failure)(task, (error ?: processedObject));
     });
 }
 
-- (void)handleOperation:(PNOperationType)operation taskDidComplete:(NSURLSessionDataTask *)task
-               withData:(id)responseObject completionBlock:(id)block {
+- (void)handleOperation:(PNOperationType)operation
+        taskDidComplete:(NSURLSessionDataTask *)task
+               withData:(id)responseObject
+        completionBlock:(id)block {
     
     __weak __typeof(self) weakSelf = self;
-    [self parseData:responseObject withParser:[self parserForOperation:operation]
+    [self parseData:responseObject
+         withParser:[self parserForOperation:operation]
          completion:^(NSDictionary *parsedData, BOOL parseError) {
-             [weakSelf handleParsedData:parsedData loadedWithTask:task forOperation:operation
-                          parsedAsError:parseError processingError:task.error
+
+             [weakSelf handleParsedData:parsedData
+                         loadedWithTask:task
+                           forOperation:operation
+                          parsedAsError:parseError
+                        processingError:task.error
                         completionBlock:[block copy]];
          }];
 }
 
-- (void)handleOperation:(PNOperationType)operation taskDidFail:(NSURLSessionDataTask *)task
-              withError:(NSError *)error completionBlock:(id)block {
+- (void)handleOperation:(PNOperationType)operation
+            taskDidFail:(NSURLSessionDataTask *)task
+              withError:(NSError *)error
+        completionBlock:(id)block {
     
     if (error.code == NSURLErrorCancelled) {
-        
         [self handleOperation:operation taskDidComplete:task withData:nil completionBlock:block];
-    }
-    else {
-        
+    } else {
         id errorDetails = nil;
         NSData *errorData = (error?: task.error).userInfo[kPNNetworkErrorResponseDataKey];
+
         if (errorData) {
-            
             errorDetails = [NSJSONSerialization JSONObjectWithData:errorData
-                                                           options:(NSJSONReadingOptions)0 error:NULL];
+                                                           options:(NSJSONReadingOptions)0
+                                                             error:NULL];
         }
-        [self parseData:errorDetails withParser:[PNErrorParser class]
+
+        [self parseData:errorDetails
+             withParser:[PNErrorParser class]
              completion:^(NSDictionary *parsedData, __unused BOOL parseError) {
 
-                 [self handleParsedData:parsedData loadedWithTask:task forOperation:operation
-                          parsedAsError:YES processingError:(error?: task.error)
+                 [self handleParsedData:parsedData
+                         loadedWithTask:task
+                           forOperation:operation
+                          parsedAsError:YES
+                        processingError:(error ?: task.error)
                         completionBlock:[block copy]];
              }];
     }
 }
 
-- (void)handleParsedData:(NSDictionary *)data loadedWithTask:(NSURLSessionDataTask *)task
-            forOperation:(PNOperationType)operation parsedAsError:(BOOL)isError
-         processingError:(NSError *)error completionBlock:(id)block {
+- (void)handleParsedData:(NSDictionary *)data
+          loadedWithTask:(NSURLSessionDataTask *)task
+            forOperation:(PNOperationType)operation
+           parsedAsError:(BOOL)isError
+         processingError:(NSError *)error
+         completionBlock:(id)block {
     
     PNResult *result = nil;
     PNStatus *status = nil;
-    
-    // Check whether request potentially has been cancelled prior actual sending to the network or
-    // not
+
     if (task && ((NSHTTPURLResponse *)task.response).statusCode == 0 &&
         error && error.code == NSURLErrorBadServerResponse) {
         
         isError = YES;
-        error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCancelled
+        error = [NSError errorWithDomain:NSURLErrorDomain
+                                    code:NSURLErrorCancelled
                                 userInfo:error.userInfo];
     }
+
     if ([self operationExpectResult:operation] && !isError) {
-        
         result = [[self resultClassForOperation:operation] objectForOperation:operation
                                                            completedWithTask:task
                                                                processedData:data
@@ -1255,16 +1283,19 @@ NS_ASSUME_NONNULL_END
     }
     
     if (isError || !data || ![self operationExpectResult:operation]){
-        
-        Class statusClass = (isError ? [PNErrorStatus class] : [self statusClassForOperation:operation]);
-        status = (PNStatus *)[statusClass objectForOperation:operation completedWithTask:task
-                                               processedData:data processingError:error];
+        Class statusClass = (isError ? [PNErrorStatus class]
+                                     : [self statusClassForOperation:operation]);
+        status = (PNStatus *)[statusClass objectForOperation:operation
+                                           completedWithTask:task
+                                               processedData:data
+                                             processingError:error];
     }
     
     if (result || status) {
-
-        [self handleOperation:operation processingCompletedWithResult:result
-                       status:status completionBlock:block];
+        [self handleOperation:operation
+    processingCompletedWithResult:result
+                           status:status
+                  completionBlock:block];
     }
     
 #if TARGET_OS_IOS
@@ -1273,8 +1304,8 @@ NS_ASSUME_NONNULL_END
         
         pn_lock(&_lock, ^{
             [self.scheduledDataTasks removeObject:task];
+
             if (self.tasksCompletionIdentifier != UIBackgroundTaskInvalid) {
-                
                 [self processIncompleteBeforeClientResignActiveTasks:self.scheduledDataTasks
                                                 onDataTaskCompletion:YES];
             }
@@ -1283,67 +1314,77 @@ NS_ASSUME_NONNULL_END
 #endif // TARGET_OS_IOS
 }
 
-- (void)handleOperation:(PNOperationType)operation processingCompletedWithResult:(PNResult *)result
-                 status:(PNStatus *)status completionBlock:(id)block {
-    
-    // Silence static analyzer warnings.
-    // Code is aware about this case and at the end will simply call on 'nil' object method.
-    // In most cases if referenced object become 'nil' it mean what there is no more need in
-    // it and probably whole client instance has been deallocated.
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Warc-repeated-use-of-weak"
-    if (result) { [self.client appendClientInformation:result]; }
-    if (status) { [self.client appendClientInformation:status]; }
+- (void)handleOperation:(PNOperationType)operation
+    processingCompletedWithResult:(PNResult *)result
+                           status:(PNStatus *)status
+                  completionBlock:(id)block {
+
+    if (result) {
+        [self.client appendClientInformation:result];
+    }
+
+    if (status) {
+        [self.client appendClientInformation:status];
+    }
+
     if (block) {
-        
         if ([self operationExpectResult:operation]) {
-            
             ((PNCompletionBlock)block)(result, status);
-        }
-        else {
-            
-            ((void(^)(id))block)(result?: status);
+        } else {
+            ((void(^)(id))block)(result ?: status);
         }
     }
-    #pragma clang diagnostic pop
 }
 
 #if PN_URLSESSION_TRANSACTION_METRICS_AVAILABLE
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
-- (void)          URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task 
-  didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics {
-        
-    NSMutableArray *redirections = metrics.transactionMetrics.count > 1 ? [NSMutableArray new] : nil;
-    __block NSMutableString *metricsData = nil;
+- (void)URLSession:(NSURLSession *)session
+                          task:(NSURLSessionTask *)task
+    didFinishCollectingMetrics:(NSURLSessionTaskMetrics *)metrics {
+
     NSArray<NSURLSessionTaskTransactionMetrics *> *transactions = metrics.transactionMetrics;
+    NSMutableArray *redirections = transactions.count > 1 ? [NSMutableArray new] : nil;
+    __block NSMutableString *metricsData = nil;
+
     [transactions enumerateObjectsUsingBlock:^(NSURLSessionTaskTransactionMetrics *transaction,
-                                               NSUInteger transactionIdx, BOOL *trabsactionsEnumeratorStop) {
+                                               NSUInteger transactionIdx,
+                                               BOOL *transactionsEnumeratorStop) {
         
         if (self.client.logger.logLevel & PNRequestMetricsLogLevel) {
-            
-            if (transactionIdx == 0) { metricsData = [self formattedMetricsDataFrom:transaction redirection:NO]; }
-            else { [redirections addObject:[self formattedMetricsDataFrom:transaction redirection:YES]]; }
+            if (transactionIdx == 0) {
+                metricsData = [self formattedMetricsDataFrom:transaction redirection:NO];
+            } else {
+                NSString *redirection = [self formattedMetricsDataFrom:transaction redirection:YES];
+                [redirections addObject:redirection];
+            }
         }
-        
-        NSTimeInterval latency = [transaction.responseEndDate timeIntervalSince1970] - [transaction.requestStartDate timeIntervalSince1970];
+
+        NSTimeInterval responseStartDate = [transaction.requestStartDate timeIntervalSince1970];
+        NSTimeInterval responseEndDate = [transaction.responseEndDate timeIntervalSince1970];
+        NSTimeInterval latency = responseEndDate - responseStartDate;
+
         if (latency > 0.f) {
             pn_lock(&self->_lock, ^{
-                NSString *taskIdentifier = [self.sessionIdentifier stringByAppendingString:@(task.taskIdentifier).stringValue];
+                NSString *taskID = @(task.taskIdentifier).stringValue;
+                NSString *identifier = [self.sessionIdentifier stringByAppendingString:taskID];
+                PNOperationType operationType = 0;
 
-                if (taskIdentifier) {
-                    PNOperationType operationType = self.dataTaskToOperationMap[taskIdentifier].integerValue;
-                    [self.dataTaskToOperationMap removeObjectForKey:taskIdentifier];
+                if (identifier) {
+                    operationType = self.dataTaskToOperationMap[identifier].integerValue;
+
+                    [self.dataTaskToOperationMap removeObjectForKey:identifier];
                     [self.client.telemetryManager setLatency:latency forOperation:operationType];
                 }
             });
         }
     }];
+
     if (redirections.count && metricsData) {
-        
-        [metricsData appendFormat:@"\nWARNING: Request redirections has been noticed:\n\t%@", 
-         [redirections componentsJoinedByString:@"\n\t"]];
+        [metricsData appendFormat:@"\nWARNING: Request redirections has been noticed:\n\t%@",
+                                   [redirections componentsJoinedByString:@"\n\t"]];
     }
+
     PNLogRequestMetrics(self.client.logger, @"%@", metricsData);
 }
 #pragma clang diagnostic pop
@@ -1354,13 +1395,12 @@ NS_ASSUME_NONNULL_END
 
 #if TARGET_OS_IOS
 
-- (BOOL)hasOperation:(PNOperationType)operation inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks {
+- (BOOL)hasOperation:(PNOperationType)operation
+         inDataTasks:(NSArray<NSURLSessionDataTask *> *)tasks {
     
     BOOL hasOperation = NO;
     for (NSURLSessionDataTask *dataTask in tasks) {
-        
         if ([PNURLBuilder isURL:dataTask.originalRequest.URL forOperation:operation]) {
-            
             hasOperation = YES;
             break;
         }
@@ -1372,13 +1412,10 @@ NS_ASSUME_NONNULL_END
 - (void)endBackgroundTasksCompletionIfRequired {
 
     if (self.configuration.applicationExtensionSharedGroupIdentifier == nil) {
-        
         pn_trylock(&_lock, ^{
-            
             UIApplication *application = [UIApplication performSelector:NSSelectorFromString(@"sharedApplication")];
             
             if (self.tasksCompletionIdentifier != UIBackgroundTaskInvalid) {
-                
                 [application endBackgroundTask:self.tasksCompletionIdentifier];
                 self.tasksCompletionIdentifier = UIBackgroundTaskInvalid;
             }
@@ -1397,15 +1434,19 @@ NS_ASSUME_NONNULL_END
     NSURLRequest *request = transaction.request;
     NSMutableString *metricsData = [NSMutableString stringWithFormat:@"<PubNub::Network::Metrics> %@ ", 
                                     request.HTTPMethod];
+
     if (!isRedirection) {
-        
-        [metricsData appendFormat:@"%@?%@", request.URL.relativePath,
-         [request.URL.query stringByReplacingOccurrencesOfString:@"%2F" withString:@"/"]];
+        NSString *query = [request.URL.query stringByReplacingOccurrencesOfString:@"%2F"
+                                                                       withString:@"/"];
+
+        [metricsData appendFormat:@"%@?%@", request.URL.relativePath, query];
+    } else {
+        NSString *uri = [request.URL.absoluteString stringByReplacingOccurrencesOfString:@"%2F"
+                                                                              withString:@"/"];
+
+        [metricsData appendString:uri];
     }
-    else {
-        
-        [metricsData appendString:[request.URL.absoluteString stringByReplacingOccurrencesOfString:@"%2F" withString:@"/"]];
-    }
+
     [metricsData appendFormat:@" (%@; ", transaction.networkProtocolName?: @"<unknown>"];
     [metricsData appendFormat:@"persistent: %@; ", transaction.isReusedConnection ? @"YES": @"NO"];
     [metricsData appendFormat:@"proxy: %@; ", transaction.isProxyConnection ? @"YES": @"NO"];
@@ -1413,38 +1454,43 @@ NS_ASSUME_NONNULL_END
     // Add request duration.
     NSDate *fetchStartDate = transaction.fetchStartDate;
     NSDate *fetchEndDate = transaction.responseEndDate;
-    NSTimeInterval fetchDuration = [fetchEndDate timeIntervalSinceDate:(fetchStartDate?:fetchEndDate)];
+    NSTimeInterval fetchDuration = [fetchEndDate timeIntervalSinceDate:(fetchStartDate ?: fetchEndDate)];
     [metricsData appendFormat:@"fetch: %@ (%fs); ", fetchStartDate, fetchDuration];
     
     // Add DNS lookup duration.
     NSDate *lookupStartDate = transaction.domainLookupStartDate;
     NSDate *lookupEndDate = transaction.domainLookupEndDate;
-    NSTimeInterval lookupDuration = [lookupEndDate timeIntervalSinceDate:(lookupStartDate?:lookupEndDate)];
-    [metricsData appendFormat:@"lookup: %@ (%fs); ", lookupStartDate?:@"<re-use>", lookupDuration];
+    NSTimeInterval lookupDuration = [lookupEndDate timeIntervalSinceDate:(lookupStartDate ?: lookupEndDate)];
+    [metricsData appendFormat:@"lookup: %@ (%fs); ", lookupStartDate ?: @"<re-use>",
+                               lookupDuration];
     
     // Add connection establish duration.
     NSDate *connectStartDate = transaction.connectStartDate;
     NSDate *connectEndDate = transaction.connectEndDate;
-    NSTimeInterval connectDuration = [connectEndDate timeIntervalSinceDate:(connectStartDate?:connectEndDate)];
-    [metricsData appendFormat:@"connect: %@ (%fs); ", connectStartDate?:@"<re-use>", connectDuration];
+    NSTimeInterval connectDuration = [connectEndDate timeIntervalSinceDate:(connectStartDate ?: connectEndDate)];
+    [metricsData appendFormat:@"connect: %@ (%fs); ", connectStartDate ?: @"<re-use>",
+                               connectDuration];
     
     // Add secure connection establish duration.
     NSDate *secureStartDate = transaction.secureConnectionStartDate;
     NSDate *secureEndDate = transaction.secureConnectionEndDate;
-    NSTimeInterval secureDuration = [secureEndDate timeIntervalSinceDate:(secureStartDate?:secureEndDate)];
-    [metricsData appendFormat:@"secure: %@ (%fs); ", secureStartDate?:@"<re-use>", secureDuration];
+    NSTimeInterval secureDuration = [secureEndDate timeIntervalSinceDate:(secureStartDate ?: secureEndDate)];
+    [metricsData appendFormat:@"secure: %@ (%fs); ", secureStartDate ?: @"<re-use>",
+                               secureDuration];
     
     // Add request sending duration.
     NSDate *requestStartDate = transaction.requestStartDate;
     NSDate *requestEndDate = transaction.requestEndDate;
-    NSTimeInterval requestDuration = [requestEndDate timeIntervalSinceDate:(requestStartDate?:requestEndDate)];
-    [metricsData appendFormat:@"request: %@ (%fs); ", requestStartDate?:@"<not-started>", requestDuration];
+    NSTimeInterval requestDuration = [requestEndDate timeIntervalSinceDate:(requestStartDate ?: requestEndDate)];
+    [metricsData appendFormat:@"request: %@ (%fs); ", requestStartDate ?: @"<not-started>",
+                               requestDuration];
     
     // Add response loading duration.
     NSDate *responseStartDate = transaction.responseStartDate;
     NSDate *responseEndDate = transaction.responseEndDate;
-    NSTimeInterval responseDuration = [responseEndDate timeIntervalSinceDate:(responseStartDate?:responseEndDate)];
-    [metricsData appendFormat:@"response: %@ (%fs))", responseStartDate?:@"<not-started>", responseDuration];
+    NSTimeInterval responseDuration = [responseEndDate timeIntervalSinceDate:(responseStartDate ?: responseEndDate)];
+    [metricsData appendFormat:@"response: %@ (%fs))", responseStartDate ?: @"<not-started>",
+                               responseDuration];
     
     return metricsData;
 }
@@ -1454,33 +1500,28 @@ NS_ASSUME_NONNULL_END
 - (void)printIfRequiredSessionCustomizationInformation {
     
     if ([NSURLSessionConfiguration pn_HTTPAdditionalHeaders].count) {
-        
-        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Custom HTTP headers is set by user: %@",
-                        [NSURLSessionConfiguration pn_HTTPAdditionalHeaders]);
+        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Custom HTTP headers is set by "
+            "user: %@", [NSURLSessionConfiguration pn_HTTPAdditionalHeaders]);
     }
     
     if ([NSURLSessionConfiguration pn_networkServiceType] != NSURLNetworkServiceTypeDefault) {
-        
-        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Custom network service type is set by user: %@",
-                        @([NSURLSessionConfiguration pn_networkServiceType]));
+        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Custom network service type is set "
+            "by user: %@", @([NSURLSessionConfiguration pn_networkServiceType]));
     }
     
     if (![NSURLSessionConfiguration pn_allowsCellularAccess]) {
-        
-        PNLogClientInfo(self.client.logger, @"<PubNub::Network> User limited access to cellular data and only"
-                        " WiFi connection can be used.");
+        PNLogClientInfo(self.client.logger, @"<PubNub::Network> User limited access to cellular "
+            "data and only WiFi connection can be used.");
     }
     
     if ([NSURLSessionConfiguration pn_protocolClasses].count) {
-        
-        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Extra requests handling protocols defined by "
-                        "user: %@", [NSURLSessionConfiguration pn_protocolClasses]);
+        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Extra requests handling protocols "
+            "defined by user: %@", [NSURLSessionConfiguration pn_protocolClasses]);
     }
     
     if ([NSURLSessionConfiguration pn_connectionProxyDictionary].count) {
-        
-        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Connection proxy has been set by user: %@",
-                        [NSURLSessionConfiguration pn_connectionProxyDictionary]);
+        PNLogClientInfo(self.client.logger, @"<PubNub::Network> Connection proxy has been set by "
+            "user: %@", [NSURLSessionConfiguration pn_connectionProxyDictionary]);
     }
 }
 

--- a/PubNub/Network/PNNetworkResponseSerializer.h
+++ b/PubNub/Network/PNNetworkResponseSerializer.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0.2
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNNetworkResponseSerializer : NSObject
 

--- a/PubNub/Network/PNNetworkResponseSerializer.m
+++ b/PubNub/Network/PNNetworkResponseSerializer.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0.2
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNNetworkResponseSerializer.h"
 

--- a/PubNub/Network/PNReachability.h
+++ b/PubNub/Network/PNReachability.h
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNReachability : NSObject
 

--- a/PubNub/Network/PNReachability.m
+++ b/PubNub/Network/PNReachability.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNReachability.h"
 #import "PubNub+CorePrivate.h"

--- a/PubNub/Network/PNRequestParameters.h
+++ b/PubNub/Network/PNRequestParameters.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNRequestParameters : NSObject
 

--- a/PubNub/Network/PNRequestParameters.m
+++ b/PubNub/Network/PNRequestParameters.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNRequestParameters.h"
 

--- a/PubNub/Network/PNURLBuilder.h
+++ b/PubNub/Network/PNURLBuilder.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNURLBuilder : NSObject
 

--- a/PubNub/Network/PNURLBuilder.m
+++ b/PubNub/Network/PNURLBuilder.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNURLBuilder.h"
 #import "PNRequestParameters.h"
@@ -15,7 +15,7 @@
  
  @since 4.0
  */
-static NSString * const PNOperationRequestTemplate[24] = {
+static NSString * const PNOperationRequestTemplate[25] = {
     [PNSubscribeOperation] = @"/v2/subscribe/{sub-key}/{channels}/0",
     [PNUnsubscribeOperation] = @"/v2/presence/sub_key/{sub-key}/channel/{channels}/leave",
     [PNPublishOperation] = @"/publish/{pub-key}/{sub-key}/0/{channel}/0/{message}",
@@ -28,6 +28,7 @@ static NSString * const PNOperationRequestTemplate[24] = {
     [PNHereNowForChannelGroupOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channel}",
     [PNHeartbeatOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channels}/heartbeat",
     [PNSetStateOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channel}/uuid/{uuid}/data",
+    [PNGetStateOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channel}/uuid/{uuid}",
     [PNStateForChannelOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channel}/uuid/{uuid}",
     [PNStateForChannelGroupOperation] = @"/v2/presence/sub-key/{sub-key}/channel/{channel}/uuid/{uuid}",
     [PNAddChannelsToGroupOperation] = @"/v1/channel-registration/sub-key/{sub-key}/channel-group/{channel-group}",

--- a/PubNub/Network/Parsers/PNChannelGroupAuditionParser.h
+++ b/PubNub/Network/Parsers/PNChannelGroupAuditionParser.h
@@ -29,7 +29,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupAuditionParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNChannelGroupAuditionParser.m
+++ b/PubNub/Network/Parsers/PNChannelGroupAuditionParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNChannelGroupAuditionParser.h"
 #import "PNDictionary.h"

--- a/PubNub/Network/Parsers/PNChannelGroupModificationParser.h
+++ b/PubNub/Network/Parsers/PNChannelGroupModificationParser.h
@@ -18,7 +18,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNChannelGroupModificationParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNChannelGroupModificationParser.m
+++ b/PubNub/Network/Parsers/PNChannelGroupModificationParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNChannelGroupModificationParser.h"
 

--- a/PubNub/Network/Parsers/PNClientStateParser.h
+++ b/PubNub/Network/Parsers/PNClientStateParser.h
@@ -1,23 +1,16 @@
-#import <Foundation/Foundation.h>
 #import "PNParser.h"
 
 
 /**
- @brief      Class suitable to handle and process \b PubNub service response on client state modification and
-             audit request.
- @discussion Handle and pre-process provided server data to fetch operation result from it.
- @discussion Expected input:
- 
- @code
-{
-  "status": @BOOL,
-  "state": NSDictionary
-}
- @endcode
- 
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ * @brief Class suitable to handle and process \b PubNub service response on client state
+ * modification and audit request.
+ *
+ * @discussion Handle and pre-process provided server data to fetch operation result from it.
+ *
+ *
+ * @author Serhii Mamontov
+ * @since 4.0
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNClientStateParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNClientStateParser.m
+++ b/PubNub/Network/Parsers/PNClientStateParser.m
@@ -1,10 +1,9 @@
 /**
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @since 4.0
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNClientStateParser.h"
-#import "PNDictionary.h"
 
 
 #pragma mark Interface implementation
@@ -16,7 +15,7 @@
 
 + (NSArray<NSNumber *> *)operations {
     
-    return @[@(PNSetStateOperation), @(PNStateForChannelOperation),
+    return @[@(PNSetStateOperation), @(PNGetStateOperation), @(PNStateForChannelOperation),
              @(PNStateForChannelGroupOperation)];
 }
 
@@ -29,16 +28,21 @@
 #pragma mark - Parsing
 
 + (NSDictionary<NSString *, id> *)parsedServiceResponse:(id)response {
-    
-    // To handle case when response is unexpected for this type of operation processed value sent through 
-    // 'nil' initialized local variable.
-    NSDictionary *processedResponse = nil;
+
+    NSMutableDictionary *processedResponse = nil;
     
     // Dictionary is valid response type for state update / audit.
-    if ([response isKindOfClass:[NSDictionary class]] && ((NSNumber *)response[@"status"]).integerValue == 200){
-        
-        processedResponse = @{@"channels": (response[@"payload"][@"channels"]?: @[]),
-                              @"state": (response[@"payload"]?: @{})};
+    if ([response isKindOfClass:[NSDictionary class]] &&
+        ((NSNumber *)response[@"status"]).integerValue == 200){
+
+        processedResponse = [@{ @"state": (response[@"payload"] ?: @{}) } mutableCopy];
+        NSDictionary *channelsState = response[@"payload"][@"channels"] ?: @{};
+
+        if (response[@"channel"]) {
+            channelsState = @{ response[@"channel"]: processedResponse[@"state"] };
+        }
+
+        processedResponse[@"channels"] = channelsState;
     }
     
     return processedResponse;

--- a/PubNub/Network/Parsers/PNErrorParser.h
+++ b/PubNub/Network/Parsers/PNErrorParser.h
@@ -16,7 +16,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNErrorParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNErrorParser.m
+++ b/PubNub/Network/Parsers/PNErrorParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNErrorParser.h"
 #import "PNDictionary.h"

--- a/PubNub/Network/Parsers/PNHeartbeatParser.h
+++ b/PubNub/Network/Parsers/PNHeartbeatParser.h
@@ -7,7 +7,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNHeartbeatParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNHeartbeatParser.m
+++ b/PubNub/Network/Parsers/PNHeartbeatParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNHeartbeatParser.h"
 

--- a/PubNub/Network/Parsers/PNHistoryParser.h
+++ b/PubNub/Network/Parsers/PNHistoryParser.h
@@ -15,7 +15,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNHistoryParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNHistoryParser.m
+++ b/PubNub/Network/Parsers/PNHistoryParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNHistoryParser.h"
 #import "PubNub+CorePrivate.h"

--- a/PubNub/Network/Parsers/PNLeaveParser.h
+++ b/PubNub/Network/Parsers/PNLeaveParser.h
@@ -7,7 +7,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNLeaveParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNLeaveParser.m
+++ b/PubNub/Network/Parsers/PNLeaveParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNLeaveParser.h"
 

--- a/PubNub/Network/Parsers/PNMessageDeleteParser.h
+++ b/PubNub/Network/Parsers/PNMessageDeleteParser.h
@@ -7,7 +7,7 @@
  
  @author Sergey Mamontov
  @since 4.7.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNMessageDeleteParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNMessageDeleteParser.m
+++ b/PubNub/Network/Parsers/PNMessageDeleteParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.7.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNMessageDeleteParser.h"
 

--- a/PubNub/Network/Parsers/PNMessagePublishParser.h
+++ b/PubNub/Network/Parsers/PNMessagePublishParser.h
@@ -17,7 +17,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNMessagePublishParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNMessagePublishParser.m
+++ b/PubNub/Network/Parsers/PNMessagePublishParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNMessagePublishParser.h"
 #import "PNDictionary.h"

--- a/PubNub/Network/Parsers/PNPresenceHereNowParser.h
+++ b/PubNub/Network/Parsers/PNPresenceHereNowParser.h
@@ -80,7 +80,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceHereNowParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNPresenceHereNowParser.m
+++ b/PubNub/Network/Parsers/PNPresenceHereNowParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceHereNowParser.h"
 #import "PNDictionary.h"

--- a/PubNub/Network/Parsers/PNPresenceWhereNowParser.h
+++ b/PubNub/Network/Parsers/PNPresenceWhereNowParser.h
@@ -18,7 +18,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPresenceWhereNowParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNPresenceWhereNowParser.m
+++ b/PubNub/Network/Parsers/PNPresenceWhereNowParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPresenceWhereNowParser.h"
 #import "PNDictionary.h"

--- a/PubNub/Network/Parsers/PNPushNotificationsAuditParser.h
+++ b/PubNub/Network/Parsers/PNPushNotificationsAuditParser.h
@@ -19,7 +19,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPushNotificationsAuditParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNPushNotificationsAuditParser.m
+++ b/PubNub/Network/Parsers/PNPushNotificationsAuditParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPushNotificationsAuditParser.h"
 #import "PNDictionary.h"

--- a/PubNub/Network/Parsers/PNPushNotificationsStateModificationParser.h
+++ b/PubNub/Network/Parsers/PNPushNotificationsStateModificationParser.h
@@ -17,7 +17,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNPushNotificationsStateModificationParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNPushNotificationsStateModificationParser.m
+++ b/PubNub/Network/Parsers/PNPushNotificationsStateModificationParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNPushNotificationsStateModificationParser.h"
 

--- a/PubNub/Network/Parsers/PNSubscribeParser.h
+++ b/PubNub/Network/Parsers/PNSubscribeParser.h
@@ -15,7 +15,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscribeParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNSubscribeParser.m
+++ b/PubNub/Network/Parsers/PNSubscribeParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNSubscribeParser.h"
 #import "PNEnvelopeInformation.h"

--- a/PubNub/Network/Parsers/PNTimeParser.h
+++ b/PubNub/Network/Parsers/PNTimeParser.h
@@ -15,7 +15,7 @@
  
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNTimeParser : NSObject <PNParser>
 

--- a/PubNub/Network/Parsers/PNTimeParser.m
+++ b/PubNub/Network/Parsers/PNTimeParser.m
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @since 4.0
- @copyright © 2009-2017 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import "PNTimeParser.h"
 #import "PNDictionary.h"

--- a/PubNub/PubNub.h
+++ b/PubNub/PubNub.h
@@ -18,6 +18,7 @@
 #import "PNClientStateUpdateStatus.h"
 #import "PNPresenceWhereNowResult.h"
 #import "PNAcknowledgmentStatus.h"
+#import "PNClientStateGetResult.h"
 #import "PNChannelGroupsResult.h"
 #import "PNClientInformation.h"
 #import "PNSubscriberResults.h"

--- a/Support/Fabric/Headers/PubNub.h
+++ b/Support/Fabric/Headers/PubNub.h
@@ -1,7 +1,7 @@
 /**
  @author Sergey Mamontov
  @version 4.2.0
- @copyright © 2009-2016 PubNub, Inc.
+ @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 
@@ -30,6 +30,7 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 #import "PNClientStateUpdateStatus.h"
 #import "PNPresenceWhereNowResult.h"
 #import "PNAcknowledgmentStatus.h"
+#import "PNClientStateGetResult.h"
 #import "PNChannelGroupsResult.h"
 #import "PNClientInformation.h"
 #import "PNSubscriberResults.h"


### PR DESCRIPTION
Now it is possible to get / set state for multiple channels / groups at once (channel and groups can be requested with single API call).

Set state:
```objc
self.client.state().set().state(@{@"state": @"test"})
    .channels(@[@"channel1", @"channel12"])
    .channelGroups(@[@"group1", @"group2"])
    .performWithCompletion(^(PNClientStateUpdateStatus *status) {
  
        if (!status.isError) {
            // Client state successfully modified on specified channels and groups.
        } else {
            /**
             Handle client state modification error. Check 'category' property
             to find out possible reason because of which request did fail.
             Review 'errorData' property (which has PNErrorData data type) of status
             object to get additional information about issue.
 
             Request can be resent using: [status retry]
            */
        }
    });
```

Get state:
```objc
self.client.state().audit().uuid(@"PubNub")
    .channels(@[@"channel1", @"channel12"])
    .channelGroups(@[@"group1", @"group2"])
    .performWithCompletion(^(PNClientStateGetResult *result, PNErrorStatus *status) {
  
        if (!status.isError) {
            // Handle downloaded state information using: result.data.channels
        } else {
            /**
             Handle client state audit error. Check 'category' property
             to find out possible reason because of which request did fail.
             Review 'errorData' property (which has PNErrorData data type) of status
             object to get additional information about issue.
 
             Request can be resent using: [status retry]
            */
        }
    });
```