### PR TITLE
Fix crash when default OS language is set to Japanese

### DIFF
--- a/Example/PubNub Example.xcodeproj/project.pbxproj
+++ b/Example/PubNub Example.xcodeproj/project.pbxproj
@@ -304,15 +304,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PubNub Mac Example/Pods-PubNub Mac Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/PubNub-macOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PubNub.framework",
 			);
@@ -326,15 +322,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PubNub_Example/Pods-PubNub_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/PubNub-iOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PubNub.framework",
 			);

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -60,7 +60,7 @@ void pn_safe_property_write(dispatch_queue_t queue, dispatch_block_t block) {
 
 NSString * pn_operating_system_version(void) {
 
-    NNSOperatingSystemVersion ver = NSProcessInfo.processInfo.operatingSystemVersion;
+    NSOperatingSystemVersion ver = NSProcessInfo.processInfo.operatingSystemVersion;
     NSArray *versionComponents = @[@(ver.majorVersion), @(ver.minorVersion), @(ver.patchVersion)];
 
     return [versionComponents componentsJoinedByString:@"."];

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -60,13 +60,8 @@ void pn_safe_property_write(dispatch_queue_t queue, dispatch_block_t block) {
 
 NSString * pn_operating_system_version(void) {
 
-    NSString *versionString = [NSProcessInfo processInfo].operatingSystemVersionString;
-    NSString *osVersion = [versionString componentsSeparatedByString:@" "][1];
-    NSMutableArray *versionComponents = [[osVersion componentsSeparatedByString:@"."] mutableCopy];
-
-    if (versionComponents.count == 2) {
-        [versionComponents addObject:@"0"];
-    }
+    NNSOperatingSystemVersion ver = NSProcessInfo.processInfo.operatingSystemVersion;
+    NSArray *versionComponents = @[@(ver.majorVersion), @(ver.minorVersion), @(ver.patchVersion)];
 
     return [versionComponents componentsJoinedByString:@"."];
 }


### PR DESCRIPTION
## 🛠 System version parsing when OS language set to Japanese

Fix crash caused by code, which performed OS version parsing using older API which
provides localized string (include additional information in addition to version
information).