### PR TITLE
Add ability to specify FCM token when working with notifications.

### DIFF
--- a/Example/PubNub Example.xcodeproj/project.pbxproj
+++ b/Example/PubNub Example.xcodeproj/project.pbxproj
@@ -304,15 +304,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PubNub Mac Example/Pods-PubNub Mac Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/PubNub-macOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PubNub.framework",
 			);
@@ -326,15 +322,11 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-PubNub_Example/Pods-PubNub_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/PubNub-iOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PubNub.framework",
 			);

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Device push token addition block.
  *
+ * @note This method will forward call to 'apnsToken' block.
+ *
  * @param token Device push token against which search on \b PubNub service should be performed.
  *
  * @return API call configuration builder.
@@ -25,6 +27,30 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.5.4
  */
 @property (nonatomic, readonly, strong) PNAPNSAuditAPICallBuilder * (^token)(NSData *token);
+
+/**
+ * @brief Device APNS push token addition block.
+ *
+ * @param token Device APNS-provided push token against which search on \b PubNub service should be
+ *     performed.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 4.8.9
+ */
+@property (nonatomic, readonly, strong) PNAPNSAuditAPICallBuilder * (^apnsToken)(NSData *token);
+
+/**
+ * @brief Device FCM push token addition block.
+ *
+ * @param token Device FCM-provided push token against which search on \b PubNub service should be
+ *     performed.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 4.8.9
+ */
+@property (nonatomic, readonly, strong) PNAPNSAuditAPICallBuilder * (^fcmToken)(NSString *token);
 
 
 #pragma mark - Execution

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSAuditAPICallBuilder.m
@@ -21,7 +21,20 @@
 
 - (PNAPNSAuditAPICallBuilder * (^)(NSData *token))token {
     
+    return self.apnsToken;
+}
+
+- (PNAPNSAuditAPICallBuilder * (^)(NSData *token))apnsToken {
+    
     return ^PNAPNSAuditAPICallBuilder * (NSData *token) {
+        [self setValue:token forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
+- (PNAPNSAuditAPICallBuilder * (^)(NSString *token))fcmToken {
+    
+    return ^PNAPNSAuditAPICallBuilder * (NSString *token) {
         [self setValue:token forParameter:NSStringFromSelector(_cmd)];
         return self;
     };

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Device push token addition block.
  *
+ * @note This method will forward call to 'apnsToken' block.
+ *
  * @param token Device push token which should be used to change notifications state on specified
  *     set of channels.
  *
@@ -26,6 +28,30 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.5.4
  */
 @property (nonatomic, readonly, strong) PNAPNSModificationAPICallBuilder * (^token)(NSData *token);
+
+/**
+ * @brief Device APNS push token addition block.
+ *
+ * @param token Device APNS-provided push token against which search on \b PubNub service should be
+ *     performed.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 4.8.9
+ */
+@property (nonatomic, readonly, strong) PNAPNSModificationAPICallBuilder * (^apnsToken)(NSData *token);
+
+/**
+ * @brief Device FCM push token addition block.
+ *
+ * @param token Device FCM-provided push token against which search on \b PubNub service should be
+ *     performed.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 4.8.9
+ */
+@property (nonatomic, readonly, strong) PNAPNSModificationAPICallBuilder * (^fcmToken)(NSString *token);
 
 /**
  * @brief List of target channels addition block.

--- a/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/APNS/PNAPNSModificationAPICallBuilder.m
@@ -21,7 +21,20 @@
 
 - (PNAPNSModificationAPICallBuilder * (^)(NSData *token))token {
     
+    return self.apnsToken;
+}
+
+- (PNAPNSModificationAPICallBuilder * (^)(NSData *token))apnsToken {
+    
     return ^PNAPNSModificationAPICallBuilder * (NSData *token) {
+        [self setValue:token forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
+- (PNAPNSModificationAPICallBuilder * (^)(NSString *token))fcmToken {
+    
+    return ^PNAPNSModificationAPICallBuilder * (NSString *token) {
         [self setValue:token forParameter:NSStringFromSelector(_cmd)];
         return self;
     };

--- a/Tests/PubNub Tests.xcodeproj/project.pbxproj
+++ b/Tests/PubNub Tests.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		794B6B8A228D492400489D37 /* PNTimeTokenTests.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 794B6B89228D492400489D37 /* PNTimeTokenTests.bundle */; };
 		794B6B8B228D492400489D37 /* PNTimeTokenTests.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 794B6B89228D492400489D37 /* PNTimeTokenTests.bundle */; };
 		794B6B8C228D492400489D37 /* PNTimeTokenTests.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 794B6B89228D492400489D37 /* PNTimeTokenTests.bundle */; };
+		794C300A22B2C64000FE054B /* PNAPNSIntegrationTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 794C300922B2C64000FE054B /* PNAPNSIntegrationTest.m */; };
 		795CED0A1BCF002900D421BB /* PNHeartbeatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795CED091BCF002900D421BB /* PNHeartbeatTests.swift */; };
 		796502F31C0E3709001F7782 /* PNDeviceIndependentMatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 51A6E5FF1BE421DC00C20B77 /* PNDeviceIndependentMatcher.m */; };
 		797BDCCA1C1F5091006EF006 /* PNPublishWithMobilePayloadTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 79EF049F1B4EAAB7007478CB /* PNPublishWithMobilePayloadTests.m */; };
@@ -279,6 +280,7 @@
 		794B5666228D4AA2007AB94F /* PNAPNSTests.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = PNAPNSTests.bundle; path = Fixtures/PNAPNSTests.bundle; sourceTree = "<group>"; };
 		794B566A228D4B19007AB94F /* PNPublishSizeOfMessage.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = PNPublishSizeOfMessage.bundle; path = Fixtures/PNPublishSizeOfMessage.bundle; sourceTree = "<group>"; };
 		794B6B89228D492400489D37 /* PNTimeTokenTests.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = PNTimeTokenTests.bundle; path = Fixtures/PNTimeTokenTests.bundle; sourceTree = "<group>"; };
+		794C300922B2C64000FE054B /* PNAPNSIntegrationTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PNAPNSIntegrationTest.m; sourceTree = "<group>"; };
 		795CED091BCF002900D421BB /* PNHeartbeatTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PNHeartbeatTests.swift; sourceTree = "<group>"; };
 		797BDD021C1F5091006EF006 /* watchOS ObjC Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "watchOS ObjC Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		797BDD3F1C1F5176006EF006 /* tvOS ObjC Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "tvOS ObjC Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -652,6 +654,7 @@
 			isa = PBXGroup;
 			children = (
 				79A3E4632215A47600F2ADB9 /* PNPubNubHistoryIntegrationTest.m */,
+				794C300922B2C64000FE054B /* PNAPNSIntegrationTest.m */,
 			);
 			name = Integration;
 			path = Tests/Integration;
@@ -675,69 +678,7 @@
 				DEF30C57C474ED0F4ABE8DA0 /* Pods-tvOS ObjC Tests.debug.xcconfig */,
 				856325838D88FF13AF9E0F81 /* Pods-tvOS ObjC Tests.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		79A3E4462215783200F2ADB9 /* Categories */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E4482215783200F2ADB9 /* NSInvocation+PNTest.h */,
-				79A3E4472215783200F2ADB9 /* NSInvocation+PNTest.m */,
-			);
-			name = Categories;
-			path = "iOS Tests/Helpers/Categories";
-			sourceTree = "<group>";
-		};
-		79A3E4552215A42C00F2ADB9 /* Unit */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E4562215A42C00F2ADB9 /* Core */,
-			);
-			name = Unit;
-			path = Tests/Unit;
-			sourceTree = "<group>";
-		};
-		79A3E4562215A42C00F2ADB9 /* Core */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E4572215A42C00F2ADB9 /* History */,
-				79A3E4592215A42C00F2ADB9 /* Interfaces */,
-			);
-			path = Core;
-			sourceTree = "<group>";
-		};
-		79A3E4572215A42C00F2ADB9 /* History */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E4582215A42C00F2ADB9 /* PNMessageCountTest.m */,
-			);
-			path = History;
-			sourceTree = "<group>";
-		};
-		79A3E4592215A42C00F2ADB9 /* Interfaces */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E45A2215A42C00F2ADB9 /* History */,
-			);
-			path = Interfaces;
-			sourceTree = "<group>";
-		};
-		79A3E45A2215A42C00F2ADB9 /* History */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E45B2215A42C00F2ADB9 /* PNMessageCountAPICallBuilderTest.m */,
-			);
-			path = History;
-			sourceTree = "<group>";
-		};
-		79A3E4622215A44000F2ADB9 /* Integration */ = {
-			isa = PBXGroup;
-			children = (
-				79A3E4632215A47600F2ADB9 /* PNPubNubHistoryIntegrationTest.m */,
-			);
-			name = Integration;
-			path = Tests/Integration;
 			sourceTree = "<group>";
 		};
 		969714371B32F08E001DECD1 /* Helpers */ = {
@@ -1081,8 +1022,6 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-tvOS ObjC Tests/Pods-tvOS ObjC Tests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BeKindRewind-tvOS/BeKindRewind.framework",
@@ -1091,8 +1030,6 @@
 				"${BUILT_PRODUCTS_DIR}/PubNub-tvOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BeKindRewind.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
@@ -1209,8 +1146,6 @@
 				"${BUILT_PRODUCTS_DIR}/PubNub-macOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BeKindRewind.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
@@ -1235,8 +1170,6 @@
 				"${BUILT_PRODUCTS_DIR}/PubNub-iOS/PubNub.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-			);
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/BeKindRewind.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
@@ -1318,6 +1251,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				794C300A22B2C64000FE054B /* PNAPNSIntegrationTest.m in Sources */,
 				79EF04B21B4EAAB7007478CB /* PNPublishWithMobilePayloadTests.m in Sources */,
 				9652F3E51BA31F7D001E940A /* PNConfigurationChiperKeyTests.m in Sources */,
 				79EF04B01B4EAAB7007478CB /* PNPublishTests.m in Sources */,

--- a/Tests/iOS Tests/Tests/Integration/PNAPNSIntegrationTest.m
+++ b/Tests/iOS Tests/Tests/Integration/PNAPNSIntegrationTest.m
@@ -1,0 +1,257 @@
+/**
+ * @author Serhii Mamontov
+ * @copyright © 2010-2019 PubNub, Inc.
+ */
+#import "NSString+PNTest.h"
+#import <PubNub/PubNub.h>
+#import <OCMock/OCMock.h>
+#import "PNTestCase.h"
+
+
+#pragma mark Test interface declaration
+
+@interface PNAPNSIntegrationTest : PNTestCase
+
+
+#pragma mark - Information
+
+@property (nonatomic, strong) PubNub *client;
+
+#pragma mark -
+
+
+@end
+
+
+#pragma mark - Tests
+
+@implementation PNAPNSIntegrationTest
+
+#pragma mark - Setup / Tear down
+
+- (void)setUp {
+    
+    [super setUp];
+    
+    
+    dispatch_queue_t callbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:self.publishKey
+                                                                     subscribeKey:self.subscribeKey];
+    configuration.stripMobilePayload = NO;
+    
+    self.client = [PubNub clientWithConfiguration:configuration callbackQueue:callbackQueue];
+}
+
+
+#pragma mark - Tests :: enable
+
+- (void)testEnable_ShouldFallbackToAPNSToken_WhenCalledWithTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013092";
+    NSData *pushToken = [pushKey dataFromHexString:pushKey];
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+        .enable()
+        .channels(@[@"channel1"])
+        .token(pushToken)
+        .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+            NSString *url = status.clientRequest.URL.absoluteString;
+            
+            XCTAssertFalse(status.isError);
+            XCTAssertNotEqual([url rangeOfString:@"type=apns"].location, NSNotFound);
+            handler();
+        });
+    }];
+}
+
+- (void)testEnable_ShouldCallWithAPNSToken_WhenCalledExplicitlyWithAPNSTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013092";
+    NSData *pushToken = [pushKey dataFromHexString:pushKey];
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+        .enable()
+        .channels(@[@"channel1"])
+        .apnsToken(pushToken)
+        .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+            NSString *url = status.clientRequest.URL.absoluteString;
+            
+            XCTAssertFalse(status.isError);
+            XCTAssertNotEqual([url rangeOfString:@"type=apns"].location, NSNotFound);
+            handler();
+        });
+    }];
+}
+
+- (void)testEnable_ShouldCallWithFCMToken_WhenCalledExplicitlyWithFCMTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013093";
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+        .enable()
+        .channels(@[@"channel1"])
+        .fcmToken(pushKey)
+        .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+            NSString *url = status.clientRequest.URL.absoluteString;
+            
+            XCTAssertFalse(status.isError);
+            XCTAssertNotEqual([url rangeOfString:@"type=gcm"].location, NSNotFound);
+            handler();
+        });
+    }];
+}
+
+
+#pragma mark - Tests :: disable
+
+- (void)testDisable_ShouldFallbackToAPNSToken_WhenCalledWithTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013092";
+    NSData *pushToken = [pushKey dataFromHexString:pushKey];
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+            .enable()
+            .channels(@[@"channel1"])
+            .token(pushToken)
+            .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                self.client.push()
+                    .disable()
+                    .token(pushToken)
+                    .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                        NSString *url = status.clientRequest.URL.absoluteString;
+                        
+                        XCTAssertFalse(status.isError);
+                        XCTAssertNotEqual([url rangeOfString:@"type=apns"].location, NSNotFound);
+                        handler();
+                    });
+            });
+    }];
+}
+
+- (void)testDisable_ShouldCallWithAPNSToken_WhenCalledExplicitlyWithAPNSTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013092";
+    NSData *pushToken = [pushKey dataFromHexString:pushKey];
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+            .enable()
+            .channels(@[@"channel1"])
+            .apnsToken(pushToken)
+            .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                self.client.push()
+                    .disable()
+                    .apnsToken(pushToken)
+                    .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                        self.client.push()
+                            .audit()
+                            .token(pushToken)
+                            .performWithCompletion(^(PNAPNSEnabledChannelsResult *result, PNErrorStatus *status) {
+                                NSString *url = result.clientRequest.URL.absoluteString;
+                                
+                                XCTAssertNil(status);
+                                XCTAssertNotEqual([url rangeOfString:@"type=apns"].location, NSNotFound);
+                                XCTAssertEqual(result.data.channels.count, 0);
+                                handler();
+                            });
+                    });
+            });
+    }];
+}
+
+- (void)testDisable_ShouldCallWithFCMToken_WhenCalledExplicitlyWithFCMTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013093";
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+            .enable()
+            .channels(@[@"channel1"])
+            .fcmToken(pushKey)
+            .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                self.client.push()
+                    .disable()
+                    .fcmToken(pushKey)
+                    .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                        self.client.push()
+                            .audit()
+                            .fcmToken(pushKey)
+                            .performWithCompletion(^(PNAPNSEnabledChannelsResult *result, PNErrorStatus *status) {
+                                NSString *url = result.clientRequest.URL.absoluteString;
+                                
+                                XCTAssertNil(status);
+                                XCTAssertNotEqual([url rangeOfString:@"type=gcm"].location, NSNotFound);
+                                XCTAssertEqual(result.data.channels.count, 0);
+                                handler();
+                            });
+                    });
+            });
+    }];
+}
+
+
+#pragma mark - Tests :: audit
+
+- (void)testAudit_ShouldFallbackToAPNSToken_WhenCalledWithTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013092";
+    NSData *pushToken = [pushKey dataFromHexString:pushKey];
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+            .audit()
+            .token(pushToken)
+            .performWithCompletion(^(PNAPNSEnabledChannelsResult *result, PNErrorStatus *status) {
+            NSString *url = result.clientRequest.URL.absoluteString;
+            
+            XCTAssertNil(status);
+            XCTAssertNotEqual([url rangeOfString:@"type=apns"].location, NSNotFound);
+            handler();
+        });
+    }];
+}
+
+- (void)testAudit_ShouldCallWithAPNSToken_WhenCalledExplicitlyWithAPNSTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013092";
+    NSData *pushToken = [pushKey dataFromHexString:pushKey];
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+            .audit()
+            .apnsToken(pushToken)
+            .performWithCompletion(^(PNAPNSEnabledChannelsResult *result, PNErrorStatus *status) {
+                NSString *url = result.clientRequest.URL.absoluteString;
+                
+                XCTAssertNil(status);
+                XCTAssertNotEqual([url rangeOfString:@"type=apns"].location, NSNotFound);
+                handler();
+            });
+    }];
+}
+
+- (void)testAudit_ShouldCallWithFCMToken_WhenCalledExplicitlyWithFCMTokenParameter {
+    NSString *pushKey = @"6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013093";
+    NSString *channel = NSUUID.UUID.UUIDString;
+    
+    [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
+        self.client.push()
+            .enable()
+            .channels(@[channel])
+            .fcmToken(pushKey)
+            .performWithCompletion(^(PNAcknowledgmentStatus *status) {
+                self.client.push()
+                    .audit()
+                    .fcmToken(pushKey)
+                    .performWithCompletion(^(PNAPNSEnabledChannelsResult *result, PNErrorStatus *status) {
+                        NSString *url = result.clientRequest.URL.absoluteString;
+                        
+                        XCTAssertNil(status);
+                        XCTAssertNotEqual([url rangeOfString:@"type=gcm"].location, NSNotFound);
+                        XCTAssertTrue([result.data.channels containsObject:channel]);
+                        handler();
+                    });
+            });
+    }];
+}
+
+#pragma mark -
+
+
+@end

--- a/Tests/iOS Tests/Tests/Integration/PNPubNubHistoryIntegrationTest.m
+++ b/Tests/iOS Tests/Tests/Integration/PNPubNubHistoryIntegrationTest.m
@@ -38,7 +38,6 @@
 
 #pragma mark - Tests
 
-
 @implementation PNPubNubHistoryIntegrationTest
 
 #pragma mark - Setup / Tear down


### PR DESCRIPTION
## 🚀 _push_: add ability to specify FCM token for APNS API
Add ability to pass FCM token for channel add / remove and audition APNS
API endpoints.

## Tests

New group of integration tests has been added to ensure, what `type` is set to proper value, when either `apnsToken` or `fcmToken` specified using API builder call.

## Documentation

@crimsonred this feature will require documentation update. Looks like there is no builder pattern based API documentation for APNS at all. I've created gist with all groups as legacy API (except remove all, because it doesn't have separate option in builder pattern and just require to omit `channels` list): https://gist.github.com/parfeon/1b417bd368bf07f3528c4aa293c9f22f