### PR TITLE
Fix listeners list inherit race of conditions

### DIFF
--- a/PubNub/Data/Managers/PNStateListener.m
+++ b/PubNub/Data/Managers/PNStateListener.m
@@ -139,10 +139,14 @@ NS_ASSUME_NONNULL_END
         return;
     }
     
+    NSHashTable *messageListeners = [listener listenersCopyFrom:listener.messageListeners];
+    NSHashTable *presenceEventListeners = [listener listenersCopyFrom:listener.presenceEventListeners];
+    NSHashTable *stateListeners = [listener listenersCopyFrom:listener.stateListeners];
+    
     dispatch_async(self.resourceAccessQueue, ^{
-        self.messageListeners = [listener listenersCopyFrom:listener.messageListeners];
-        self.presenceEventListeners = [listener listenersCopyFrom:listener.presenceEventListeners];
-        self.stateListeners = [listener listenersCopyFrom:listener.stateListeners];
+        self.messageListeners = messageListeners;
+        self.presenceEventListeners = presenceEventListeners;
+        self.stateListeners = stateListeners;
     });
 }
 

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAddPushOnChannels.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAddPushOnChannels.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:48Z</date>
+	<date>2019-06-21T08:48:34Z</date>
 	<key>scenes</key>
 	<array>
 		<dict>
@@ -17,7 +17,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;type=apns&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -27,18 +27,18 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKROriginalRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.3712611</real>
+					<real>1561106914.682342</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>1ED34BDE-6933-4DAC-A4A6-F9D8BA2143CB</string>
+					<string>0322C015-F510-4CB7-A312-39E35F959B4C</string>
 				</dict>
 				<dict>
 					<key>HTTPMethod</key>
@@ -48,38 +48,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
-					<key>allHTTPHeaderFields</key>
-					<dict>
-						<key>Accept</key>
-						<string>*/*</string>
-						<key>Accept-Encoding</key>
-						<string>gzip,deflate</string>
-						<key>Connection</key>
-						<string>keep-alive</string>
-						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
-					</dict>
-					<key>allowsCellularAccess</key>
-					<true/>
-					<key>class</key>
-					<string>BKRCurrentRequestFrame</string>
-					<key>creationDate</key>
-					<real>1557992208.3715081</real>
-					<key>timeoutInterval</key>
-					<real>60</real>
-					<key>uniqueIdentifier</key>
-					<string>1ED34BDE-6933-4DAC-A4A6-F9D8BA2143CB</string>
-				</dict>
-				<dict>
-					<key>HTTPMethod</key>
-					<string>GET</string>
-					<key>HTTPShouldHandleCookies</key>
-					<true/>
-					<key>HTTPShouldUsePipelining</key>
-					<false/>
-					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;type=apns&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -91,24 +60,24 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKRCurrentRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.3723049</real>
+					<real>1561106914.683235</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>1ED34BDE-6933-4DAC-A4A6-F9D8BA2143CB</string>
+					<string>0322C015-F510-4CB7-A312-39E35F959B4C</string>
 				</dict>
 				<dict>
 					<key>MIMEType</key>
 					<string>text/javascript</string>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;add=1,2,3&amp;type=apns&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHeaderFields</key>
 					<dict>
 						<key>Accept-Ranges</key>
@@ -126,36 +95,34 @@
 						<key>Content-Length</key>
 						<string>24</string>
 						<key>Content-Type</key>
-						<string>text/javascript; charset="UTF-8"</string>
+						<string>text/javascript; charset=&quot;UTF-8&quot;</string>
 						<key>Date</key>
-						<string>Thu, 16 May 2019 07:36:48 GMT</string>
+						<string>Fri, 21 Jun 2019 08:48:35 GMT</string>
 						<key>Server</key>
 						<string>Pubnub</string>
 					</dict>
 					<key>class</key>
 					<string>BKRResponseFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.6401081</real>
+					<real>1561106915.727996</real>
 					<key>statusCode</key>
 					<integer>200</integer>
 					<key>uniqueIdentifier</key>
-					<string>1ED34BDE-6933-4DAC-A4A6-F9D8BA2143CB</string>
+					<string>0322C015-F510-4CB7-A312-39E35F959B4C</string>
 				</dict>
 				<dict>
 					<key>class</key>
 					<string>BKRDataFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.6401949</real>
+					<real>1561106915.72813</real>
 					<key>data</key>
-					<data>
-					WzEsICJNb2RpZmllZCBDaGFubmVscyJd
-					</data>
+					<data>WzEsICJNb2RpZmllZCBDaGFubmVscyJd</data>
 					<key>uniqueIdentifier</key>
-					<string>1ED34BDE-6933-4DAC-A4A6-F9D8BA2143CB</string>
+					<string>0322C015-F510-4CB7-A312-39E35F959B4C</string>
 				</dict>
 			</array>
 			<key>uniqueIdentifier</key>
-			<string>1ED34BDE-6933-4DAC-A4A6-F9D8BA2143CB</string>
+			<string>0322C015-F510-4CB7-A312-39E35F959B4C</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAddPushOnChannelsWithNilPushToken.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAddPushOnChannelsWithNilPushToken.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:48Z</date>
+	<date>2019-06-21T08:48:35Z</date>
 	<key>scenes</key>
 	<array/>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAddPushOnNilChannels.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAddPushOnNilChannels.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:48Z</date>
+	<date>2019-06-21T08:48:35Z</date>
 	<key>scenes</key>
 	<array/>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAuditPushNotificationStatus.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAuditPushNotificationStatus.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:48Z</date>
+	<date>2019-06-21T08:48:35Z</date>
 	<key>scenes</key>
 	<array>
 		<dict>
@@ -17,7 +17,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -27,18 +27,18 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKROriginalRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.6883512</real>
+					<real>1561106915.893078</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>FEA1B709-A0ED-45B6-8D50-CEC83B2902DC</string>
+					<string>1928D191-2754-4EFC-B22D-ECF95F6993C7</string>
 				</dict>
 				<dict>
 					<key>HTTPMethod</key>
@@ -48,7 +48,38 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
+					<key>allHTTPHeaderFields</key>
+					<dict>
+						<key>Accept</key>
+						<string>*/*</string>
+						<key>Accept-Encoding</key>
+						<string>gzip,deflate</string>
+						<key>Connection</key>
+						<string>keep-alive</string>
+						<key>User-Agent</key>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
+					</dict>
+					<key>allowsCellularAccess</key>
+					<true/>
+					<key>class</key>
+					<string>BKRCurrentRequestFrame</string>
+					<key>creationDate</key>
+					<real>1561106915.89315</real>
+					<key>timeoutInterval</key>
+					<real>60</real>
+					<key>uniqueIdentifier</key>
+					<string>1928D191-2754-4EFC-B22D-ECF95F6993C7</string>
+				</dict>
+				<dict>
+					<key>HTTPMethod</key>
+					<string>GET</string>
+					<key>HTTPShouldHandleCookies</key>
+					<true/>
+					<key>HTTPShouldUsePipelining</key>
+					<false/>
+					<key>URL</key>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -60,24 +91,24 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKRCurrentRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.688854</real>
+					<real>1561106915.893543</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>FEA1B709-A0ED-45B6-8D50-CEC83B2902DC</string>
+					<string>1928D191-2754-4EFC-B22D-ECF95F6993C7</string>
 				</dict>
 				<dict>
 					<key>MIMEType</key>
 					<string>text/javascript</string>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHeaderFields</key>
 					<dict>
 						<key>Accept-Ranges</key>
@@ -95,36 +126,34 @@
 						<key>Content-Length</key>
 						<string>15</string>
 						<key>Content-Type</key>
-						<string>text/javascript; charset="UTF-8"</string>
+						<string>text/javascript; charset=&quot;UTF-8&quot;</string>
 						<key>Date</key>
-						<string>Thu, 16 May 2019 07:36:48 GMT</string>
+						<string>Fri, 21 Jun 2019 08:48:36 GMT</string>
 						<key>Server</key>
 						<string>Pubnub</string>
 					</dict>
 					<key>class</key>
 					<string>BKRResponseFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.9095809</real>
+					<real>1561106916.853613</real>
 					<key>statusCode</key>
 					<integer>200</integer>
 					<key>uniqueIdentifier</key>
-					<string>FEA1B709-A0ED-45B6-8D50-CEC83B2902DC</string>
+					<string>1928D191-2754-4EFC-B22D-ECF95F6993C7</string>
 				</dict>
 				<dict>
 					<key>class</key>
 					<string>BKRDataFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.9096398</real>
+					<real>1561106916.853642</real>
 					<key>data</key>
-					<data>
-					WyIxIiwgIjMiLCAiMiJd
-					</data>
+					<data>WyIxIiwgIjMiLCAiMiJd</data>
 					<key>uniqueIdentifier</key>
-					<string>FEA1B709-A0ED-45B6-8D50-CEC83B2902DC</string>
+					<string>1928D191-2754-4EFC-B22D-ECF95F6993C7</string>
 				</dict>
 			</array>
 			<key>uniqueIdentifier</key>
-			<string>FEA1B709-A0ED-45B6-8D50-CEC83B2902DC</string>
+			<string>1928D191-2754-4EFC-B22D-ECF95F6993C7</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAuditPushNotificationStatusWithNilPushToken.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testAuditPushNotificationStatusWithNilPushToken.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:48Z</date>
+	<date>2019-06-21T08:48:36Z</date>
 	<key>scenes</key>
 	<array/>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemoveAllPushNotificationFromDevice.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemoveAllPushNotificationFromDevice.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:48Z</date>
+	<date>2019-06-21T08:48:36Z</date>
 	<key>scenes</key>
 	<array>
 		<dict>
@@ -17,7 +17,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -27,18 +27,18 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKROriginalRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.938206</real>
+					<real>1561106916.882332</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>F3854270-4995-42AA-97B9-510984C89FBF</string>
+					<string>F514BAB8-26EC-4E1B-A0EE-86065AC5320C</string>
 				</dict>
 				<dict>
 					<key>HTTPMethod</key>
@@ -48,7 +48,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -60,24 +60,24 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKRCurrentRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992208.9384089</real>
+					<real>1561106916.882649</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>F3854270-4995-42AA-97B9-510984C89FBF</string>
+					<string>F514BAB8-26EC-4E1B-A0EE-86065AC5320C</string>
 				</dict>
 				<dict>
 					<key>MIMEType</key>
 					<string>text/javascript</string>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHeaderFields</key>
 					<dict>
 						<key>Accept-Ranges</key>
@@ -95,36 +95,34 @@
 						<key>Content-Length</key>
 						<string>21</string>
 						<key>Content-Type</key>
-						<string>text/javascript; charset="UTF-8"</string>
+						<string>text/javascript; charset=&quot;UTF-8&quot;</string>
 						<key>Date</key>
-						<string>Thu, 16 May 2019 07:36:49 GMT</string>
+						<string>Fri, 21 Jun 2019 08:48:37 GMT</string>
 						<key>Server</key>
 						<string>Pubnub</string>
 					</dict>
 					<key>class</key>
 					<string>BKRResponseFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.1913729</real>
+					<real>1561106917.8787</real>
 					<key>statusCode</key>
 					<integer>200</integer>
 					<key>uniqueIdentifier</key>
-					<string>F3854270-4995-42AA-97B9-510984C89FBF</string>
+					<string>F514BAB8-26EC-4E1B-A0EE-86065AC5320C</string>
 				</dict>
 				<dict>
 					<key>class</key>
 					<string>BKRDataFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.1914001</real>
+					<real>1561106917.878746</real>
 					<key>data</key>
-					<data>
-					WzEsICJSZW1vdmVkIERldmljZSJd
-					</data>
+					<data>WzEsICJSZW1vdmVkIERldmljZSJd</data>
 					<key>uniqueIdentifier</key>
-					<string>F3854270-4995-42AA-97B9-510984C89FBF</string>
+					<string>F514BAB8-26EC-4E1B-A0EE-86065AC5320C</string>
 				</dict>
 			</array>
 			<key>uniqueIdentifier</key>
-			<string>F3854270-4995-42AA-97B9-510984C89FBF</string>
+			<string>F514BAB8-26EC-4E1B-A0EE-86065AC5320C</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemoveAllPushNotificationFromDeviceWithNilToken.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemoveAllPushNotificationFromDeviceWithNilToken.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:49Z</date>
+	<date>2019-06-21T08:48:37Z</date>
 	<key>scenes</key>
 	<array/>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromChannel.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromChannel.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:49Z</date>
+	<date>2019-06-21T08:48:37Z</date>
 	<key>scenes</key>
 	<array>
 		<dict>
@@ -17,7 +17,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?remove=1,2,3&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?pnsdk=PubNub-ObjC-iOS%2F4.8.9&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;remove=1,2,3</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -27,18 +27,18 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKROriginalRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.2184029</real>
+					<real>1561106917.913481</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>1777937B-354D-4EBA-8A06-E35C416459C2</string>
+					<string>006F24C5-61E4-4E66-8EA0-7582DFBDDEC4</string>
 				</dict>
 				<dict>
 					<key>HTTPMethod</key>
@@ -48,7 +48,38 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?remove=1,2,3&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?pnsdk=PubNub-ObjC-iOS%2F4.8.9&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;remove=1,2,3</string>
+					<key>allHTTPHeaderFields</key>
+					<dict>
+						<key>Accept</key>
+						<string>*/*</string>
+						<key>Accept-Encoding</key>
+						<string>gzip,deflate</string>
+						<key>Connection</key>
+						<string>keep-alive</string>
+						<key>User-Agent</key>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
+					</dict>
+					<key>allowsCellularAccess</key>
+					<true/>
+					<key>class</key>
+					<string>BKRCurrentRequestFrame</string>
+					<key>creationDate</key>
+					<real>1561106917.913515</real>
+					<key>timeoutInterval</key>
+					<real>60</real>
+					<key>uniqueIdentifier</key>
+					<string>006F24C5-61E4-4E66-8EA0-7582DFBDDEC4</string>
+				</dict>
+				<dict>
+					<key>HTTPMethod</key>
+					<string>GET</string>
+					<key>HTTPShouldHandleCookies</key>
+					<true/>
+					<key>HTTPShouldUsePipelining</key>
+					<false/>
+					<key>URL</key>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?pnsdk=PubNub-ObjC-iOS%2F4.8.9&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;remove=1,2,3</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -60,24 +91,24 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKRCurrentRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.2186089</real>
+					<real>1561106917.91413</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>1777937B-354D-4EBA-8A06-E35C416459C2</string>
+					<string>006F24C5-61E4-4E66-8EA0-7582DFBDDEC4</string>
 				</dict>
 				<dict>
 					<key>MIMEType</key>
 					<string>text/javascript</string>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?remove=1,2,3&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091?pnsdk=PubNub-ObjC-iOS%2F4.8.9&amp;uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;remove=1,2,3</string>
 					<key>allHeaderFields</key>
 					<dict>
 						<key>Accept-Ranges</key>
@@ -95,36 +126,34 @@
 						<key>Content-Length</key>
 						<string>24</string>
 						<key>Content-Type</key>
-						<string>text/javascript; charset="UTF-8"</string>
+						<string>text/javascript; charset=&quot;UTF-8&quot;</string>
 						<key>Date</key>
-						<string>Thu, 16 May 2019 07:36:49 GMT</string>
+						<string>Fri, 21 Jun 2019 08:48:38 GMT</string>
 						<key>Server</key>
 						<string>Pubnub</string>
 					</dict>
 					<key>class</key>
 					<string>BKRResponseFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.4945669</real>
+					<real>1561106918.902308</real>
 					<key>statusCode</key>
 					<integer>200</integer>
 					<key>uniqueIdentifier</key>
-					<string>1777937B-354D-4EBA-8A06-E35C416459C2</string>
+					<string>006F24C5-61E4-4E66-8EA0-7582DFBDDEC4</string>
 				</dict>
 				<dict>
 					<key>class</key>
 					<string>BKRDataFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.494607</real>
+					<real>1561106918.902373</real>
 					<key>data</key>
-					<data>
-					WzEsICJNb2RpZmllZCBDaGFubmVscyJd
-					</data>
+					<data>WzEsICJNb2RpZmllZCBDaGFubmVscyJd</data>
 					<key>uniqueIdentifier</key>
-					<string>1777937B-354D-4EBA-8A06-E35C416459C2</string>
+					<string>006F24C5-61E4-4E66-8EA0-7582DFBDDEC4</string>
 				</dict>
 			</array>
 			<key>uniqueIdentifier</key>
-			<string>1777937B-354D-4EBA-8A06-E35C416459C2</string>
+			<string>006F24C5-61E4-4E66-8EA0-7582DFBDDEC4</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromChannelWithNilDevicePushToken.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromChannelWithNilDevicePushToken.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:49Z</date>
+	<date>2019-06-21T08:48:38Z</date>
 	<key>scenes</key>
 	<array/>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromNilChannel.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromNilChannel.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:49Z</date>
+	<date>2019-06-21T08:48:38Z</date>
 	<key>scenes</key>
 	<array>
 		<dict>
@@ -17,7 +17,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -27,18 +27,18 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKROriginalRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.5399189</real>
+					<real>1561106918.936164</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>95280E80-0311-450B-9BD7-5C726344054E</string>
+					<string>0061DAAD-7D53-4235-83D0-B89000CA8009</string>
 				</dict>
 				<dict>
 					<key>HTTPMethod</key>
@@ -48,7 +48,7 @@
 					<key>HTTPShouldUsePipelining</key>
 					<false/>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHTTPHeaderFields</key>
 					<dict>
 						<key>Accept</key>
@@ -60,24 +60,24 @@
 						<key>Connection</key>
 						<string>keep-alive</string>
 						<key>User-Agent</key>
-						<string>iPhone; CPU iPhone OS 12.1.0 Version</string>
+						<string>iPhone; CPU iPhone OS 12.2.0 Version</string>
 					</dict>
 					<key>allowsCellularAccess</key>
 					<true/>
 					<key>class</key>
 					<string>BKRCurrentRequestFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.540122</real>
+					<real>1561106918.936449</real>
 					<key>timeoutInterval</key>
 					<real>60</real>
 					<key>uniqueIdentifier</key>
-					<string>95280E80-0311-450B-9BD7-5C726344054E</string>
+					<string>0061DAAD-7D53-4235-83D0-B89000CA8009</string>
 				</dict>
 				<dict>
 					<key>MIMEType</key>
 					<string>text/javascript</string>
 					<key>URL</key>
-					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.7</string>
+					<string>https://ps.pndsn.com/v1/push/sub-key/rsub-c-00000000-0000-0000-0000-000000000000/devices/6652cff7f17536c86bc353527017741ec07a91699661abaf68c5977a83013091/remove?uuid=322A70B3-F0EA-48CD-9BB0-D3F0F5DE996C&amp;instanceid=58EB05C9-9DE4-4118-B5D7-EE059FBF19A9&amp;deviceid=3650F534-FC54-4EE8-884C-EF1B83188BB7&amp;type=apns&amp;pnsdk=PubNub-ObjC-iOS%2F4.8.9</string>
 					<key>allHeaderFields</key>
 					<dict>
 						<key>Accept-Ranges</key>
@@ -95,36 +95,34 @@
 						<key>Content-Length</key>
 						<string>21</string>
 						<key>Content-Type</key>
-						<string>text/javascript; charset="UTF-8"</string>
+						<string>text/javascript; charset=&quot;UTF-8&quot;</string>
 						<key>Date</key>
-						<string>Thu, 16 May 2019 07:36:49 GMT</string>
+						<string>Fri, 21 Jun 2019 08:48:39 GMT</string>
 						<key>Server</key>
 						<string>Pubnub</string>
 					</dict>
 					<key>class</key>
 					<string>BKRResponseFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.779315</real>
+					<real>1561106919.904523</real>
 					<key>statusCode</key>
 					<integer>200</integer>
 					<key>uniqueIdentifier</key>
-					<string>95280E80-0311-450B-9BD7-5C726344054E</string>
+					<string>0061DAAD-7D53-4235-83D0-B89000CA8009</string>
 				</dict>
 				<dict>
 					<key>class</key>
 					<string>BKRDataFrame</string>
 					<key>creationDate</key>
-					<real>1557992209.7793641</real>
+					<real>1561106919.904554</real>
 					<key>data</key>
-					<data>
-					WzEsICJSZW1vdmVkIERldmljZSJd
-					</data>
+					<data>WzEsICJSZW1vdmVkIERldmljZSJd</data>
 					<key>uniqueIdentifier</key>
-					<string>95280E80-0311-450B-9BD7-5C726344054E</string>
+					<string>0061DAAD-7D53-4235-83D0-B89000CA8009</string>
 				</dict>
 			</array>
 			<key>uniqueIdentifier</key>
-			<string>95280E80-0311-450B-9BD7-5C726344054E</string>
+			<string>0061DAAD-7D53-4235-83D0-B89000CA8009</string>
 		</dict>
 	</array>
 	<key>version</key>

--- a/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromNilChannelWithNilDevicePushToken.plist
+++ b/Tests/iOS Tests/Fixtures/PNAPNSTests.bundle/testRemovePushNotificationFromNilChannelWithNilDevicePushToken.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>creationDate</key>
-	<date>2019-05-16T07:36:49Z</date>
+	<date>2019-06-21T08:48:39Z</date>
 	<key>scenes</key>
 	<array/>
 	<key>version</key>

--- a/Tests/iOS Tests/Tests/PNPublishCompressedTests.m
+++ b/Tests/iOS Tests/Tests/PNPublishCompressedTests.m
@@ -39,7 +39,7 @@
                           NSLog(@"status.data.information: %@", status.data.information);
                           NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                           XCTAssertEqualObjects(status.data.information, @"Sent");
-                          XCTAssertEqualObjects(status.data.timetoken, @15579290210619794);
+                          XCTAssertNotNil(status.data.timetoken);
                       }];
 }
 
@@ -56,7 +56,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579290221180226);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 

--- a/Tests/iOS Tests/Tests/PNPublishTests.m
+++ b/Tests/iOS Tests/Tests/PNPublishTests.m
@@ -36,7 +36,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309706510371);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -66,7 +66,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309675380331);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -94,7 +94,7 @@
         NSLog(@"status.data.information: %@", status.data.information);
         NSLog(@"status.data.timeToken: %@", status.data.timetoken);
         XCTAssertEqualObjects(status.data.information, @"Sent");
-        XCTAssertEqualObjects(status.data.timetoken, @15579309677819067);
+        XCTAssertNotNil(status.data.timetoken);
     }];
 }
 
@@ -110,7 +110,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309680941913);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -126,7 +126,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309669122726);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -142,7 +142,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309671612776);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -202,7 +202,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309664230353);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -222,7 +222,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579309683556526);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -247,7 +247,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309686166447);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -278,7 +278,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309696139899);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -309,7 +309,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309652322208);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -372,7 +372,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309688874229);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -404,7 +404,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309698842761);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -436,7 +436,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309654727293);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -500,7 +500,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309691443739);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -532,7 +532,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309701199838);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -564,7 +564,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309657266143);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -629,7 +629,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309693711291);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -662,7 +662,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309703645034);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];
@@ -695,7 +695,7 @@
               NSLog(@"status.data.information: %@", status.data.information);
               NSLog(@"status.data.timeToken: %@", status.data.timetoken);
               XCTAssertEqualObjects(status.data.information, @"Sent");
-              XCTAssertEqualObjects(status.data.timetoken, @15579309659595591);
+              XCTAssertNotNil(status.data.timetoken);
               
               [networkExpectation fulfill];
           }];

--- a/Tests/iOS Tests/Tests/PNPublishWithHistoryTests.m
+++ b/Tests/iOS Tests/Tests/PNPublishWithHistoryTests.m
@@ -39,7 +39,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579389980468737);
+                      XCTAssertNotNil(status.data.timetoken);
     }];
 }
 
@@ -55,7 +55,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579389983119314);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -106,7 +106,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579389974228260);
+                      XCTAssertNotNil(status.data.timetoken);
     }];
 }
 
@@ -123,7 +123,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579389977161012);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 

--- a/Tests/iOS Tests/Tests/PNPublishWithMobilePayloadTests.m
+++ b/Tests/iOS Tests/Tests/PNPublishWithMobilePayloadTests.m
@@ -49,7 +49,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579392339292296);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -68,7 +68,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579392336778917);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 
@@ -94,7 +94,7 @@
                       NSLog(@"status.data.information: %@", status.data.information);
                       NSLog(@"status.data.timeToken: %@", status.data.timetoken);
                       XCTAssertEqualObjects(status.data.information, @"Sent");
-                      XCTAssertEqualObjects(status.data.timetoken, @15579392331600180);
+                      XCTAssertNotNil(status.data.timetoken);
                   }];
 }
 


### PR DESCRIPTION
## 🛠 fix listeners list inherit race of conditions

Fix issue because of which listener from which listenres has been inherited able to
clean it before new listener will get that list (because new one make call on async
private queue).