### PR TITLE
Fix framework umbrella headers missing Objects API import

### DIFF
--- a/Framework/PubNub/PubNub.h
+++ b/Framework/PubNub/PubNub.h
@@ -1,7 +1,8 @@
 /**
- @author Sergey Mamontov
- @version 4.2.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @version 4.10.1
+ * @since 4.2.0
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 
@@ -53,6 +54,7 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 #import "PubNub+Presence.h"
 #import "PubNub+Publish.h"
 #import "PubNub+History.h"
+#import "PubNub+Objects.h"
 #import "PubNub+State.h"
 #import "PNErrorCodes.h"
 #import "PNStructures.h"

--- a/Support/Fabric/Headers/PubNub.h
+++ b/Support/Fabric/Headers/PubNub.h
@@ -1,7 +1,8 @@
 /**
- @author Sergey Mamontov
- @version 4.8.4
- @copyright © 2010-2019 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @version 4.10.1
+ * @since 4.8.4
+ * @copyright © 2010-2019 PubNub, Inc.
  */
 #import <Foundation/Foundation.h>
 
@@ -53,6 +54,7 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 #import "PubNub+Presence.h"
 #import "PubNub+Publish.h"
 #import "PubNub+History.h"
+#import "PubNub+Objects.h"
 #import "PubNub+State.h"
 #import "PNErrorCodes.h"
 #import "PNStructures.h"


### PR DESCRIPTION
## 🛠 _Frameworks_: add missing Objects API interface import for Frameworks

Framework umbrella header is missing import of `PubNub+Objects.h` which introduce new interface to work with Objects API.