### PR TITLE
Enhance publish sequence manager performance

### DIFF
--- a/PubNub/Data/Managers/PNPublishSequence.h
+++ b/PubNub/Data/Managers/PNPublishSequence.h
@@ -8,60 +8,57 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma mark - Interface declaration
+
 /**
- @brief      Published messages sequence tracking manager.
- @discussion \b PubNub client allow to assign for each published messages it's sequence number. Manager allow 
-             to keep track on published sequence number even after application restart.
- 
- @author Sergey Mamontov
- @since 4.5.2
- @copyright © 2010-2018 PubNub, Inc.
+ * @brief Published messages sequence tracking manager.
+ *
+ * @discussion \b PubNub client allow to assign for each published messages it's sequence number.
+ * Manager allow to keep track on published sequence number even after application restart.
+ *
+ * @author Sergey Mamontov
+ * @version 4.10.2
+ * @since 4.5.2
+ * @copyright © 2010-2019 PubNub, Inc.
  */
 @interface PNPublishSequence : NSObject
 
 
-///------------------------------------------------
-/// @name Information
-///------------------------------------------------
+#pragma mark - Information
 
 /**
- @brief  Stores reference on sequence number which has been used for recent message publish API usage.
- 
- @since 4.5.2
+ * @brief Sequence number which has been used for recent message publish API usage.
  */
 @property (nonatomic, readonly, assign) NSUInteger sequenceNumber;
 
 /**
- @brief  Retrieve sequence number for next message and update current value if requested.
- 
- @param shouldUpdateCurrent Whether current value should be set to the one which is returned by this method.
- 
- @return Next published message sequence number.
- 
- @since 4.5.2
+ * @brief Sequence number for next message and update current value if requested.
+ *
+ * @param shouldUpdateCurrent Whether current value should be set to the one which is returned by
+ * this method.
+ *
+ * @return Next published message sequence number.
  */
 - (NSUInteger)nextSequenceNumber:(BOOL)shouldUpdateCurrent;
 
 
-///------------------------------------------------
-/// @name Initialization and Configuration
-///------------------------------------------------
+#pragma mark - Initialization and Configuration
 
 /**
- @brief      Create and configure published messages sequence manager.
- @discussion If instance for same publish key already created it will be reused.
- 
- @param client Reference on client for which published messages sequence manager should be created.
- 
- @return Configured and ready to use client published messages sequence manager.
- 
- @since 4.5.2
+ * @brief Create and configure published messages sequence manager.
+ *
+ * @note If instance for same publish key already created it will be reused.
+ *
+ * @param client Client for which published messages sequence manager should be created.
+ *
+ * @return Configured and ready to use client published messages sequence manager.
  */
 + (instancetype)sequenceForClient:(PubNub *)client;
 
 /**
- @brief      Reset all information which is related to publish message sequence.
- @discussion All data will be reset and removed from \b Keychain.
+ * @brief Reset all information which is related to publish message sequence.
+ *
+ * @discussion All data will be reset and removed from \b Keychain.
  */
 - (void)reset;
 

--- a/PubNub/Data/Managers/PNPublishSequence.m
+++ b/PubNub/Data/Managers/PNPublishSequence.m
@@ -1,4 +1,9 @@
-
+/**
+ * @author Sergey Mamontov
+ * @version 4.11.0
+ * @since 4.5.2
+ * @copyright © 2010-2019 PubNub, Inc.
+ */
 #import "PNPublishSequence.h"
 
 #if TARGET_OS_IOS
@@ -18,26 +23,21 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark Static
 
 /**
- @brief  Stores reference on key under which in Keychain stored information about previously used sequence 
-         number for message publish.
- 
- @since 4.5.2
+ * @brief Key under which in Keychain stored information about previously used sequence number for
+ * message publish.
  */
 static NSString * const kPNPublishSequenceDataKey = @"pn_publishSequence";
 
 /**
- @brief      Stores reference on maximum age of \c publish key inactiviry after which it will be removed and 
-             count for it will be reset to \b 0.
- @discussion \b Default: 30 days
- 
- @since 4.5.2
+ * @brief Maximum age of \c publish key inactivity after which it will be removed and count for it
+ * will be reset to \b 0.
+ *
+ * @note \b Default: 30 days
  */
 static NSUInteger const kPNMaximumPublishSequenceDataAge = (30 * 24 * 60 * 60);
 
 /**
- @brief  Spin-lock which is used to protect access to shared resources from multiple threads.
- 
- @since 4.5.2
+ * @brief Spin-lock which is used to protect access to shared resources from multiple threads.
  */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
@@ -48,29 +48,22 @@ static os_unfair_lock publishSequenceKeychainAccessLock = OS_UNFAIR_LOCK_INIT;
 #pragma mark - Structures
 
 /**
- @brief  Describes storable sequence manager data structure.
- 
- @since 4.5.2
+ * @brief Storable sequence manager data structure.
  */
 struct PNPublishSequenceDataStructure {
     
     /**
-     @brief  Stores reference on key under which stored date when sequence last has been re-saved / modified.
-     
-     @since 4.5.2
+     * @brief Key under which stored date when sequence last has been re-saved / modified.
      */
     __unsafe_unretained NSString *lastSaveDate;
     
     /**
-     @brief  Stores reference key under which stored last saved sequence number value.
-     
-     @since 4.5.2
+     * @brief Key under which stored last saved sequence number value.
      */
     __unsafe_unretained NSString *sequence;
 };
 
 struct PNPublishSequenceDataStructure PNPublishSequenceData = {
-    
     .lastSaveDate = @"sd",
     .sequence = @"sn"
 };
@@ -79,12 +72,9 @@ struct PNPublishSequenceDataStructure PNPublishSequenceData = {
 #pragma mark - Private interface declaration
 
 @interface PNPublishSequence () {
-    
     /**
-     @brief  Stores reference on spin-lock which is used to protect access to current message sequence number
-             which can be changed at any moment.
-     
-     @since 4.5.2
+     * @brief Spin-lock which is used to protect access to current message sequence number which can
+     * be changed at any moment.
      */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
@@ -96,18 +86,22 @@ struct PNPublishSequenceDataStructure PNPublishSequenceData = {
 #pragma mark - Information
 
 /**
- @brief  Weak reference on client for which state cache manager created.
- 
- @since 4.5.2
+ * @brief Client for which state cache manager created.
  */
 @property (nonatomic, weak) PubNub *client;
 
+/**
+ * @brief Sequence number which has been used for recent message publish API usage.
+ */
 @property (nonatomic, assign) NSUInteger sequenceNumber;
 
 /**
- @brief  Stores reference on current \b PubNub client publish key.
- 
- @since 4.5.2
+ * @brief Whether stored sequence number for \b publishKey has been changed or not.
+ */
+@property (nonatomic, assign) BOOL sequenceNumberChanged;
+
+/**
+ * @brief Current \b PubNub client publish key.
  */
 @property (nonatomic, copy) NSString *publishKey;
 
@@ -115,23 +109,19 @@ struct PNPublishSequenceDataStructure PNPublishSequenceData = {
 #pragma mark - Initialization and Configuration
 
 /**
- @brief  Retrieve reference on dictionary which store initialized publish sequence number managers.
- 
- @return Dictionary where publish sequence numbers stored under publish keys which is used for \b PubNub 
-         client configuration.
- 
- @since 4.5.2
+ * @brief Dictionary which store initialized publish sequence number managers.
+ *
+ * @return Dictionary where publish sequence numbers stored under publish keys which is used for
+ * \b PubNub client configuration.
  */
 + (NSMutableDictionary<NSString *, PNPublishSequence *> *)sequenceManagers;
 
 /**
- @brief  Initialize published messages sequence manager.
- 
- @param client Reference on client for which published messages sequence manager should be created.
- 
- @return Initialized and ready to use client published messages sequence manager.
- 
- @since 4.5.2
+ * @brief Initialize published messages sequence manager.
+ *
+ * @param client Client for which published messages sequence manager should be created.
+ *
+ * @return Initialized and ready to use client published messages sequence manager.
  */
 - (instancetype)initForClient:(PubNub *)client;
 
@@ -139,25 +129,17 @@ struct PNPublishSequenceDataStructure PNPublishSequenceData = {
 #pragma mark - Data storage
 
 /**
- @brief      Fetch sequence information from \b Keychain.
- @discussion Use persistent data from \b Keychain to properly track messages sequence number for each publish 
-             key. 
- 
- @since 4.5.2
+ * @brief Fetch sequence information from \b Keychain.
  */
 - (void)loadFromPersistentStorage;
 
 /**
- @brief  Store in-memory sequence information to \b Keychain.
- 
- @since 4.5.2
+ * @brief Store in-memory sequence information to \b Keychain.
  */
 - (void)saveToPersistentStorage;
 
 /**
- @brief  Clean-up sequence information from information about \c old publish keys.
- 
- @since 4.5.2
+ * @brief Clean-up sequence information from information about \c old publish keys.
  */
 - (void)cleanUpIfRequired;
 
@@ -165,12 +147,9 @@ struct PNPublishSequenceDataStructure PNPublishSequenceData = {
 #pragma mark - Handlers
 
 /**
- @brief  Handle application transition between different execution contexts.
- 
- @param notification Reference on object which stored information about notification which triggered callback
-                     and name of notification which will allow to decide further actions.
- 
- @since 4.5.2
+ * @brief Handle application transition between different execution contexts.
+ *
+ * @param notification Notification which triggered callback.
  */
 - (void)handleContextTransition:(NSNotification *)notification;
 
@@ -178,11 +157,10 @@ struct PNPublishSequenceDataStructure PNPublishSequenceData = {
 #pragma mark - Misc
 
 /**
- @brief      Subscribe to application context change notifications.
- @discussion Context change allow to react and if required save sequence data information into persistent 
-             storage.
- 
- @since 4.5.2
+ * @brief Subscribe to application context change notifications.
+ *
+ * @discussion Context change allow to react and if required save sequence data information into
+ * persistent storage.
  */
 - (void)subscribeOnNotifications;
 
@@ -202,61 +180,74 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Information
 
 - (NSUInteger)sequenceNumber {
-    
     __block NSUInteger sequenceNumber = 0;
-    pn_lock(&_lock, ^{ sequenceNumber = self->_sequenceNumber; });
+    
+    pn_lock(&_lock, ^{
+        sequenceNumber = self->_sequenceNumber;
+    });
     
     return sequenceNumber;
 }
 
 - (NSUInteger)nextSequenceNumber:(BOOL)shouldUpdateCurrent {
-    
     __block NSUInteger sequenceNumber = 0;
+    
     pn_lock(&_lock, ^{
-        sequenceNumber = (self->_sequenceNumber == NSUIntegerMax ? 1 : self->_sequenceNumber + 1);
-        if (shouldUpdateCurrent) { self->_sequenceNumber = sequenceNumber; }
+        sequenceNumber = self->_sequenceNumber == NSUIntegerMax ? 1 : self->_sequenceNumber + 1;
+        
+        if (shouldUpdateCurrent) {
+            self->_sequenceNumber = sequenceNumber;
+            self->_sequenceNumberChanged = YES;
+        }
     });
     
     return sequenceNumber;
+}
+
+- (BOOL)sequenceNumberChanged {
+    __block BOOL sequenceNumberChanged = 0;
+    
+    pn_lock(&_lock, ^{
+        sequenceNumberChanged = self->_sequenceNumberChanged;
+    });
+    
+    return sequenceNumberChanged;
 }
 
 
 #pragma mark - Initialization and Configuration
 
 + (instancetype)sequenceForClient:(PubNub *)client {
-    
     PNPublishSequence *manager = nil;
     NSMutableDictionary<NSString *, PNPublishSequence *> *sequenceManagers = [self sequenceManagers];
+    
     @synchronized (sequenceManagers) {
-        
         manager = sequenceManagers[client.currentConfiguration.publishKey];
+        
         if (!manager) {
-            
             manager = [[self alloc] initForClient:client];
             sequenceManagers[client.currentConfiguration.publishKey] = manager;
+        } else {
+            manager.client = client;
         }
-        // In case if received manager which existed after PubNub client has been deallocated it should be set
-        // new reference on client.
-        if (manager.client == nil) { manager.client = client; }
     }
     
     return manager;
 }
 
 + (NSMutableDictionary<NSString *, PNPublishSequence *> *)sequenceManagers {
-    
     static NSMutableDictionary<NSString *, PNPublishSequence *> *_sharedSequenceManagers;
     static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ _sharedSequenceManagers = [NSMutableDictionary new]; });
+    
+    dispatch_once(&onceToken, ^{
+        _sharedSequenceManagers = [NSMutableDictionary new];
+    });
     
     return _sharedSequenceManagers;
 }
 
 - (instancetype)initForClient:(PubNub *)client {
-    
-    // Check whether initialization was successful or not.
     if ((self = [super init])) {
-        
         _client = client;
         _publishKey = client.currentConfiguration.publishKey;
 #pragma clang diagnostic push
@@ -273,8 +264,11 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)reset {
+    pn_lock(&_lock, ^{
+        self->_sequenceNumberChanged = YES;
+        self->_sequenceNumber = 0;
+    });
     
-    pn_lock(&_lock, ^{ self->_sequenceNumber = 0; });
     [self saveToPersistentStorage];
 }
 
@@ -282,69 +276,82 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Data storage
 
 - (void)loadFromPersistentStorage {
-    
     pn_lock_async(&publishSequenceKeychainAccessLock, ^(dispatch_block_t completion) {
-        
-        [PNKeychain valueForKey:kPNPublishSequenceDataKey withCompletionBlock:^(NSDictionary *sequences) {
+        [PNKeychain valueForKey:kPNPublishSequenceDataKey
+            withCompletionBlock:^(NSDictionary *sequences) {
             
             NSMutableDictionary *mutableSequences = [(sequences?: @{}) mutableCopy];
             NSMutableDictionary *sequenceData = [(mutableSequences[self.publishKey]?: @{}) mutableCopy];
             NSNumber *sequenceNumber = (NSNumber *)sequenceData[PNPublishSequenceData.sequence];
             sequenceData[PNPublishSequenceData.lastSaveDate] = @([NSDate date].timeIntervalSince1970);
             self->_sequenceNumber = sequenceNumber.unsignedIntegerValue;
-            [PNKeychain storeValue:mutableSequences forKey:kPNPublishSequenceDataKey
-               withCompletionBlock:^(BOOL stored) { completion(); }];
+            
+            [PNKeychain storeValue:mutableSequences
+                            forKey:kPNPublishSequenceDataKey
+               withCompletionBlock:^(BOOL stored) {
+                   
+                   completion();
+               }];
         }];
     });
 }
 
 - (void)saveToPersistentStorage {
+    if (!self.sequenceNumberChanged) {
+        return;
+    }
+
+    pn_lock(&_lock, ^{
+        self->_sequenceNumberChanged = NO;
+    });
     
     pn_lock_async(&publishSequenceKeychainAccessLock, ^(dispatch_block_t completion) {
-        
-        // Perform data maniupulation only if PubNub client, for which manager has been created, still 
-        // available. 
-        if (self.client != nil) {
-            
-            [PNKeychain valueForKey:kPNPublishSequenceDataKey withCompletionBlock:^(NSDictionary *sequences) {
+        [PNKeychain valueForKey:kPNPublishSequenceDataKey
+            withCompletionBlock:^(NSDictionary *sequences) {
                 
-                NSMutableDictionary *mutableSequences = [(sequences?: @{}) mutableCopy];
-                NSMutableDictionary *sequenceData = [(mutableSequences[self.publishKey]?: @{}) mutableCopy];
-                sequenceData[PNPublishSequenceData.sequence] = @(self.sequenceNumber);
-                sequenceData[PNPublishSequenceData.lastSaveDate] = @([NSDate date].timeIntervalSince1970);
-                mutableSequences[self.publishKey] = sequenceData;
-                [PNKeychain storeValue:mutableSequences forKey:kPNPublishSequenceDataKey
-                   withCompletionBlock:^(BOOL stored) { completion(); }];
-            }];
-        }
+            NSMutableDictionary *mutableSequences = [(sequences?: @{}) mutableCopy];
+            NSMutableDictionary *sequenceData = [(mutableSequences[self.publishKey]?: @{}) mutableCopy];
+            sequenceData[PNPublishSequenceData.sequence] = @(self.sequenceNumber);
+            sequenceData[PNPublishSequenceData.lastSaveDate] = @([NSDate date].timeIntervalSince1970);
+            mutableSequences[self.publishKey] = sequenceData;
+            
+            [PNKeychain storeValue:mutableSequences
+                            forKey:kPNPublishSequenceDataKey
+               withCompletionBlock:^(BOOL stored) {
+                   
+                   completion();
+               }];
+        }];
     });
 }
 
 - (void)cleanUpIfRequired {
-
     NSTimeInterval currentTimestamp = [NSDate date].timeIntervalSince1970;
+    
     pn_lock_async(&publishSequenceKeychainAccessLock, ^(dispatch_block_t completion) {
-        
         [PNKeychain valueForKey:kPNPublishSequenceDataKey withCompletionBlock:^(NSDictionary *sequences) {
             
             NSMutableDictionary *mutableSequences = [(sequences?: @{}) mutableCopy];
-            [mutableSequences enumerateKeysAndObjectsUsingBlock:^(NSString *publishKey, 
+            [mutableSequences enumerateKeysAndObjectsUsingBlock:^(NSString *publishKey,
                                                                   NSDictionary *sequenceData,
                                                                   BOOL *sequencesEnumeratorStop) {
                 
                 if (![publishKey isEqualToString:self.publishKey]) {
-                    
                     NSNumber *lastUpdateDate = sequenceData[PNPublishSequenceData.lastSaveDate];
                     NSTimeInterval lastUpdateTimestamp = lastUpdateDate.doubleValue;
+                    
                     if (ABS(currentTimestamp - lastUpdateTimestamp) > kPNMaximumPublishSequenceDataAge) {
-                        
                         mutableSequences[publishKey] = nil;
                     }
                 }
             }];
             
-            [PNKeychain storeValue:mutableSequences forKey:kPNPublishSequenceDataKey
-               withCompletionBlock:^(BOOL stored) { completion(); }];
+            [PNKeychain storeValue:mutableSequences
+                            forKey:kPNPublishSequenceDataKey
+               withCompletionBlock:^(BOOL stored) {
+                   
+                   completion();
+               }];
         }];
     });
 }
@@ -353,7 +360,6 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Handlers
 
 - (void)handleContextTransition:(NSNotification *)notification {
-    
     [self saveToPersistentStorage];
 }
 
@@ -361,27 +367,43 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Misc
 
 - (void)subscribeOnNotifications {
-    
 #if TARGET_OS_IOS
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:) 
-                               name:UIApplicationWillResignActiveNotification object:nil];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:)
-                               name:UIApplicationDidEnterBackgroundNotification object:nil];
+    NSNotificationCenter *notificationCenter = NSNotificationCenter.defaultCenter;
+    
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:UIApplicationWillResignActiveNotification
+                             object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:UIApplicationDidEnterBackgroundNotification
+                             object:nil];
 #elif TARGET_OS_WATCH
     NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:)
-                               name:NSExtensionHostWillResignActiveNotification object:nil];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:)
-                               name:NSExtensionHostDidEnterBackgroundNotification object:nil];
+    
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:NSExtensionHostWillResignActiveNotification
+                             object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:NSExtensionHostDidEnterBackgroundNotification
+                             object:nil];
 #elif TARGET_OS_OSX
     NSNotificationCenter *notificationCenter = [[NSWorkspace sharedWorkspace] notificationCenter];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:)
-                               name:NSWorkspaceWillSleepNotification object:nil];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:)
-                               name:NSWorkspaceSessionDidResignActiveNotification object:nil];
-    [notificationCenter addObserver:self selector:@selector(handleContextTransition:)
-                               name:NSWorkspaceDidDeactivateApplicationNotification object:nil];
+    
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:NSWorkspaceWillSleepNotification
+                             object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:NSWorkspaceSessionDidResignActiveNotification
+                             object:nil];
+    [notificationCenter addObserver:self
+                           selector:@selector(handleContextTransition:)
+                               name:NSWorkspaceDidDeactivateApplicationNotification
+                             object:nil];
 #endif // TARGET_OS_OSX
 }
 


### PR DESCRIPTION
## ⚙️: conditional publish sequence manager data save

Enhanced performance by making save only in case if any change to represented data has been made.
Ensure save completion will be called even if publish sequence manager doesn't have reference on PubNub client instance for which it has been created.