### PR TITLE
Disable auto-retry for 403

### DIFF
--- a/PubNub/Data/Managers/PNSubscriber.m
+++ b/PubNub/Data/Managers/PNSubscriber.m
@@ -1330,7 +1330,8 @@ NS_ASSUME_NONNULL_END
             statusCategory == PNTLSConnectionFailedCategory) {
             
             __weak __typeof(self) weakSelf = self;
-            ((PNStatus *)status).automaticallyRetry = (statusCategory != PNMalformedFilterExpressionCategory &&
+            ((PNStatus *)status).automaticallyRetry = (statusCategory != PNAccessDeniedCategory &&
+                                                       statusCategory != PNMalformedFilterExpressionCategory &&
                                                        statusCategory != PNRequestURITooLongCategory);
             PNSubscriberState subscriberState = PNAccessRightsErrorSubscriberState;
             ((PNStatus *)status).retryCancelBlock = ^{

--- a/Tests/Tests/Contract/Steps/Subscribe/PNSubscribeContractTestSteps.m
+++ b/Tests/Tests/Contract/Steps/Subscribe/PNSubscribeContractTestSteps.m
@@ -15,14 +15,6 @@
 - (void)setup {
     [self startCucumberHookEventsListening];
     
-    Given(@"the crypto keyset", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
-        self.configuration.cipherKey = @"enigma";
-    });
-    
-    Given(@"the invalid-crypto keyset", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
-        self.configuration.cipherKey = @"secret";
-    });
-    
     When(@"I subscribe", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNSubscribeOperation;
         
@@ -54,6 +46,12 @@
         XCTAssertEqual(statuses.lastObject.category, PNDecryptionErrorCategory);
 
         [self pauseMainQueueFor:0.5f];
+    });
+    
+    Match(@[@"*"], @"I don't auto-retry subscribe", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        self.allowsPendingRequests = YES;
+        // Delay execution to ensure that there is no automated retry.
+        [self pauseMainQueueFor:2.f];
     });
 }
 

--- a/Tests/Tests/Helpers/PNContractTestCase.h
+++ b/Tests/Tests/Helpers/PNContractTestCase.h
@@ -33,6 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) PNOperationType testedFeatureType;
 
+/**
+ * @brief Whether at the end of the test on expectation check it is allowed to have pending requests
+ * or not.
+ */
+@property (nonatomic, assign, class) BOOL allowsPendingRequests;
+@property (nonatomic, assign) BOOL allowsPendingRequests;
+
 
 #pragma mark - Initialization & Configuration
 

--- a/Tests/Tests/Helpers/PNContractTestCase.m
+++ b/Tests/Tests/Helpers/PNContractTestCase.m
@@ -17,6 +17,8 @@
 
 #pragma mark Types & Constants
 
+static BOOL _allowsPendingRequests = NO;
+
 /**
  * @brief Origin which should be used to reach mock server for contract testing.
  */
@@ -159,6 +161,22 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Information
 
++ (BOOL)allowsPendingRequests {
+    return _allowsPendingRequests;
+}
+
++ (void)setAllowsPendingRequests:(BOOL)allowsPendingRequests {
+    _allowsPendingRequests = allowsPendingRequests;
+}
+
+- (BOOL)allowsPendingRequests {
+    return [PNContractTestCase class].allowsPendingRequests;
+}
+
+- (void)setAllowsPendingRequests:(BOOL)allowsPendingRequests {
+    [PNContractTestCase class].allowsPendingRequests = allowsPendingRequests;
+}
+
 - (PNConfiguration *)configuration {
     if (!self.currentConfiguration) {
         self.currentConfiguration = [PNConfiguration configurationWithPublishKey:kPNDefaultPublishKey
@@ -245,8 +263,12 @@ NS_ASSUME_NONNULL_END
                                                                            error:nil];
                 
                 NSArray<NSString *> *pendingExpectation = [response valueForKeyPath:@"expectations.pending"];
-                if (pendingExpectation.count) {
-                    XCTAssertTrue(false, @"Expectations not met: %@", [pendingExpectation componentsJoinedByString:@", "]);
+                NSArray<NSString *> *failedExpectation = [response valueForKeyPath:@"expectations.failed"];
+                if (pendingExpectation.count && !self.allowsPendingRequests) {
+                    XCTAssertTrue(false, @"Expectations not met (pending): %@", [pendingExpectation componentsJoinedByString:@", "]);
+                }
+                if (failedExpectation.count) {
+                    XCTAssertTrue(false, @"Expectations not met (failed): %@", [failedExpectation componentsJoinedByString:@", "]);
                 }
             }
             
@@ -260,6 +282,26 @@ NS_ASSUME_NONNULL_END
         
         Given(@"the invalid keyset", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
             // Nothing to do. Mock server will simulate proper error here.
+        });
+        
+        Given(@"the crypto keyset", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            self.configuration.cipherKey = @"enigma";
+        });
+        
+        Given(@"the invalid-crypto keyset", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            self.configuration.cipherKey = @"secret";
+        });
+        
+        Given(@"auth key", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            self.configuration.authKey = @"test-auth-key";
+        });
+        
+        Given(@"no auth key", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            // Nothing to do. By default PubNub client doesn't have configured authKey.
+        });
+        
+        Given(@"token", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            [self.client setAuthToken:@"my-test-token"];
         });
         
         Then(@"I receive successful response", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
@@ -291,6 +333,24 @@ NS_ASSUME_NONNULL_END
             }
         });
         
+        Then(@"I receive access denied status", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            PNStatus *status = [self lastStatus];
+            
+            XCTAssertNotNil(status, @"Last API call should fail");
+            XCTAssertTrue(status.isError, @"Last API call should report error");
+            XCTAssertEqual(status.category, PNAccessDeniedCategory);
+            XCTAssertEqual([self lastStatus].statusCode, 403);
+        });
+        
+        Match(@[@"*"], @"I receive access denied status", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+            PNStatus *status = [self lastStatus];
+            
+            XCTAssertNotNil(status, @"Last API call should fail");
+            XCTAssertTrue(status.isError, @"Last API call should report error");
+            XCTAssertEqual(status.category, PNAccessDeniedCategory);
+            XCTAssertEqual([self lastStatus].statusCode, 403);
+        });
+        
         // Complete known contract steps configuration.
         [[PNAccessContractTestSteps new] setup];
         [[PNFilesContractTestSteps new] setup];
@@ -317,7 +377,10 @@ synchronouslyToChannels:(NSArray *)channels
     client = client ?: self.client;
     
     [_statusHandlers addObject:^void(PubNub *receiver, PNStatus *status) {
-        if (status.operation == PNSubscribeOperation && status.category == PNConnectedCategory) {
+        if (status.operation == PNSubscribeOperation &&
+            (status.category == PNConnectedCategory || status.category == PNAccessDeniedCategory)) {
+            [self storeRequestStatus:status];
+            
             subscribeCompletedInTime = YES;
             dispatch_semaphore_signal(semaphore);
         }
@@ -379,7 +442,8 @@ synchronouslyFromChannels:(NSArray *)channels
             NSString *clientIdentifier = receiver.currentConfiguration.uuid;
             
             if ([client.currentConfiguration.uuid isEqualToString:clientIdentifier]) {
-                receivedRequiredCount = messagesCount >= [weakSelf messagesCountForClient:receiver onChannel:channel];
+                NSUInteger messagesCountForClient = [weakSelf messagesCountForClient:receiver onChannel:channel];
+                receivedRequiredCount = messagesCountForClient > 0 && messagesCount >= messagesCountForClient;
             }
             
             if (receivedRequiredCount) {


### PR DESCRIPTION
feat(subscribe): disable auto-retry for 403

Disable automatic subscribe request retry after 403 has been received.

BREAKING CHANGES: subscribe loop will stop instead of retry after 1 second when 403 received.

test(acceptance): add 403 auto-retry test

Add tests for subscrib auto-retry in case of 403.