### PR TITLE
Introduce `userId` as `uuid` replacement

### DIFF
--- a/PubNub/Core/PubNub+Core.h
+++ b/PubNub/Core/PubNub+Core.h
@@ -50,11 +50,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (PNConfiguration *)currentConfiguration;
 
 /**
- * @brief Retrieve UUID which has been used during client initialization.
+ * @brief Retrieve unique identifier to be used as a device identifier.
  *
- * @return User-provided or generated unique user identifier.
+ * @return User-provided unique identifier to be used as a device identifier.
  */
-- (NSString *)uuid;
+- (NSString *)uuid DEPRECATED_MSG_ATTRIBUTE("use 'userId' instead.");
+
+/**
+ * @brief Retrieve unique identifier to be used as a device identifier.
+ *
+ * @return User-provided unique identifier to be used as a device identifier.
+ */
+- (NSString *)userId;
 
 
 #pragma mark - Initialization
@@ -121,14 +128,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Make copy of client with it's current state using new configuration.
  *
  * @discussion Allow to retrieve reference on client which will have same state as receiver, but
- * will use updated configuration. If authorization and/or uuid keys has been changed while
- * subscribed, this method will trigger \c leave presence event on behalf of current uuid and
+ * will use updated configuration. If authorization and/or userId keys has been changed while
+ * subscribed, this method will trigger \c leave presence event on behalf of current userId and
  * subscribe using new one.
  *
  * @note Copy will be returned asynchronous, because some operations may require communication with
- * \b PubNub network (like switching active \c uuid while subscribed).
+ * \b PubNub network (like switching active \c userId while subscribed).
  *
- * @note Re-subscription with new \c uuid will be done using catchup and all messages which has been
+ * @note Re-subscription with new \c userId will be done using catchup and all messages which has been
  * sent while client changed configuration will be handled.
  *
  * @note All listeners will be copied to new client.
@@ -155,14 +162,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Make copy of client with it's current state using new configuration.
  *
  * @discussion Allow to retrieve reference on client which will have same state as receiver, but
- * will use updated configuration. If authorization and/or uuid keys has been changed while
- * subscribed, this method will trigger \c leave presence event on behalf of current uuid and
+ * will use updated configuration. If authorization and/or userId keys has been changed while
+ * subscribed, this method will trigger \c leave presence event on behalf of current userId and
  * subscribe using new one.
  *
  * @note Copy will be returned asynchronous, because some operations may require communication with
- * \b PubNub network (like switching active \c uuid while subscribed).
+ * \b PubNub network (like switching active \c userId while subscribed).
  *
- * @note Re-subscription with new \c uuid will be done using catchup and all messages which has been
+ * @note Re-subscription with new \c userId will be done using catchup and all messages which has been
  * sent while client changed configuration will be handled.
  * @note All listeners will be copied to new client.
  *

--- a/PubNub/Core/PubNub+Core.m
+++ b/PubNub/Core/PubNub+Core.m
@@ -188,12 +188,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Store provided unique user identifier in keychain.
  *
- * @param uuid Unique user identifier which has been provided with \b PNConfiguration instance.
+ * @param userId Unique user identifier which has been provided with \b PNConfiguration instance.
  * @param identifier Account publish or subscribe key which has been provided with \c PNConfiguration instance.
  *
  * @since 4.15.3
  */
-- (void)storeUUID:(NSString *)uuid forIdentifier:(NSString *)identifier;
+- (void)storeUserId:(NSString *)userId forIdentifier:(NSString *)identifier;
 
 /**
  * @brief Create and configure \b PubNub client logger instance.
@@ -240,7 +240,11 @@ NS_ASSUME_NONNULL_END
 }
 
 - (NSString *)uuid {
-    return self.configuration.uuid;
+    return self.userId;
+}
+
+- (NSString *)userId {
+    return self.configuration.userId;
 }
 
 
@@ -265,7 +269,7 @@ NS_ASSUME_NONNULL_END
 - (instancetype)initWithConfiguration:(PNConfiguration *)configuration callbackQueue:(dispatch_queue_t)callbackQueue {
     if ((self = [super init])) {
         NSString *storageIdentifier = configuration.publishKey ?: configuration.subscribeKey;
-        [self storeUUID:configuration.uuid forIdentifier:storageIdentifier];
+        [self storeUserId:configuration.userId forIdentifier:storageIdentifier];
         [self setupClientLogger];
         
         PNLogClientInfo(self.logger, @"<PubNub> PubNub SDK %@ (%@)", kPNLibraryVersion, kPNCommit);
@@ -351,13 +355,13 @@ NS_ASSUME_NONNULL_END
         // Stop any interactions on subscription loop.
         [self cancelSubscribeOperations];
         
-        BOOL uuidChanged = ![configuration.uuid isEqualToString:self.configuration.uuid];
+        BOOL userIdChanged = ![configuration.userId isEqualToString:self.configuration.userId];
         BOOL authKeyChanged = ((self.configuration.authKey && !configuration.authKey) ||
                                (!self.configuration.authKey && configuration.authKey) ||
                                (configuration.authKey && self.configuration.authKey &&
                                 ![configuration.authKey isEqualToString:self.configuration.authKey]));
         
-        if (uuidChanged || authKeyChanged) {
+        if (userIdChanged || authKeyChanged) {
             [self unsubscribeFromChannels:self.subscriberManager.channels 
                                    groups:self.subscriberManager.channelGroups
                              withPresence:YES
@@ -554,7 +558,7 @@ NS_ASSUME_NONNULL_END
                                @"{pub-key}": (self.configuration.publishKey?: @"")};
     
     NSMutableDictionary *queryComponents = [@{
-        @"uuid": [PNString percentEscapedString:(self.configuration.uuid?: @"")],
+        @"uuid": [PNString percentEscapedString:(self.configuration.userId?: @"")],
         @"deviceid": (self.configuration.deviceID?: @""),
         @"instanceid": self.instanceID,
         @"pnsdk":[NSString stringWithFormat:@"PubNub-%@%%2F%@", kPNClientName, kPNLibraryVersion]
@@ -581,7 +585,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)appendClientInformation:(PNResult *)result {
     result.TLSEnabled = self.configuration.isTLSEnabled;
-    result.uuid = self.configuration.uuid;
+    result.userId = self.configuration.userId;
     result.authKey = self.configuration.authToken ?: self.configuration.authKey;
     result.origin = self.configuration.origin;
 }
@@ -678,9 +682,9 @@ NS_ASSUME_NONNULL_END
     return class;
 }
 
-- (void)storeUUID:(NSString *)uuid forIdentifier:(NSString *)identifier {
+- (void)storeUserId:(NSString *)userId forIdentifier:(NSString *)identifier {
     id<PNKeyValueStorage> storage = [PNDataStorage persistentClientDataWithIdentifier:identifier];
-    [storage storeValue:uuid forKey:kPNConfigurationUUIDKey];
+    [storage storeValue:userId forKey:kPNConfigurationUserIdKey];
 }
 
 - (void)setupClientLogger {

--- a/PubNub/Core/PubNub+Objects.m
+++ b/PubNub/Core/PubNub+Objects.m
@@ -518,7 +518,7 @@ NS_ASSUME_NONNULL_END
 - (void)setUUIDMetadataWithRequest:(PNSetUUIDMetadataRequest *)request
                         completion:(PNSetUUIDMetadataCompletionBlock)block {
 
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
     
     [self performRequest:request withCompletion:^(PNSetUUIDMetadataStatus *status) {
@@ -535,7 +535,7 @@ NS_ASSUME_NONNULL_END
 - (void)removeUUIDMetadataWithRequest:(PNRemoveUUIDMetadataRequest *)request
                            completion:(PNRemoveUUIDMetadataCompletionBlock)block {
 
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
     
     [self performRequest:request withCompletion:^(PNAcknowledgmentStatus *status) {
@@ -552,7 +552,7 @@ NS_ASSUME_NONNULL_END
 - (void)uuidMetadataWithRequest:(PNFetchUUIDMetadataRequest *)request
                      completion:(PNFetchUUIDMetadataCompletionBlock)block {
 
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
     
     [self performRequest:request
@@ -662,7 +662,7 @@ NS_ASSUME_NONNULL_END
 - (void)setMembershipsWithRequest:(PNSetMembershipsRequest *)request
                        completion:(nullable PNManageMembershipsCompletionBlock)block {
     
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
 
     [self performRequest:request withCompletion:^(PNManageMembershipsStatus *status) {
@@ -679,7 +679,7 @@ NS_ASSUME_NONNULL_END
 - (void)removeMembershipsWithRequest:(PNRemoveMembershipsRequest *)request
                           completion:(PNManageMembershipsCompletionBlock)block {
     
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
 
     [self performRequest:request withCompletion:^(PNManageMembershipsStatus *status) {
@@ -696,7 +696,7 @@ NS_ASSUME_NONNULL_END
 - (void)manageMembershipsWithRequest:(PNManageMembershipsRequest *)request
                           completion:(PNManageMembershipsCompletionBlock)block {
     
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
     
     [self performRequest:request withCompletion:^(PNManageMembershipsStatus *status) {
@@ -713,7 +713,7 @@ NS_ASSUME_NONNULL_END
 - (void)membershipsWithRequest:(PNFetchMembershipsRequest *)request
                     completion:(PNFetchMembershipsCompletionBlock)block {
     
-    request.identifier = request.identifier.length ? request.identifier : self.configuration.uuid;
+    request.identifier = request.identifier.length ? request.identifier : self.configuration.userId;
     __weak __typeof(self) weakSelf = self;
     
     [self performRequest:request

--- a/PubNub/Core/PubNub+PAM.m
+++ b/PubNub/Core/PubNub+PAM.m
@@ -20,7 +20,7 @@
 #pragma mark - PAM
 
 - (PNPAMToken *)parseAuthToken:(NSString *)token {
-    return [PNPAMToken tokenFromBase64String:token forUUID:self.configuration.uuid];
+    return [PNPAMToken tokenFromBase64String:token forUUID:self.configuration.userId];
 }
 
 - (void)setAuthToken:(NSString *)token {

--- a/PubNub/Core/PubNub+State.h
+++ b/PubNub/Core/PubNub+State.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
  * group).
  *
  * @code
- * [self.client setState:@{ @"state": @"online" } forUUID:self.client.uuid onChannel:@"chat"
+ * [self.client setState:@{ @"state": @"online" } forUUID:self.client.userId onChannel:@"chat"
  *        withCompletion:^(PNClientStateUpdateStatus *status) {
  *
  *     if (!status.isError) {
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Modify state information for \c uuid on specified channel group.
  *
  * @code
- * [self.client setState:@{ @"announcement": @"New red is blue" } forUUID:self.client.uuid
+ * [self.client setState:@{ @"announcement": @"New red is blue" } forUUID:self.client.userId
  *        onChannelGroup:@"system" withCompletion:^(PNClientStateUpdateStatus *status) {
  *
  *     if (!status.isError) {
@@ -112,7 +112,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Retrieve state information for \c uuid on specified channel.
  *
  * @code
- * [self.client stateForUUID:self.client.uuid onChannel:@"chat"
+ * [self.client stateForUUID:self.client.userId onChannel:@"chat"
  *            withCompletion:^(PNChannelClientStateResult *result, PNErrorStatus *status) {
  *
  *     if (!status.isError) {
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Retrieve state information for \c uuid on specified channel group.
  *
  * @code
- * [self.client stateForUUID:self.client.uuid onChannelGroup:@"system"
+ * [self.client stateForUUID:self.client.userId onChannelGroup:@"system"
  *            withCompletion:^(PNChannelGroupClientStateResult *result, PNErrorStatus *status) {
  *
  *     if (!status.isError) {

--- a/PubNub/Core/PubNub+State.m
+++ b/PubNub/Core/PubNub+State.m
@@ -387,7 +387,7 @@ NS_ASSUME_NONNULL_END
                       groups:(NSArray<NSString *> *)groups
               withCompletion:(PNSetStateCompletionBlock)block {
 
-    if (status && !status.isError && [uuid isEqualToString:self.configuration.uuid]) {
+    if (status && !status.isError && [uuid isEqualToString:self.configuration.userId]) {
         NSDictionary *state = status.data.state ?: @{};
 
         [self.clientStateManager setState:state forObjects:channels];
@@ -405,7 +405,7 @@ NS_ASSUME_NONNULL_END
               fromBuilder:(BOOL)apiCallBuilder
            withCompletion:(id)block {
 
-    if (result && [uuid isEqualToString:self.configuration.uuid]) {
+    if (result && [uuid isEqualToString:self.configuration.userId]) {
         NSDictionary *state = @{};
 
         if (!apiCallBuilder) {

--- a/PubNub/Data/Managers/PNSubscriber.m
+++ b/PubNub/Data/Managers/PNSubscriber.m
@@ -1665,7 +1665,7 @@ NS_ASSUME_NONNULL_END
     // In case of state modification event for current client it should be applied on local storage.
     if ([data.data.presenceEvent isEqualToString:@"state-change"]) {
         // Check whether state has been changed for current client or not.
-        if ([data.data.presence.uuid isEqualToString:self.client.configuration.uuid]) {
+        if ([data.data.presence.uuid isEqualToString:self.client.configuration.userId]) {
             [self.client.clientStateManager setState:data.data.presence.state forObjects:@[data.data.channel]];
         }
     }

--- a/PubNub/Data/PNConfiguration.h
+++ b/PubNub/Data/PNConfiguration.h
@@ -11,8 +11,9 @@ NS_ASSUME_NONNULL_BEGIN
  * \b PubNub network.
  *
  * @author Sergey Mamontov
+ * @version 5.2.0
  * @since 4.0
- * @copyright © 2010-2018 PubNub, Inc.
+ * @copyright © 2010-2022PubNub, Inc.
  */
 @interface PNConfiguration : NSObject
 
@@ -57,8 +58,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, copy) NSString *authKey;
 
 /**
- * @brief Unique client identifier used to identify concrete client user from another which
- * currently use \b PubNub services.
+ * @brief The unique identifier to be used as a device identifier..
  *
  * @discussion This value is different from \c authKey (which is used only by \b PAM) and represent
  * concrete client across server. This identifier is used for presence events to tell what some
@@ -70,7 +70,25 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @default Client will use it's own-generated value if won't be specified by user.
  */
-@property (nonatomic, copy, setter = setUUID:) NSString *uuid;
+@property (nonatomic, copy, setter = setUUID:) NSString *uuid
+    DEPRECATED_MSG_ATTRIBUTE("use 'userId' instead.");
+
+/**
+ * @brief The unique identifier to be used as a device identifier.
+ *
+ * @discussion This value is different from \c authKey (which is used only by \b PAM) and represent
+ * concrete client across server. This identifier is used for presence events to tell what some
+ * client joined or leaved live feed.
+ *
+ * @warning There can't be two same client identifiers online at the same time.
+ *
+ * @throw Exception in case if \c userId is empty string.
+ *
+ * @default Client will use it's own-generated value if won't be specified by user.
+ *
+ * @since 5.2.0
+ */
+@property (nonatomic, copy, setter = setUserId:) NSString *userId;
 
 /**
  * @brief Data encryption key.
@@ -301,11 +319,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * @brief Construct configuration instance using minimal required data.
  *
- * @param publishKey Key which allow client to use data push API.
- * @param subscribeKey Key which allow client to subscribe on live feeds pushed from \b PubNub
- *     service.
- * @param uuid Unique client identifier used to identify concrete client user from another which
- *     currently use \b PubNub services.
+ * @param publishKey The PubNub Publish Key to be used when publishing data to a channel
+ * @param subscribeKey The PubNub Subscribe Key to be used when getting data from a channel
+ * @param uuid The unique identifier to be used as a device identifier.
  *
  * @throw Exception in case if \c uuid is empty string.
  *
@@ -314,7 +330,24 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)configurationWithPublishKey:(NSString *)publishKey
                                subscribeKey:(NSString *)subscribeKey
                                        uuid:(NSString *)uuid
-    NS_SWIFT_NAME(init(publishKey:subscribeKey:uuid:));
+    NS_SWIFT_NAME(init(publishKey:subscribeKey:uuid:))
+    DEPRECATED_MSG_ATTRIBUTE("use 'configurationWithPublishKey:subscribeKey:userId:' instead.");
+
+/**
+ * @brief Construct configuration instance using minimal required information.
+ *
+ * @param publishKey The \b PubNub Publish Key to be used when publishing data to a channel
+ * @param subscribeKey The \b PubNub Subscribe Key to be used when getting data from a channel
+ * @param userId The unique identifier to be used as a device identifier.
+ *
+ * @throw Exception in case if \c userId is empty string.
+ *
+ * @return Configured and ready to se configuration instance.
+ */
++ (instancetype)configurationWithPublishKey:(NSString *)publishKey
+                               subscribeKey:(NSString *)subscribeKey
+                                     userId:(NSString *)userId
+    NS_SWIFT_NAME(init(publishKey:subscribeKey:userId:));
 
 #pragma mark -
 

--- a/PubNub/Data/Service Objects/PNResult+Private.h
+++ b/PubNub/Data/Service Objects/PNResult+Private.h
@@ -1,7 +1,8 @@
 /**
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 4.0.0
+ * @copyright © 2010-2022 PubNub, Inc.
  */
 #import "PNResult.h"
 #import "PNStructures.h"
@@ -14,49 +15,41 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PNResult (Private) <NSCopying>
 
 
-///------------------------------------------------
-/// @name Information
-///------------------------------------------------
+#pragma mark - Information
 
 @property (nonatomic, assign) NSInteger statusCode;
 @property (nonatomic, assign) PNOperationType operation;
 @property (nonatomic, assign, getter = isTLSEnabled) BOOL TLSEnabled;
 
 /**
- @brief  Stores whether unexpected service data has been passed from parsers.
+ * @brief  Stores whether unexpected service data has been passed from parsers.
  */
 @property (nonatomic, assign, getter = isUnexpectedServiceData) BOOL unexpectedServiceData;
-@property (nonatomic, copy) NSString *uuid;
+@property (nonatomic, copy) NSString *userId;
 @property (nonatomic, nullable, copy) NSString *authKey;
 @property (nonatomic, copy) NSString *origin;
 @property (nonatomic, nullable, copy) NSURLRequest *clientRequest;
 
 /**
- @brief      Stores reference on processed \c response which is ready to use by user.
- @discussion Content and format for this property different for API. Each method has description about 
-             expected fields and data stored inside.
- 
- @since 4.0
+ * @brief Stores reference on processed \c response which is ready to use by user.
+ *
+ * @discussion Content and format for this property different for API. Each method has description about
+ *             expected fields and data stored inside.
  */
 @property (nonatomic, nullable, copy) NSDictionary<NSString *, id> *serviceData;
 
 
-///------------------------------------------------
-/// @name Initialization and configuration
-///------------------------------------------------
+#pragma mark - Initialization and configuration
 
 /**
- @brief  Consntruct result instance in response to successful task completion.
- 
- @param operation     One of \b PNOperationType enum fields to describe what kind of operation has been 
-                      processed.
- @param task          Reference on data task which has been used to communicate with \b PubNub network.
- @param processedData Reference on data which has been loaded and pre-processed by corresponding parser.
- @param error         Reference on request processing error.
- 
- @return Constructed and ready to use result instance.
- 
- @since 4.0
+ * @brief Construct result instance in response to successful task completion.
+ *
+ * @param operation One of \b PNOperationType enum fields to describe what kind of operation has been processed.
+ * @param task Reference on data task which has been used to communicate with \b PubNub network.
+ * @param processedData Reference on data which has been loaded and pre-processed by corresponding parser.
+ * @param error Reference on request processing error.
+ *
+ * @return Constructed and ready to use result instance.
  */
 + (instancetype)objectForOperation:(PNOperationType)operation
                  completedWithTask:(nullable NSURLSessionDataTask *)task
@@ -64,17 +57,14 @@ NS_ASSUME_NONNULL_BEGIN
                    processingError:(nullable NSError *)error;
 
 /**
- @brief  Initialize result instance in response to successful task completion.
- 
- @param operation     One of \b PNOperationType enum fields to describe what kind of operation has been 
-                      processed.
- @param task          Reference on data task which has been used to communicate with \b PubNub network.
- @param processedData Reference on data which has been loaded and pre-processed by corresponding parser.
- @param error         Reference on request processing error.
- 
- @return Initialized and ready to use result instance.
- 
- @since 4.0
+ * @brief Initialize result instance in response to successful task completion.
+ *
+ * @param operation One of \b PNOperationType enum fields to describe what kind of operation has been processed.
+ * @param task Reference on data task which has been used to communicate with \b PubNub network.
+ * @param processedData Reference on data which has been loaded and pre-processed by corresponding parser.
+ * @param error Reference on request processing error.
+ *
+ * @return Initialized and ready to use result instance.
  */
 - (instancetype)initForOperation:(PNOperationType)operation
                completedWithTask:(nullable NSURLSessionDataTask *)task
@@ -82,46 +72,36 @@ NS_ASSUME_NONNULL_BEGIN
                  processingError:(nullable NSError *)error;
 
 /**
- @brief      Make copy of current result object with mutated data which should be stored in it.
- @discussion Method can be used to create sub-events (for example one for each message or presence event).
- 
- @param data Reference on data which should be stored within new instance.
- 
- @return Copy of receiver with modified data.
- 
- @since 4.0
+ * @brief Make copy of current result object with mutated data which should be stored in it.
+ * @discussion Method can be used to create sub-events (for example one for each message or presence event).
+ *
+ * @param data Reference on data which should be stored within new instance.
+ *
+ * @return Copy of receiver with modified data.
  */
 - (instancetype)copyWithMutatedData:(nullable id)data;
 
 /**
- @brief  Update data stored for result object.
- 
- @param data New data which should be placed into result object.
- 
- @since 4.0
+ * @brief Update data stored for result object.
+ *
+ * @param data New data which should be placed into result object.
  */
 - (void)updateData:(nullable id)data;
 
 
-///------------------------------------------------
-/// @name Misc
-///------------------------------------------------
+#pragma mark - Misc
 
 /**
- @brief  Convert result object to dictionary which can be used to print out structured data
- 
- @return Object in dictionary representation.
- 
- @since 4.0
+ * @brief Convert result object to dictionary which can be used to print out structured data
+ *
+ * @return Object in dictionary representation.
  */
 - (NSDictionary *)dictionaryRepresentation;
 
 /**
- @brief  Convert result object to string which can be used to print out data
- 
- @return Stringified object representation.
- 
- @since 4.0
+ * @brief Convert result object to string which can be used to print out data
+ *
+ * @return Stringified object representation.
  */
 - (NSString *)stringifiedRepresentation;
 

--- a/PubNub/Data/Service Objects/PNResult.h
+++ b/PubNub/Data/Service Objects/PNResult.h
@@ -5,79 +5,73 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- @brief      Class which is used to describe server response.
- @discussion This object contains response itself and also set of data which has been used to communicate with
-             \b PubNub service to get this response.
- 
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @brief Class which is used to describe server response.
+ *
+ * @discussion This object contains response itself and also set of data which has been used to communicate with
+ *     \b PubNub service to get this response.
+ *
+ * @author Sergey Mamontov
+ * @version 5.2.0
+ * @since 4.0.0
+ * @copyright © 2010-2022 PubNub, Inc.
  */
 @interface PNResult: NSObject
 
 
-///------------------------------------------------
-/// @name Information
-///------------------------------------------------
+#pragma mark Information
 
 /**
- @brief Stores HTTP status code with which \c request completed processing with \b PubNub service.
- 
- @since 4.0
+ * @brief Stores HTTP status code with which \c request completed processing with \b PubNub service.
  */
 @property (nonatomic, readonly, assign) NSInteger statusCode;
 
 /**
- @brief Represent type of operation which has been issued to \b PubNub service and received response stored in
-        \c response and processed response in \c data.
-
- @since 4.0
+ * @brief Represent type of operation which has been issued to \b PubNub service and received response stored in
+ *        \c response and processed response in \c data.
  */
 @property (nonatomic, readonly, assign) PNOperationType operation;
 
 /**
- @brief  Stores whether secured connection has been used to send request or not.
- 
- @since 4.0
+ * @brief Stores whether secured connection has been used to send request or not.
  */
 @property (nonatomic, readonly, assign, getter = isTLSEnabled) BOOL TLSEnabled;
 
 /**
- @brief  UUID which is currently used by client to identify user on \b PubNub service.
- 
- @since 4.0
+ * @brief The unique identifier to be used as a device identifier.
  */
-@property (nonatomic, readonly, copy) NSString *uuid;
+@property (nonatomic, readonly, copy) NSString *uuid DEPRECATED_MSG_ATTRIBUTE("use 'userId' instead.");
 
 /**
- @brief      Authorization key / token which is used to get access to protected remote resources.
- @discussion Some resources can be protected by \b PAM functionality and access done using this authorization 
-             key.
- 
- @since 4.0
+ * @brief The unique identifier to be used as a device identifier.
+ *
+ * @since 5.2.0
+ */
+@property (nonatomic, readonly, copy) NSString *userId;
+
+/**
+ * @brief Authorization key / token which is used to get access to protected remote resources.
+ *
+ * @discussion Some resources can be protected by \b PAM functionality and access done using this authorization
+ *             key.
  */
 @property (nonatomic, nullable, readonly, copy) NSString *authKey;
 
 /**
- @brief Stores reference on \b PubNub service host name or IP address against which \c request has been 
-        called.
- 
- @since 4.0
+ * @brief Stores reference on \b PubNub service host name or IP address against which \c request has been
+ *        called.
  */
 @property (nonatomic, readonly, copy) NSString *origin;
 
 /**
- @brief Stores reference on copy of original request which has been used to fetch or push data to \b PubNub 
-        service.
- 
- @since 4.0
+ * @brief Stores reference on copy of original request which has been used to fetch or push data to \b PubNub
+ *        service.
  */
 @property (nonatomic, nullable, readonly, copy) NSURLRequest *clientRequest;
 
 /**
- @brief  Stringified \c operation value.
- 
- @return Stringified representation for \c operation property which store value from \b PNOperationType.
+ * @brief Stringified \c operation value.
+ *
+ * @return Stringified representation for \c operation property which store value from \b PNOperationType.
  */
 - (NSString *)stringifiedOperation;
 

--- a/PubNub/Data/Service Objects/PNResult.m
+++ b/PubNub/Data/Service Objects/PNResult.m
@@ -1,7 +1,6 @@
 /**
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @copyright © 2010-2022 PubNub, Inc.
  */
 #import "PNResult+Private.h"
 #import "PNPrivateStructures.h"
@@ -22,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) PNOperationType operation;
 @property (nonatomic, assign, getter = isTLSEnabled) BOOL TLSEnabled;
 @property (nonatomic, assign, getter = isUnexpectedServiceData) BOOL unexpectedServiceData;
-@property (nonatomic, copy) NSString *uuid;
+@property (nonatomic, copy) NSString *userId;
 @property (nonatomic, nullable, copy) NSString *authKey;
 @property (nonatomic, copy) NSString *origin;
 @property (nonatomic, nullable, copy) NSURLRequest *clientRequest;
@@ -32,24 +31,24 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Misc
 
 /**
- @brief  Create instance copy with additional adjustments on whether service data information should be copied
-         sor not.
- 
- @param shouldCopyServiceData Whether service data should be passed to new copy or not.
- 
- @return Receiver's new copy.
+ * @brief Create instance copy with additional adjustments on whether service data information should be copied or not.
+ *
+ * @param shouldCopyServiceData Whether service data should be passed to new copy or not.
+ *
+ * @return Receiver's new copy.
  */
 - (id)copyWithServiceData:(BOOL)shouldCopyServiceData;
 
 /**
- @brief      Ensure what passed \c serviceData has required data type (dictionary). If \c serviceData has 
-             different data type, it will be wrapped into dictionary.
- @discussion If unexpected data type will be passes, object will set corresponding flag, so it will be
-             processed and printed out to log file for further investigation.
- 
- @param serviceData Reference on data which should be verified and used for resulting object.
- 
- @return \c Normalized service data dictionary.
+ * @brief Ensure what passed \c serviceData has required data type (dictionary). If \c serviceData has
+ *         different data type, it will be wrapped into dictionary.
+ *
+ * @discussion If unexpected data type will be passes, object will set corresponding flag, so it will be
+ *             processed and printed out to log file for further investigation.
+ *
+ * @param serviceData Reference on data which should be verified and used for resulting object.
+ *
+ * @return \c Normalized service data dictionary.
  */
 - (NSDictionary *)normalizedServiceData:(nullable id)serviceData;
 
@@ -61,53 +60,56 @@ NS_ASSUME_NONNULL_BEGIN
 NS_ASSUME_NONNULL_END
 
 
-#pragma mark Interface implementation
+#pragma mark - Interface implementation
 
 @implementation PNResult
 
 
 #pragma mark - Information
 
+- (NSString *)uuid {
+    return self.userId;
+}
+
 - (NSString *)stringifiedOperation {
-    
     return (self.operation >= PNSubscribeOperation ? PNOperationTypeStrings[self.operation] : @"Unknown");
 }
 
 
 #pragma mark - Initialization and Configuration
 
-+ (instancetype)objectForOperation:(PNOperationType)operation completedWithTask:(NSURLSessionDataTask *)task
++ (instancetype)objectForOperation:(PNOperationType)operation
+                 completedWithTask:(NSURLSessionDataTask *)task
                      processedData:(NSDictionary<NSString *, id> *)processedData 
                    processingError:(NSError *)error {
     
-    return [[self alloc] initForOperation:operation completedWithTask:task
-                            processedData:processedData processingError:error];
+    return [[self alloc] initForOperation:operation
+                        completedWithTask:task
+                            processedData:processedData
+                          processingError:error];
 }
 
-- (instancetype)initForOperation:(PNOperationType)operation completedWithTask:(NSURLSessionDataTask *)task
+- (instancetype)initForOperation:(PNOperationType)operation
+               completedWithTask:(NSURLSessionDataTask *)task
                    processedData:(NSDictionary<NSString *, id> *)processedData 
                  processingError:(NSError *)__unused error {
     
-    // Check whether initialization was successful or not.
     if ((self = [super init])) {
-        
-        _statusCode = (task ? ((NSHTTPURLResponse *)task.response).statusCode : 200);
+        _statusCode = task ? ((NSHTTPURLResponse *)task.response).statusCode : 200;
         _operation = operation;
         _clientRequest = [task.currentRequest copy];
+        
         if ([processedData[@"status"] isKindOfClass:[NSNumber class]]) {
-            
             NSMutableDictionary *dataForUpdate = [processedData mutableCopy];
             NSNumber *statusCode = [dataForUpdate[@"status"] copy];
             [dataForUpdate removeObjectForKey:@"status"];
             processedData = [dataForUpdate copy];
             _statusCode = (([statusCode integerValue] > 200) ? [statusCode integerValue] : _statusCode);
-        }
-        // Received unknown response from service.
-        else if (processedData && ![processedData isKindOfClass:[NSDictionary class]]){
-            
+        } else if (processedData && ![processedData isKindOfClass:[NSDictionary class]]) {
             _unexpectedServiceData = YES;
             processedData = [self normalizedServiceData:processedData];
         }
+        
         _serviceData = [processedData copy];
     }
     
@@ -115,12 +117,10 @@ NS_ASSUME_NONNULL_END
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    
     return [self copyWithServiceData:YES];
 }
 
 - (instancetype)copyWithMutatedData:(id)data {
-    
     PNResult *result = [self copyWithServiceData:NO];
     [result updateData:data];
     
@@ -128,7 +128,6 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)updateData:(id)data {
-    
     _serviceData = [[self normalizedServiceData:data] copy];
     _unexpectedServiceData = ![_serviceData isEqual:data];
 }
@@ -137,17 +136,16 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Misc
 
 - (id)copyWithServiceData:(BOOL)shouldCopyServiceData {
-    
     PNResult *result = [[self class] new];
     result.statusCode = self.statusCode;
     result.operation = self.operation;
     result.TLSEnabled = self.isTLSEnabled;
-    result.uuid = self.uuid;
+    result.userId = self.userId;
     result.authKey = self.authKey;
     result.origin = self.origin;
     result.clientRequest = self.clientRequest;
+    
     if (shouldCopyServiceData) {
-        
         [result updateData:self.serviceData];
     }
     
@@ -155,10 +153,9 @@ NS_ASSUME_NONNULL_END
 }
 
 - (NSDictionary *)normalizedServiceData:(id)serviceData {
-    
     NSDictionary *normalizedServiceData = serviceData?: @{};
+    
     if (serviceData && ![serviceData isKindOfClass:[NSDictionary class]]) {
-        
         normalizedServiceData = @{@"information": serviceData};
     }
     
@@ -166,48 +163,45 @@ NS_ASSUME_NONNULL_END
 }
 
 - (NSMethodSignature *)methodSignatureForSelector:(SEL)__unused selector {
-    
     return [[self class] instanceMethodSignatureForSelector:@selector(doNothing)];
 }
 
 - (void)forwardInvocation:(NSInvocation *)__unused invocation {
-    
 }
 
 - (void)doNothing {
-    
 }
 
 - (NSDictionary *)dictionaryRepresentation {
+    id processedData = [self.serviceData mutableCopy] ?: @"no data";
     
-    id processedData = ([self.serviceData mutableCopy]?: @"no data");
     if (self.serviceData[@"envelope"]) {
-        
         processedData[@"envelope"] = [self.serviceData[@"envelope"] valueForKey:@"dictionaryRepresentation"];
     }
     
     NSMutableDictionary *response = [@{@"Status code": @(self.statusCode),
                                        @"Processed data": processedData} mutableCopy];
-    if (_unexpectedServiceData) { response[@"Unexpected"] = @(YES); }
+    
+    if (_unexpectedServiceData) {
+        response[@"Unexpected"] = @(YES);
+    }
     
     return @{@"Operation": PNOperationTypeStrings[[self operation]],
-             @"Request": @{@"Method": (self.clientRequest.HTTPMethod?: @"GET"),
+             @"Request": @{@"Method": (self.clientRequest.HTTPMethod ?: @"GET"),
                            @"URL": ([self.clientRequest.URL absoluteString]?: @"null"),
                            @"POST Body size": [self.clientRequest valueForHTTPHeaderField:@"content-length"] ?: @0,
                            @"Secure": (self.isTLSEnabled ? @"YES" : @"NO"),
-                           @"UUID": (self.uuid?: @"unknown"),
-                           @"Authorization": (self.authKey?: @"not set"),
-                           @"Origin": (self.origin?: @"unknown")},
+                           @"User ID": (self.userId ?: @"unknown"),
+                           @"Authorization": (self.authKey ?: @"not set"),
+                           @"Origin": (self.origin ?: @"unknown")},
              @"Response": response};
 }
 
 - (NSString *)stringifiedRepresentation {
-    
     return [PNJSON JSONStringFrom:[self dictionaryRepresentation] withError:NULL];
 }
 
 - (NSString *)debugDescription {
-    
     return [[self dictionaryRepresentation] description];
 }
 

--- a/PubNub/Misc/PNPrivateStructures.h
+++ b/PubNub/Misc/PNPrivateStructures.h
@@ -26,7 +26,7 @@ extern NSString * const kPNPublishSequenceDataKey;
 /**
  * @brief Key under which unique user identifier will be stored persistently.
  */
-extern NSString * const kPNConfigurationUUIDKey;
+extern NSString * const kPNConfigurationUserIdKey;
 
 /**
  * @brief Options describe object's message type.

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Cucumberish (1.4.0)
   - OCMock (3.6)
-  - PubNub (5.0.0):
-    - PubNub/Core (= 5.0.0)
-  - PubNub/Core (5.0.0)
+  - PubNub (5.1.0):
+    - PubNub/Core (= 5.1.0)
+  - PubNub/Core (5.1.0)
   - YAHTTPVCR (1.4.2)
 
 DEPENDENCIES:
@@ -32,7 +32,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Cucumberish: 6cbd0c1f50306b369acebfe7d9f514c9c287d26c
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
-  PubNub: b218a66a1f4c772e2eb55a889aa349feb1fbd25e
+  PubNub: 49b8a60d845c722ef636b9db5ede52d6f962cc18
   YAHTTPVCR: e2aa406443a4db12585ff626b445369e1953a729
 
 PODFILE CHECKSUM: 569ce5fdb7670790d6d4a9d1a5a304a20781e374

--- a/Tests/Tests/Helpers/PNRecordableTestCase.m
+++ b/Tests/Tests/Helpers/PNRecordableTestCase.m
@@ -758,7 +758,7 @@ NS_ASSUME_NONNULL_END
     
     PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:publishKey
                                                                      subscribeKey:subscribeKey
-                                                                             uuid:uuid];
+                                                                           userId:uuid];
     configuration.authKey = [self pubNubAuthForTestCaseWithName:self.name];
     
     return configuration;
@@ -781,7 +781,7 @@ NS_ASSUME_NONNULL_END
 
 - (PubNub *)createPubNubForUser:(NSString *)user withConfiguration:(PNConfiguration *)configuration {
     dispatch_queue_t callbackQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    configuration.uuid = [self uuidForUser:user];
+    configuration.userId = [self uuidForUser:user];
     
     PubNub *client = [PubNub clientWithConfiguration:configuration callbackQueue:callbackQueue];
     client.logger.enabled = PUBNUB_LOGGER_ENABLED;
@@ -818,7 +818,7 @@ NS_ASSUME_NONNULL_END
 - (void)completePubNubConfiguration:(PubNub *)client {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-variable"
-    NSString *uuid = client.currentConfiguration.uuid;
+    NSString *uuid = client.currentConfiguration.userId;
 #pragma clang diagnostic pop
 }
 
@@ -1164,7 +1164,9 @@ NS_ASSUME_NONNULL_END
     client = client ?: self.client;
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
-        [client setState:state forUUID:client.currentConfiguration.uuid onChannel:channel
+        [client setState:state
+                 forUUID:client.currentConfiguration.userId
+               onChannel:channel
           withCompletion:^(PNClientStateUpdateStatus *status) {
             XCTAssertFalse(status.isError);
             handler();

--- a/Tests/Tests/Integration/Actions/PNMessageActionsIntegrationTest.m
+++ b/Tests/Tests/Integration/Actions/PNMessageActionsIntegrationTest.m
@@ -63,7 +63,7 @@
                 XCTAssertNotNil(action);
                 XCTAssertEqualObjects(action.type, expectedType);
                 XCTAssertEqualObjects(action.value, expectedValue);
-                XCTAssertEqualObjects(action.uuid, self.client.uuid);
+                XCTAssertEqualObjects(action.uuid, self.client.userId);
                 XCTAssertEqualObjects(action.messageTimetoken, timetokens[0]);
                 XCTAssertNotNil(action.actionTimetoken);
                 XCTAssertNotEqual([action.debugDescription rangeOfString:@"actionTimetoken"].location, NSNotFound);
@@ -133,7 +133,7 @@
             XCTAssertNotNil(action);
             XCTAssertEqualObjects(action.type, expectedType);
             XCTAssertEqualObjects(action.value, expectedValue);
-            XCTAssertEqualObjects(action.uuid, client1.uuid);
+            XCTAssertEqualObjects(action.uuid, client1.userId);
             XCTAssertEqualObjects(action.messageTimetoken, timetokens.firstObject);
             XCTAssertNotNil(action.actionTimetoken);
             XCTAssertEqualObjects(event.data.event, @"added");
@@ -424,7 +424,7 @@
             *remove = YES;
             PNMessageAction *action = event.data.action;
             XCTAssertNotNil(action);
-            XCTAssertEqualObjects(action.uuid, client1.uuid);
+            XCTAssertEqualObjects(action.uuid, client1.userId);
             XCTAssertEqualObjects(action.messageTimetoken, timetokens.firstObject);
             XCTAssertNotNil(action.actionTimetoken);
             XCTAssertEqualObjects(event.data.event, @"removed");

--- a/Tests/Tests/Integration/Files/PNFilesIntegrationTests.m
+++ b/Tests/Tests/Integration/Files/PNFilesIntegrationTests.m
@@ -347,7 +347,7 @@ NS_ASSUME_NONNULL_END
     PubNub *client1 = [self createPubNubForUser:@"serhii"];
     PubNub *client2 = [self createPubNubForUser:@"david"];
     client2.filterExpression = [NSString stringWithFormat:@"uuid == '%@'",
-                                client2.currentConfiguration.uuid];
+                                client2.currentConfiguration.userId];
     
     [self subscribeClient:client2 toChannels:@[self.channel] withPresence:NO];
     
@@ -368,7 +368,7 @@ NS_ASSUME_NONNULL_END
         client1.files().sendFile(self.channel, fileName)
             .data(data)
             .message(expectedMessage)
-            .fileMessageMetadata(@{ @"uuid": client1.currentConfiguration.uuid })
+            .fileMessageMetadata(@{ @"uuid": client1.currentConfiguration.userId })
             .performWithCompletion(^(PNSendFileStatus *status) {
                 XCTAssertFalse(status.isError);
             });
@@ -386,7 +386,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldDownloadFileAndReceiveResultWithExpectedOperation {
     NSArray<NSDictionary *> *uploadedFiles = [self uploadFiles:1 toChannel:self.channel usingClient:nil];
-    NSString *expectedUUID = [@"uuid=" stringByAppendingString:self.client.currentConfiguration.uuid];
+    NSString *expectedUUID = [@"uuid=" stringByAppendingString:self.client.currentConfiguration.userId];
     
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
@@ -563,7 +563,7 @@ NS_ASSUME_NONNULL_END
 - (void)testItShouldFetchFilesListWhenAuthKeyIsSet {
     NSArray<NSDictionary *> *uploadedFiles = [self uploadFiles:1 toChannel:self.channel usingClient:nil];
     NSString *expectedAuth = [@"auth=" stringByAppendingString:self.client.currentConfiguration.authKey];
-    NSString *expectedUUID = [@"uuid=" stringByAppendingString:self.client.currentConfiguration.uuid];
+    NSString *expectedUUID = [@"uuid=" stringByAppendingString:self.client.currentConfiguration.userId];
     
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {

--- a/Tests/Tests/Integration/PNPresenceIntegrationTest.m
+++ b/Tests/Tests/Integration/PNPresenceIntegrationTest.m
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_END
             
             for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                 NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
                 
                 XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                 XCTAssertEqualObjects(channelInformation[@"uuids"], @[@{ @"uuid": clientUUID }]);
@@ -119,7 +119,7 @@ NS_ASSUME_NONNULL_END
 
             for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                 NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
 
                 XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                 XCTAssertEqualObjects(channelInformation[@"uuids"], @[clientUUID]);
@@ -166,7 +166,7 @@ NS_ASSUME_NONNULL_END
 
             for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                 NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
                 NSDictionary *channelParticipant = channelInformation[@"uuids"][0];
                 
                 XCTAssertEqualObjects(channelParticipant[@"uuid"], clientUUID);
@@ -272,7 +272,7 @@ NS_ASSUME_NONNULL_END
                 
                 for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                     NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                    NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                    NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
                     
                     XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                     XCTAssertEqualObjects(channelInformation[@"uuids"], @[@{ @"uuid": clientUUID }]);
@@ -318,7 +318,7 @@ NS_ASSUME_NONNULL_END
             for (NSUInteger clientIdx = 0; clientIdx < clients.count; clientIdx++) {
                 PubNub *client = clients[clientIdx];
                 
-                XCTAssertTrue([uuids containsObject:@{ @"uuid": client.currentConfiguration.uuid }]);
+                XCTAssertTrue([uuids containsObject:@{ @"uuid": client.currentConfiguration.userId }]);
             }
             
             handler();
@@ -357,7 +357,7 @@ NS_ASSUME_NONNULL_END
             for (NSUInteger clientIdx = 0; clientIdx < clients.count; clientIdx++) {
                 PubNub *client = clients[clientIdx];
                 
-                XCTAssertTrue([uuids containsObject:client.currentConfiguration.uuid]);
+                XCTAssertTrue([uuids containsObject:client.currentConfiguration.userId]);
             }
 
             handler();
@@ -397,7 +397,7 @@ NS_ASSUME_NONNULL_END
             XCTAssertNotNil(uuids);
             
             for (NSUInteger clientIdx = 0; clientIdx < clients.count; clientIdx++) {
-                NSString *clientUUID = clients[clientIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[clientIdx].currentConfiguration.userId;
                 NSDictionary *userInformation = nil;
                 
                 for (NSDictionary *information in uuids) {
@@ -541,7 +541,7 @@ NS_ASSUME_NONNULL_END
 
                 for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                     NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                    NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                    NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
 
                     XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                     XCTAssertEqualObjects(channelInformation[@"uuids"], @[@{ @"uuid": clientUUID }]);
@@ -590,7 +590,7 @@ NS_ASSUME_NONNULL_END
 
             for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                 NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
 
                 XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                 XCTAssertEqualObjects(channelInformation[@"uuids"], @[@{ @"uuid": clientUUID }]);
@@ -638,7 +638,7 @@ NS_ASSUME_NONNULL_END
 
             for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                 NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
 
                 XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                 XCTAssertEqualObjects(channelInformation[@"uuids"], @[clientUUID]);
@@ -691,7 +691,7 @@ NS_ASSUME_NONNULL_END
 
             for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                 NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
                 NSDictionary *channelParticipant = channelInformation[@"uuids"][0];
                 
                 XCTAssertEqualObjects(channelParticipant[@"uuid"], clientUUID);
@@ -809,7 +809,7 @@ NS_ASSUME_NONNULL_END
                 
                 for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                     NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                    NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                    NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
                     
                     XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                     XCTAssertEqualObjects(channelInformation[@"uuids"], @[@{ @"uuid": clientUUID }]);
@@ -859,7 +859,7 @@ NS_ASSUME_NONNULL_END
 
                 for (NSUInteger channelIdx = 0; channelIdx < channels.count; channelIdx++) {
                     NSDictionary *channelInformation = fetchedChannels[channels[channelIdx]];
-                    NSString *clientUUID = clients[channelIdx].currentConfiguration.uuid;
+                    NSString *clientUUID = clients[channelIdx].currentConfiguration.userId;
 
                     XCTAssertEqual(((NSNumber *)channelInformation[@"occupancy"]).unsignedIntegerValue, 1);
                     XCTAssertEqualObjects(channelInformation[@"uuids"], @[@{ @"uuid": clientUUID }]);
@@ -891,7 +891,7 @@ NS_ASSUME_NONNULL_END
     
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
-        [self.client whereNowUUID:self.client.currentConfiguration.uuid
+        [self.client whereNowUUID:self.client.currentConfiguration.userId
                    withCompletion:^(PNPresenceWhereNowResult *result, PNErrorStatus *status) {
             
             NSArray<NSString *> *fetchedChannels = result.data.channels;
@@ -950,7 +950,7 @@ NS_ASSUME_NONNULL_END
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         self.client.presence().whereNow()
-            .uuid(self.client.currentConfiguration.uuid)
+            .uuid(self.client.currentConfiguration.userId)
             .performWithCompletion(^(PNPresenceWhereNowResult *result, PNErrorStatus *status) {
                 NSArray<NSString *> *fetchedChannels = result.data.channels;
                 XCTAssertNil(status);
@@ -992,7 +992,7 @@ NS_ASSUME_NONNULL_END
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         self.client.presence().whereNow()
-            .uuid(self.client.currentConfiguration.uuid)
+            .uuid(self.client.currentConfiguration.userId)
             .performWithCompletion(^(PNPresenceWhereNowResult *result, PNErrorStatus *status) {
                 XCTAssertEqual(result.data.channels.count, channels.count);
                 
@@ -1145,7 +1145,7 @@ NS_ASSUME_NONNULL_END
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         self.client.presence().whereNow()
-            .uuid(self.client.currentConfiguration.uuid)
+            .uuid(self.client.currentConfiguration.userId)
             .performWithCompletion(^(PNPresenceWhereNowResult *result, PNErrorStatus *status) {
                 XCTAssertEqual(result.data.channels.count, 0);
                 
@@ -1261,7 +1261,7 @@ NS_ASSUME_NONNULL_END
             .performWithCompletion(^(PNPresenceChannelGroupHereNowResult *result, PNErrorStatus *status) {
                 NSDictionary<NSString *, NSDictionary *> *fetchedChannels = result.data.channels;
                 NSArray<NSDictionary *> *uuids = fetchedChannels[channels.firstObject][@"uuids"];
-                NSDictionary *fetchedState = uuids.firstObject[self.client.currentConfiguration.uuid];
+                NSDictionary *fetchedState = uuids.firstObject[self.client.currentConfiguration.userId];
                 XCTAssertNil(status);
                 XCTAssertNotNil(fetchedState);
                 XCTAssertEqualObjects(fetchedState, states[channelGroup]);
@@ -1373,7 +1373,7 @@ NS_ASSUME_NONNULL_END
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         self.client.presence().whereNow()
-            .uuid(self.client.currentConfiguration.uuid)
+            .uuid(self.client.currentConfiguration.userId)
             .performWithCompletion(^(PNPresenceWhereNowResult *result, PNErrorStatus *status) {
                 XCTAssertEqual(result.data.channels.count, 0);
                 

--- a/Tests/Tests/Integration/PNPresenceStateIntegrationTest.m
+++ b/Tests/Tests/Integration/PNPresenceStateIntegrationTest.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSetPresenceStateForChannelAndReceiveStatusWithExpectedOperationAndCategory {
     NSString *channel = [self channelWithName:@"test-channel1"];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"channel1-state": [self randomizedValuesWithValues:@[@"channel-1-random-value"]]
     };
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSetPresenceStateForChannelAndNotCrashWhenCompletionBlockIsNil {
     NSString *channel = [self channelWithName:@"test-channel1"];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"channel1-state": [self randomizedValuesWithValues:@[@"channel-1-random-value"]]
     };
@@ -105,7 +105,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"state-change"]) {
-                XCTAssertEqualObjects(event.data.presence.uuid, client1.currentConfiguration.uuid);
+                XCTAssertEqualObjects(event.data.presence.uuid, client1.currentConfiguration.userId);
                 XCTAssertEqualObjects(event.data.presence.state, updatedState);
                 XCTAssertNotNil(event.data.presence.timetoken);
                 *remove = YES;
@@ -114,7 +114,8 @@ NS_ASSUME_NONNULL_END
             }
         }];
         
-        [client1 setState:updatedState forUUID:client1.currentConfiguration.uuid onChannel:channel
+        [client1 setState:updatedState forUUID:client1.currentConfiguration.userId
+                onChannel:channel
            withCompletion:^(PNClientStateUpdateStatus *status) {
             XCTAssertFalse(status.isError);
         }];
@@ -128,7 +129,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldNotSetPresenceStateForChannelAndReceiveBadRequestStatusWhenChannelIsNil {
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"channel1-state": [self randomizedValuesWithValues:@[@"channel-1-random-value"]]
     };
@@ -188,7 +189,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSetPresenceStateForChannelUsingBuilderPatternInterface {
     NSArray<NSString *> *channels = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"users-state": [self randomizedValuesWithValues:@[@"users-random-value"]]
     };
@@ -219,7 +220,7 @@ NS_ASSUME_NONNULL_END
 - (void)testItShouldSetPresenceStateForChannelGroupAndReceiveStatusWithExpectedOperationAndCategory {
     NSArray<NSString *> *channels = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
     NSString *channelGroup = [self channelGroupWithName:@"test-channel-group"];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"user-state": [self randomizedValuesWithValues:@[@"users-random-value"]]
     };
@@ -250,7 +251,7 @@ NS_ASSUME_NONNULL_END
 - (void)testItShouldSetPresenceStateForChannelGroupAndNotCrashWhenCompletionBlockIsNil {
     NSArray<NSString *> *channels = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
     NSString *channelGroup = [self channelGroupWithName:@"test-channel-group"];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"user-state": [self randomizedValuesWithValues:@[@"users-random-value"]]
     };
@@ -270,7 +271,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldNotSetPresenceStateForChannelGroupAndReceiveBadRequestStatusWhenChannelGroupIsNil {
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSString *channelGroup = nil;
     NSDictionary *state = @{
         @"user-state": [self randomizedValuesWithValues:@[@"users-random-value"]]
@@ -332,7 +333,7 @@ NS_ASSUME_NONNULL_END
     NSArray<NSString *> *channelGroups = [self channelGroupsWithNames:@[@"test-channel-group1", @"test-channel-group2"]];
     NSArray<NSString *> *channels1 = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
     NSArray<NSString *> *channels2 = [self channelsWithNames:@[@"test-channel3", @"test-channel4"]];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"users-state": [self randomizedValuesWithValues:@[@"channel-1-random-value"]]
     };
@@ -370,7 +371,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldFetchPresenceStateForChannelAndReceiveResultWithExpectedOperation {
     NSString *channel = [self channelWithName:@"test-channel1"];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"channel1-state": [self randomizedValuesWithValues:@[@"channel-1-random-value"]]
     };
@@ -403,7 +404,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldNotFetchPresenceStateForChannelAndReceiveBadRequestStatusWhenChannelIsNil {
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     __block BOOL retried = NO;
     NSString *channel = nil;
         
@@ -456,7 +457,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldFetchPresenceStateForChannelUsingBuilderPatternInterface {
     NSArray<NSString *> *channels = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"users-state": [self randomizedValuesWithValues:@[@"users-random-value"]]
     };
@@ -500,7 +501,7 @@ NS_ASSUME_NONNULL_END
 - (void)testItShouldFetchPresenceStateForChannelGroupAndReceiveResultWithExpectedOperation {
     NSArray<NSString *> *channels = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
     NSString *channelGroup = [self channelGroupWithName:@"test-channel-group"];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"user-state": [self randomizedValuesWithValues:@[@"users-random-value"]]
     };
@@ -542,7 +543,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldNotFetchPresenceStateForChannelGroupAndReceiveBadRequestStatusWhenChannelGroupIsNil {
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSString *channelGroup = nil;
     __block BOOL retried = NO;
         
@@ -597,7 +598,7 @@ NS_ASSUME_NONNULL_END
     NSArray<NSString *> *channelGroups = [self channelGroupsWithNames:@[@"test-channel-group1", @"test-channel-group2"]];
     NSArray<NSString *> *channels1 = [self channelsWithNames:@[@"test-channel1", @"test-channel2"]];
     NSArray<NSString *> *channels2 = [self channelsWithNames:@[@"test-channel3", @"test-channel4"]];
-    NSString *uuid = self.client.currentConfiguration.uuid;
+    NSString *uuid = self.client.currentConfiguration.userId;
     NSDictionary *state = @{
         @"users-state": [self randomizedValuesWithValues:@[@"channel-1-random-value"]]
     };

--- a/Tests/Tests/Integration/PNPublishIntegrationTests.m
+++ b/Tests/Tests/Integration/PNPublishIntegrationTests.m
@@ -318,7 +318,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -347,7 +347,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -376,7 +376,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -405,7 +405,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -434,7 +434,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -463,7 +463,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -492,7 +492,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -522,7 +522,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -579,7 +579,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -615,7 +615,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *receivedMessage, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(receivedMessage.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(receivedMessage.data.publisher, client1.currentConfiguration.userId);
             XCTAssertNotEqualObjects(receivedMessage.data.message, message);
             XCTAssertTrue([receivedMessage.data.message isKindOfClass:[NSString class]]);
             XCTAssertEqualObjects(receivedMessage.data.message, expectedMessage);
@@ -650,7 +650,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *receivedMessage, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(receivedMessage.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(receivedMessage.data.publisher, client1.currentConfiguration.userId);
             XCTAssertNotEqualObjects(receivedMessage.data.message, message);
             XCTAssertTrue([receivedMessage.data.message isKindOfClass:[NSString class]]);
             XCTAssertNotEqualObjects(receivedMessage.data.message, notExpectedMessage);
@@ -685,7 +685,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             XCTAssertEqualObjects(message.data.userMetadata, expectedMetadata);
             *shouldRemove = YES;
@@ -789,7 +789,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -822,7 +822,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -855,7 +855,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -888,7 +888,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -921,7 +921,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -955,7 +955,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -994,7 +994,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -1033,7 +1033,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertNotEqualObjects(message.data.message, notExpectedMessage);
             *shouldRemove = YES;
             
@@ -1067,7 +1067,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -1162,7 +1162,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -1251,7 +1251,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addMessageHandlerForClient:client2 withBlock:^(PubNub *client, PNMessageResult *message, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(message.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(message.data.message, expectedMessage);
             *shouldRemove = YES;
             
@@ -1377,7 +1377,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addSignalHandlerForClient:client2 withBlock:^(PubNub *client, PNSignalResult *signal, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(signal.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(signal.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(signal.data.message, expectedSignal);
             *shouldRemove = YES;
             
@@ -1406,7 +1406,7 @@
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         [self addSignalHandlerForClient:client2 withBlock:^(PubNub *client, PNSignalResult *signal, BOOL *shouldRemove) {
-            XCTAssertEqualObjects(signal.data.publisher, client1.currentConfiguration.uuid);
+            XCTAssertEqualObjects(signal.data.publisher, client1.currentConfiguration.userId);
             XCTAssertEqualObjects(signal.data.message, message);
             *shouldRemove = YES;
             

--- a/Tests/Tests/Integration/PNSubscribeIntegrationTest.m
+++ b/Tests/Tests/Integration/PNSubscribeIntegrationTest.m
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 XCTAssertEqual([@0 compare:event.data.presence.timetoken], NSOrderedAscending);
                 XCTAssertEqualObjects(event.data.subscription, channel);
@@ -155,10 +155,10 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.userId]) {
                 
                 NSString *presenceChannel = [channel stringByAppendingString:@"-pnpres"];
-                XCTAssertEqualObjects(event.data.presence.uuid, self.client.currentConfiguration.uuid);
+                XCTAssertEqualObjects(event.data.presence.uuid, self.client.currentConfiguration.userId);
                 XCTAssertEqual([@0 compare:event.data.presence.timetoken], NSOrderedAscending);
                 XCTAssertNotEqual([self.client.presenceChannels indexOfObject:presenceChannel], NSNotFound);
                 XCTAssertEqualObjects(event.data.subscription, channel);
@@ -218,7 +218,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 XCTAssertTrue([channels containsObject:event.data.subscription]);
                 XCTAssertTrue([channels containsObject:event.data.channel]);
@@ -253,7 +253,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -275,7 +275,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -298,7 +298,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.userId]) {
                 
                 XCTAssertTrue([channels containsObject:event.data.subscription]);
                 XCTAssertTrue([channels containsObject:event.data.channel]);
@@ -345,7 +345,8 @@ NS_ASSUME_NONNULL_END
     
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
-        [self.client stateForUUID:self.client.currentConfiguration.uuid onChannel:channel
+        [self.client stateForUUID:self.client.currentConfiguration.userId
+                        onChannel:channel
                    withCompletion:^(PNChannelClientStateResult *result, PNErrorStatus *status) {
             
             NSDictionary *fetchedState = result.data.state;
@@ -389,7 +390,7 @@ NS_ASSUME_NONNULL_END
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         self.client.state().audit()
-            .uuid(self.client.currentConfiguration.uuid)
+            .uuid(self.client.currentConfiguration.userId)
             .channels(channels)
             .performWithCompletion(^(PNClientStateGetResult *result, PNErrorStatus *status) {
                 NSDictionary<NSString *, NSDictionary *> *fetchedChannels = result.data.channels;
@@ -506,7 +507,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 XCTAssertEqual([@0 compare:event.data.presence.timetoken], NSOrderedAscending);
                 XCTAssertEqualObjects(event.data.subscription, channelGroup);
@@ -539,10 +540,10 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.userId]) {
                 NSString *presenceChannelGroup = [channelGroup stringByAppendingString:@"-pnpres"];
                 XCTAssertNotEqual([self.client.channelGroups indexOfObject:presenceChannelGroup], NSNotFound);
-                XCTAssertEqualObjects(event.data.presence.uuid, self.client.currentConfiguration.uuid);
+                XCTAssertEqualObjects(event.data.presence.uuid, self.client.currentConfiguration.userId);
                 XCTAssertEqual([@0 compare:event.data.presence.timetoken], NSOrderedAscending);
                 XCTAssertEqualObjects(event.data.subscription, channelGroup);
                 XCTAssertEqualObjects(event.data.channel, channel);
@@ -615,7 +616,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 XCTAssertTrue([channelGroups containsObject:event.data.subscription]);
                 XCTAssertTrue([channels containsObject:event.data.channel]);
@@ -653,7 +654,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:self.client.currentConfiguration.userId]) {
                 
                 XCTAssertTrue([channelGroups containsObject:event.data.subscription]);
                 XCTAssertTrue([channels containsObject:event.data.channel]);
@@ -708,7 +709,8 @@ NS_ASSUME_NONNULL_END
     
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
-        [self.client stateForUUID:self.client.currentConfiguration.uuid onChannel:channel
+        [self.client stateForUUID:self.client.currentConfiguration.userId
+                        onChannel:channel
                    withCompletion:^(PNChannelClientStateResult *result, PNErrorStatus *status) {
             
             NSDictionary *fetchedState = result.data.state;
@@ -764,7 +766,7 @@ NS_ASSUME_NONNULL_END
     
     [self waitToCompleteIn:self.testCompletionDelay codeBlock:^(dispatch_block_t handler) {
         self.client.state().audit()
-            .uuid(self.client.currentConfiguration.uuid)
+            .uuid(self.client.currentConfiguration.userId)
             .channelGroups(channelGroups)
             .performWithCompletion(^(PNClientStateGetResult *result, PNErrorStatus *status) {
                 NSDictionary<NSString *, NSDictionary *> *fetchedChannels = result.data.channels;
@@ -890,7 +892,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -912,7 +914,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"join"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -966,7 +968,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 XCTAssertEqual([@0 compare:event.data.presence.timetoken], NSOrderedAscending);
                 *remove = YES;
@@ -1022,7 +1024,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 reportedOfflineCount++;
             }
@@ -1052,7 +1054,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -1073,7 +1075,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -1133,7 +1135,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 XCTAssertEqual([@0 compare:event.data.presence.timetoken], NSOrderedAscending);
                 *remove = YES;
@@ -1201,7 +1203,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 
                 reportedOfflineCount++;
             }
@@ -1272,7 +1274,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -1293,7 +1295,7 @@ NS_ASSUME_NONNULL_END
                                 withBlock:^(PubNub *client, PNPresenceEventResult *event, BOOL *remove) {
             
             if ([event.data.presenceEvent isEqualToString:@"leave"] &&
-                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.uuid]) {
+                [event.data.presence.uuid isEqualToString:client1.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -1390,7 +1392,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
                                    
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.subscription, channel);
                 XCTAssertEqualObjects(message.data.channel, channel);
@@ -1432,7 +1434,7 @@ NS_ASSUME_NONNULL_END
     if (YHVVCR.cassette.isNewCassette) {
         PNConfiguration *configuration = self.client.currentConfiguration;
         NSLog(@"Run following command in Terminal:\n\ncurl 'http://%@/publish/%@/%@/0/%@.%%FF/0/%%22hel%%FFlo%%22?uuid=%@' ; echo\n\n",
-              configuration.origin, configuration.publishKey, configuration.subscribeKey, randomChannel, configuration.uuid);
+              configuration.origin, configuration.publishKey, configuration.subscribeKey, randomChannel, configuration.userId);
         [self waitTask:@"waitForDistribution" completionFor:(YHVVCR.cassette.isNewCassette ? 3.f : 0.5f)];
     }
     
@@ -1441,7 +1443,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
                                    
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.subscription, subscription);
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.channel, channel);
@@ -1473,7 +1475,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:client2
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
 
-            if ([message.data.publisher isEqualToString:client1.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:client1.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.subscription, channel);
                 XCTAssertEqualObjects(message.data.channel, channel);
@@ -1509,7 +1511,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:client2
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
 
-            if ([message.data.publisher isEqualToString:client1.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:client1.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.subscription, channel);
                 XCTAssertEqualObjects(message.data.channel, channel);
@@ -1574,7 +1576,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
                                    
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.subscription, channels.lastObject);
                 XCTAssertEqualObjects(message.data.channel, channels.lastObject);
@@ -1631,7 +1633,7 @@ NS_ASSUME_NONNULL_END
 
             NSURLRequest *request = [message valueForKey:@"clientRequest"];
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertTrue([request.URL.absoluteString pnt_includesString:lastTimetoken.stringValue]);
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 *remove = YES;
@@ -1681,7 +1683,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
 
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 *remove = YES;
                 
@@ -1732,7 +1734,7 @@ NS_ASSUME_NONNULL_END
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             NSURLRequest *request = [message valueForKey:@"clientRequest"];
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertTrue([request.URL.absoluteString pnt_includesString:lastTimetoken.stringValue]);
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 *remove = YES;
@@ -1760,7 +1762,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
                                    
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.subscription, channelGroup);
                 XCTAssertEqualObjects(message.data.channel, channel);
@@ -1794,7 +1796,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
                                    
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 XCTAssertEqualObjects(message.data.subscription, channelGroups.firstObject);
                 XCTAssertEqualObjects(message.data.channel, channels.firstObject);
@@ -1860,7 +1862,7 @@ NS_ASSUME_NONNULL_END
 
             NSURLRequest *request = [message valueForKey:@"clientRequest"];
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertTrue([request.URL.absoluteString pnt_includesString:lastTimetoken.stringValue]);
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 *remove = YES;
@@ -1920,7 +1922,7 @@ NS_ASSUME_NONNULL_END
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             NSURLRequest *request = [message valueForKey:@"clientRequest"];
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 XCTAssertTrue([request.URL.absoluteString pnt_includesString:lastTimetoken.stringValue]);
                 XCTAssertEqualObjects(message.data.message, publishedMessage);
                 *remove = YES;
@@ -1940,9 +1942,9 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Tests :: Messages filter expression
 
 - (void)testItShouldSubscribeToSingleChannelAndReceiveMessageWhenFilterExpressionIsSetToExactMatch {
-    NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@'", self.client.currentConfiguration.uuid];
+    NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@'", self.client.currentConfiguration.userId];
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
-    NSDictionary *messageMetadata = @{ @"uuid": self.client.currentConfiguration.uuid };
+    NSDictionary *messageMetadata = @{ @"uuid": self.client.currentConfiguration.userId };
     NSString *channel = [self channelWithName:@"test-channel1"];
     
     
@@ -1957,7 +1959,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -1974,10 +1976,10 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSubscribeToSingleChannelAndReceiveMessageWhenFilterExpressionIsSetToCompound {
     NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@' && (('admin','super-user') contains role) && age >= 32",
-                                  self.client.currentConfiguration.uuid];
+                                  self.client.currentConfiguration.userId];
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
     NSDictionary *messageMetadata = @{
-        @"uuid": self.client.currentConfiguration.uuid,
+        @"uuid": self.client.currentConfiguration.userId,
         @"role": @"super-user",
         @"age": @32
     };
@@ -1995,7 +1997,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -2012,10 +2014,10 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSubscribeToSingleChannelAndReceiveMessageWhenFilterExpressionIsSetToCompoundWithSubstringCheck {
     NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@' && role contains 'adm' && age >= 32",
-                                  self.client.currentConfiguration.uuid];
+                                  self.client.currentConfiguration.userId];
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
     NSDictionary *messageMetadata = @{
-        @"uuid": self.client.currentConfiguration.uuid,
+        @"uuid": self.client.currentConfiguration.userId,
         @"role": @"admin",
         @"age": @32
     };
@@ -2033,7 +2035,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -2050,10 +2052,10 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSubscribeToSingleChannelAndReceiveMessageWhenFilterExpressionIsSetToCompoundWithLike {
     NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@' && privileges like '*write' && age >= 32",
-                                  self.client.currentConfiguration.uuid];
+                                  self.client.currentConfiguration.userId];
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
     NSDictionary *messageMetadata = @{
-        @"uuid": self.client.currentConfiguration.uuid,
+        @"uuid": self.client.currentConfiguration.userId,
         @"privileges": @[@"write", @"read-write"],
         @"age": @32
     };
@@ -2071,7 +2073,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -2088,7 +2090,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSubscribeToSingleChannelAndNotReceiveMessageWhenFilterExpressionIsSetToExactMatch {
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
-    NSDictionary *messageMetadata = @{ @"uuid": self.client.currentConfiguration.uuid };
+    NSDictionary *messageMetadata = @{ @"uuid": self.client.currentConfiguration.userId };
     NSString *channel = [self channelWithName:@"test-channel1"];
     NSString *filterExpression = @"uuid == 'bob'";
     
@@ -2104,7 +2106,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -2121,10 +2123,10 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSubscribeToSingleChannelAndNotReceiveMessageWhenFilterExpressionIsSetToCompound {
     NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@' && !admin && age >= 32",
-                                  self.client.currentConfiguration.uuid];
+                                  self.client.currentConfiguration.userId];
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
     NSDictionary *messageMetadata = @{
-        @"uuid": self.client.currentConfiguration.uuid,
+        @"uuid": self.client.currentConfiguration.userId,
         @"admin": @YES,
         @"age": @33
     };
@@ -2142,7 +2144,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -2159,10 +2161,10 @@ NS_ASSUME_NONNULL_END
 
 - (void)testItShouldSubscribeToSingleChannelAndReceiveFilteredMessagesWhenFilterExpressionSetAfterSubscribe {
     NSString *filterExpression = [NSString stringWithFormat:@"uuid == '%@' && !admin && age >= 32",
-                                  self.client.currentConfiguration.uuid];
+                                  self.client.currentConfiguration.userId];
     NSDictionary *publishedMessage = @{ @"test-message": [self randomizedValuesWithValues:@[@"message"]] };
     NSDictionary *messageMetadata = @{
-        @"uuid": self.client.currentConfiguration.uuid,
+        @"uuid": self.client.currentConfiguration.userId,
         @"admin": @YES,
         @"age": @33
     };
@@ -2177,7 +2179,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();
@@ -2199,7 +2201,7 @@ NS_ASSUME_NONNULL_END
         [self addMessageHandlerForClient:self.client
                                withBlock:^(PubNub *client, PNMessageResult *message, BOOL *remove) {
             
-            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.uuid]) {
+            if ([message.data.publisher isEqualToString:self.client.currentConfiguration.userId]) {
                 *remove = YES;
                 
                 handler();

--- a/Tests/Tests/Unit/Core/Objects/PNMembershipObjectsTest.m
+++ b/Tests/Tests/Unit/Core/Objects/PNMembershipObjectsTest.m
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldSetMembershipsUsingPubNubClientUUIDWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
     NSArray<NSDictionary *> *channels = @[
         @{ @"channel": [NSUUID UUID].UUIDString, @"custom": @{ @"channel": [NSUUID UUID].UUIDString } }
     ];
@@ -188,7 +188,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldRemoveMembershipsUsingPubNubClientUUIDWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
     NSArray<NSDictionary *> *channels = @[
         @{ @"channel": [NSUUID UUID].UUIDString, @"custom": @{ @"channel": [NSUUID UUID].UUIDString } }
     ];
@@ -276,7 +276,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldManageMembershipsUsingPubNubClientUUIDWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
     NSArray<NSDictionary *> *setChannels = @[
             @{ @"channel": [NSUUID UUID].UUIDString, @"custom": @{ @"channel": [NSUUID UUID].UUIDString } }
     ];
@@ -381,7 +381,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldFetchMembershipsUsingPubNubClientUUIDMembershipsWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
 
 
     id clientMock = [self mockForObject:self.client];

--- a/Tests/Tests/Unit/Core/Objects/PNUUIDMetadataObjectsTest.m
+++ b/Tests/Tests/Unit/Core/Objects/PNUUIDMetadataObjectsTest.m
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldSetUUIDMetadataUsingPubNubClientUUIDWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
 
 
     id clientMock = [self mockForObject:self.client];
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldRemoveUUIDMetadataUsingPubNubClientUUIDWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
 
 
     id clientMock = [self mockForObject:self.client];
@@ -293,7 +293,7 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)testItShouldFetchUUIDMetadataUsingPubNubClientUUIDWhenUUIDIsMissing {
-    NSString *expectedId = self.client.currentConfiguration.uuid;
+    NSString *expectedId = self.client.currentConfiguration.userId;
 
 
     id clientMock = [self mockForObject:self.client];

--- a/Tests/Tests/Unit/Data/PNConfigurationTest.m
+++ b/Tests/Tests/Unit/Data/PNConfigurationTest.m
@@ -38,33 +38,33 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Tests :: UUID requirement
 
 - (void)testItShouldNotThrowWhenUUIDIsSet {
-    XCTAssertNoThrow([PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" uuid:@"uuid"],
+    XCTAssertNoThrow([PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" userId:@"uuid"],
                      @"Should not throw when UUID is set.");
 }
 
 - (void)testItShouldNotThrowWhenSetToNonEmptyUUID {
-    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" uuid:@"uuid"];
-    XCTAssertNoThrow(configuration.uuid = @"uuid2", @"Should not throw when UUID changed.");
+    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" userId:@"uuid"];
+    XCTAssertNoThrow(configuration.userId = @"uuid2", @"Should not throw when UUID changed.");
 }
 
 - (void)testItShouldThrowWhenUUIDIsEmpty {
-    XCTAssertThrows([PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" uuid:@""],
+    XCTAssertThrows([PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" userId:@""],
                     @"Should throw on empty UUID.");
 }
 
 - (void)testItShouldThrowWhenUUIDWhichContainsOnlySpaces {
-    XCTAssertThrows([PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" uuid:@"   "],
+    XCTAssertThrows([PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" userId:@"   "],
                     @"Should throw on empty UUID.");
 }
 
 - (void)testItShouldThrowWhenSetEmptyUUID {
-    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" uuid:@"uuid"];
-    XCTAssertThrows(configuration.uuid = @"", @"Should throw when UUID changed to empty.");
+    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" userId:@"uuid"];
+    XCTAssertThrows(configuration.userId = @"", @"Should throw when UUID changed to empty.");
 }
 
 - (void)testItShouldThrowWhenSetUUIDWhichContainsOnlySpaces {
-    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" uuid:@"uuid"];
-    XCTAssertThrows(configuration.uuid = @"    ", @"Should throw when UUID changed to empty.");
+    PNConfiguration *configuration = [PNConfiguration configurationWithPublishKey:@"demo" subscribeKey:@"demo" userId:@"uuid"];
+    XCTAssertThrows(configuration.userId = @"    ", @"Should throw when UUID changed to empty.");
 }
 
 #pragma mark -


### PR DESCRIPTION
feat: introduce `userId` as `uuid` replacement

Introduce new `userId` configuration (provided to `PNConfiguration` instance) property which replaces deprecated `uuid`.