### PR TITLE
Add message type support for: `publish`, `signal`, `history` and `subscribe`

### DIFF
--- a/Framework/PubNub Framework.xcodeproj/project.pbxproj
+++ b/Framework/PubNub Framework.xcodeproj/project.pbxproj
@@ -2493,6 +2493,31 @@
 		A5A7B0332349330F0060113B /* PNBaseMessageActionRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A7AFF82349330F0060113B /* PNBaseMessageActionRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A5A7B0342349330F0060113B /* PNBaseMessageActionRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A7AFF82349330F0060113B /* PNBaseMessageActionRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A5A7B0362349330F0060113B /* PNBaseMessageActionRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = A5A7AFF82349330F0060113B /* PNBaseMessageActionRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35612959C45B0038FD6F /* PNMessageType.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE355F2959C45B0038FD6F /* PNMessageType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35622959C45B0038FD6F /* PNMessageType.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE355F2959C45B0038FD6F /* PNMessageType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35632959C45B0038FD6F /* PNMessageType.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE355F2959C45B0038FD6F /* PNMessageType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35642959C45B0038FD6F /* PNMessageType.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE355F2959C45B0038FD6F /* PNMessageType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35652959C45B0038FD6F /* PNMessageType.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE355F2959C45B0038FD6F /* PNMessageType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35662959C45B0038FD6F /* PNMessageType.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35602959C45B0038FD6F /* PNMessageType.m */; };
+		A5CE35672959C45B0038FD6F /* PNMessageType.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35602959C45B0038FD6F /* PNMessageType.m */; };
+		A5CE35682959C45B0038FD6F /* PNMessageType.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35602959C45B0038FD6F /* PNMessageType.m */; };
+		A5CE35692959C45B0038FD6F /* PNMessageType.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35602959C45B0038FD6F /* PNMessageType.m */; };
+		A5CE356A2959C45B0038FD6F /* PNMessageType.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35602959C45B0038FD6F /* PNMessageType.m */; };
+		A5CE356C2959C9260038FD6F /* PNMessageType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */; };
+		A5CE356D2959C9260038FD6F /* PNMessageType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */; };
+		A5CE356E2959C9260038FD6F /* PNMessageType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */; };
+		A5CE356F2959C9260038FD6F /* PNMessageType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */; };
+		A5CE35702959C9260038FD6F /* PNMessageType+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */; };
+		A5CE35732959D1E80038FD6F /* PNSpaceId.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE35712959D1E80038FD6F /* PNSpaceId.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35742959D1E80038FD6F /* PNSpaceId.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE35712959D1E80038FD6F /* PNSpaceId.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35752959D1E80038FD6F /* PNSpaceId.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE35712959D1E80038FD6F /* PNSpaceId.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35762959D1E80038FD6F /* PNSpaceId.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE35712959D1E80038FD6F /* PNSpaceId.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35772959D1E80038FD6F /* PNSpaceId.h in Headers */ = {isa = PBXBuildFile; fileRef = A5CE35712959D1E80038FD6F /* PNSpaceId.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A5CE35782959D1E80038FD6F /* PNSpaceId.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35722959D1E80038FD6F /* PNSpaceId.m */; };
+		A5CE35792959D1E80038FD6F /* PNSpaceId.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35722959D1E80038FD6F /* PNSpaceId.m */; };
+		A5CE357A2959D1E80038FD6F /* PNSpaceId.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35722959D1E80038FD6F /* PNSpaceId.m */; };
+		A5CE357B2959D1E80038FD6F /* PNSpaceId.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35722959D1E80038FD6F /* PNSpaceId.m */; };
+		A5CE357C2959D1E80038FD6F /* PNSpaceId.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CE35722959D1E80038FD6F /* PNSpaceId.m */; };
 		A5FADC342490270E001D7704 /* PubNub+Files.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FADC322490270E001D7704 /* PubNub+Files.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A5FADC352490270E001D7704 /* PubNub+Files.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FADC322490270E001D7704 /* PubNub+Files.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A5FADC362490270E001D7704 /* PubNub+Files.h in Headers */ = {isa = PBXBuildFile; fileRef = A5FADC322490270E001D7704 /* PubNub+Files.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3043,6 +3068,11 @@
 		A5A7AFF62349330E0060113B /* PNRemoveMessageActionRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = PNRemoveMessageActionRequest.m; path = Message/PNRemoveMessageActionRequest.m; sourceTree = "<group>"; };
 		A5A7AFF72349330F0060113B /* PNRemoveMessageActionRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PNRemoveMessageActionRequest.h; path = Message/PNRemoveMessageActionRequest.h; sourceTree = "<group>"; };
 		A5A7AFF82349330F0060113B /* PNBaseMessageActionRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PNBaseMessageActionRequest.h; path = Message/PNBaseMessageActionRequest.h; sourceTree = "<group>"; };
+		A5CE355F2959C45B0038FD6F /* PNMessageType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PNMessageType.h; sourceTree = "<group>"; };
+		A5CE35602959C45B0038FD6F /* PNMessageType.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PNMessageType.m; sourceTree = "<group>"; };
+		A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PNMessageType+Private.h"; sourceTree = "<group>"; };
+		A5CE35712959D1E80038FD6F /* PNSpaceId.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PNSpaceId.h; sourceTree = "<group>"; };
+		A5CE35722959D1E80038FD6F /* PNSpaceId.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PNSpaceId.m; sourceTree = "<group>"; };
 		A5FADC322490270E001D7704 /* PubNub+Files.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "PubNub+Files.h"; sourceTree = "<group>"; };
 		A5FADC332490270E001D7704 /* PubNub+Files.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PubNub+Files.m"; sourceTree = "<group>"; };
 		A5FADC3F2490292A001D7704 /* PNSendFileRequest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PNSendFileRequest.h; sourceTree = "<group>"; };
@@ -3780,30 +3810,35 @@
 		A55A86A322FD817E002D0A72 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				A55BCD24231D27F00019DB68 /* PNMessageAction+Private.h */,
-				A55BCD14231D26110019DB68 /* PNMessageAction.h */,
-				A55BCD15231D26110019DB68 /* PNMessageAction.m */,
-				A58975E023005CFB0093BD9A /* PNMembership+Private.h */,
-				A58975C023005BD80093BD9A /* PNMembership.h */,
-				A58975C123005BD80093BD9A /* PNMembership.m */,
-				A568655F2300622C0014E17C /* PNChannelMember+Private.h */,
-				A58975D023005BE60093BD9A /* PNChannelMember.h */,
-				A58975D123005BE60093BD9A /* PNChannelMember.m */,
 				A55A86A522FD817E002D0A72 /* PNChannelMetadata+Private.h */,
 				A55A86A622FD817E002D0A72 /* PNChannelMetadata.h */,
 				A55A86A922FD817E002D0A72 /* PNChannelMetadata.m */,
+				A568655F2300622C0014E17C /* PNChannelMember+Private.h */,
+				A58975D023005BE60093BD9A /* PNChannelMember.h */,
+				A58975D123005BE60093BD9A /* PNChannelMember.m */,
+				A55BCD24231D27F00019DB68 /* PNMessageAction+Private.h */,
+				A55BCD14231D26110019DB68 /* PNMessageAction.h */,
+				A55BCD15231D26110019DB68 /* PNMessageAction.m */,
 				A55A86A722FD817E002D0A72 /* PNUUIDMetadata+Private.h */,
 				A55A86A822FD817E002D0A72 /* PNUUIDMetadata.h */,
 				A55A86A422FD817E002D0A72 /* PNUUIDMetadata.m */,
+				A5CE356B2959C9260038FD6F /* PNMessageType+Private.h */,
+				A5CE355F2959C45B0038FD6F /* PNMessageType.h */,
+				A5CE35602959C45B0038FD6F /* PNMessageType.m */,
+				A5CE35712959D1E80038FD6F /* PNSpaceId.h */,
+				A5CE35722959D1E80038FD6F /* PNSpaceId.m */,
+				A58975E023005CFB0093BD9A /* PNMembership+Private.h */,
+				A58975C023005BD80093BD9A /* PNMembership.h */,
+				A58975C123005BD80093BD9A /* PNMembership.m */,
 				79CFA2CF26DE1CD100D206D4 /* PNPAMToken+Private.h */,
 				79CFA2B726DE1C4900D206D4 /* PNPAMToken.h */,
 				79CFA2B826DE1C4900D206D4 /* PNPAMToken.m */,
-				A504E14B24AA9515006DCF5B /* PNFile+Private.h */,
-				A504E13F24AA94C8006DCF5B /* PNFile.h */,
-				A504E14024AA94C8006DCF5B /* PNFile.m */,
 				A55DAF0624B1FEC800766EE9 /* PNXML+Private.h */,
 				A55DAEFA24B1FE9E00766EE9 /* PNXML.h */,
 				A55DAEFB24B1FE9E00766EE9 /* PNXML.m */,
+				A504E14B24AA9515006DCF5B /* PNFile+Private.h */,
+				A504E13F24AA94C8006DCF5B /* PNFile.h */,
+				A504E14024AA94C8006DCF5B /* PNFile.m */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -4057,6 +4092,7 @@
 				79AA8EC926EAB81500ADA747 /* PNConfiguration+Private.h in Headers */,
 				A58975B223005AAC0093BD9A /* PNManageMembershipsStatus.h in Headers */,
 				79A238D01D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
+				A5CE356C2959C9260038FD6F /* PNMessageType+Private.h in Headers */,
 				791582521BD709C60084FC70 /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				7932485E1D874D9F00FBDF36 /* PNPublishSequence.h in Headers */,
 				79A0D8441DC22C950039A264 /* PNAPNSAuditAPICallBuilder.h in Headers */,
@@ -4168,6 +4204,7 @@
 				A55DAEFC24B1FE9E00766EE9 /* PNXML.h in Headers */,
 				A55A87DC22FD8272002D0A72 /* PNBaseObjectsRequest.h in Headers */,
 				A57A3089238D751400DE8C68 /* PNMPNSNotificationPayload.h in Headers */,
+				A5CE35612959C45B0038FD6F /* PNMessageType.h in Headers */,
 				79A0D86E1DC22C950039A264 /* PNAPICallBuilder+Private.h in Headers */,
 				A57A30E9238DCAAF00DE8C68 /* PNAPNSNotificationTarget+Private.h in Headers */,
 				A55A881B22FD8272002D0A72 /* PNFetchAllChannelsMetadataRequest.h in Headers */,
@@ -4216,6 +4253,7 @@
 				A5A4519E246DE792008ECC74 /* PNRemoveMembershipsRequest.h in Headers */,
 				A504E11C24AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.h in Headers */,
 				A55A86B822FD817E002D0A72 /* PNChannelMetadata.h in Headers */,
+				A5CE35732959D1E80038FD6F /* PNSpaceId.h in Headers */,
 				7915827E1BD709C60084FC70 /* PNURLBuilder.h in Headers */,
 				A55A86BF22FD817E002D0A72 /* PNUUIDMetadata+Private.h in Headers */,
 				7915827C1BD709C60084FC70 /* PNTimeParser.h in Headers */,
@@ -4332,6 +4370,7 @@
 				79AA8ECB26EAB81500ADA747 /* PNConfiguration+Private.h in Headers */,
 				A58975B423005AAC0093BD9A /* PNManageMembershipsStatus.h in Headers */,
 				791583201BD709D10084FC70 /* PNPushNotificationsStateModificationParser.h in Headers */,
+				A5CE356E2959C9260038FD6F /* PNMessageType+Private.h in Headers */,
 				79A238D21D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				791582FB1BD709D10084FC70 /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				793248601D874D9F00FBDF36 /* PNPublishSequence.h in Headers */,
@@ -4443,6 +4482,7 @@
 				A55DAEFE24B1FE9E00766EE9 /* PNXML.h in Headers */,
 				A55A87DE22FD8272002D0A72 /* PNBaseObjectsRequest.h in Headers */,
 				A57A308B238D751400DE8C68 /* PNMPNSNotificationPayload.h in Headers */,
+				A5CE35632959C45B0038FD6F /* PNMessageType.h in Headers */,
 				791583111BD709D10084FC70 /* PNHistoryResult.h in Headers */,
 				A57A30EB238DCAAF00DE8C68 /* PNAPNSNotificationTarget+Private.h in Headers */,
 				A55A881D22FD8272002D0A72 /* PNFetchAllChannelsMetadataRequest.h in Headers */,
@@ -4491,6 +4531,7 @@
 				A5A451A0246DE792008ECC74 /* PNRemoveMembershipsRequest.h in Headers */,
 				A504E11E24AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.h in Headers */,
 				A55A86BA22FD817E002D0A72 /* PNChannelMetadata.h in Headers */,
+				A5CE35752959D1E80038FD6F /* PNSpaceId.h in Headers */,
 				791583191BD709D10084FC70 /* PNTimeResult.h in Headers */,
 				A55A86C122FD817E002D0A72 /* PNUUIDMetadata+Private.h in Headers */,
 				79A0D8C01DC22FD60039A264 /* PNPresenceChannelHereNowAPICallBuilder.h in Headers */,
@@ -4633,6 +4674,7 @@
 				7988423D1C18F128003E8948 /* PNAPNSEnabledChannelsResult.h in Headers */,
 				A57A3027238D59B500DE8C68 /* PNRemovePushNotificationsRequest.h in Headers */,
 				A5A7AFD2234932F30060113B /* PNFetchMessagesActionsParser.h in Headers */,
+				A5CE35772959D1E80038FD6F /* PNSpaceId.h in Headers */,
 				A55A861522FD80B9002D0A72 /* PNRemoveUUIDMetadataAPICallBuilder.h in Headers */,
 				79A0D8871DC22F520039A264 /* PNAPNSAPICallBuilder.h in Headers */,
 				A5A451C1246DE8C3008ECC74 /* PNRemoveChannelMembersRequest.h in Headers */,
@@ -4649,6 +4691,7 @@
 				A5A7B0132349330F0060113B /* PNAddMessageActionRequest.h in Headers */,
 				A55BCCFB231D222B0019DB68 /* PNRemoveMessageActionAPICallBuilder.h in Headers */,
 				7960B6691F68122200FFAEBB /* PNDeleteMessageAPICallBuilder.h in Headers */,
+				A5CE35652959C45B0038FD6F /* PNMessageType.h in Headers */,
 				A55DAF0B24B1FEC800766EE9 /* PNXML+Private.h in Headers */,
 				A504E15824AA9CFB006DCF5B /* PNFilesAPICallBuilder.h in Headers */,
 				A57A308E238D751400DE8C68 /* PNMPNSNotificationPayload.h in Headers */,
@@ -4835,6 +4878,7 @@
 				7925DB8C1D3FFCAC00857C0D /* PNLLogger.h in Headers */,
 				79CFA2BD26DE1C4900D206D4 /* PNPAMToken.h in Headers */,
 				79A3E4142215699900F2ADB9 /* PNMessageCountAPICallBuilder.h in Headers */,
+				A5CE35702959C9260038FD6F /* PNMessageType+Private.h in Headers */,
 				A55A866222FD80B9002D0A72 /* PNFetchChannelMetadataAPICallBuilder.h in Headers */,
 				79ABD8961F01636B007634E0 /* PNTelemetry.h in Headers */,
 				7988427F1C18F286003E8948 /* PNNumber.h in Headers */,
@@ -4881,6 +4925,7 @@
 				79AA8ECA26EAB81500ADA747 /* PNConfiguration+Private.h in Headers */,
 				A58975B323005AAC0093BD9A /* PNManageMembershipsStatus.h in Headers */,
 				79A8BC8D1C58F93900015BDE /* PNPushNotificationsStateModificationParser.h in Headers */,
+				A5CE356D2959C9260038FD6F /* PNMessageType+Private.h in Headers */,
 				79A238D11D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				79A8BC681C58F93900015BDE /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				7932485F1D874D9F00FBDF36 /* PNPublishSequence.h in Headers */,
@@ -4992,6 +5037,7 @@
 				A55DAEFD24B1FE9E00766EE9 /* PNXML.h in Headers */,
 				A55A87DD22FD8272002D0A72 /* PNBaseObjectsRequest.h in Headers */,
 				A57A308A238D751400DE8C68 /* PNMPNSNotificationPayload.h in Headers */,
+				A5CE35622959C45B0038FD6F /* PNMessageType.h in Headers */,
 				79A8BC7E1C58F93900015BDE /* PNHistoryResult.h in Headers */,
 				A57A30EA238DCAAF00DE8C68 /* PNAPNSNotificationTarget+Private.h in Headers */,
 				A55A881C22FD8272002D0A72 /* PNFetchAllChannelsMetadataRequest.h in Headers */,
@@ -5040,6 +5086,7 @@
 				A5A4519F246DE792008ECC74 /* PNRemoveMembershipsRequest.h in Headers */,
 				A504E11D24AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.h in Headers */,
 				A55A86B922FD817E002D0A72 /* PNChannelMetadata.h in Headers */,
+				A5CE35742959D1E80038FD6F /* PNSpaceId.h in Headers */,
 				79A8BC861C58F93900015BDE /* PNTimeResult.h in Headers */,
 				A55A86C022FD817E002D0A72 /* PNUUIDMetadata+Private.h in Headers */,
 				79A0D8BF1DC22FD60039A264 /* PNPresenceChannelHereNowAPICallBuilder.h in Headers */,
@@ -5156,6 +5203,7 @@
 				79AA8ECC26EAB81500ADA747 /* PNConfiguration+Private.h in Headers */,
 				A58975B523005AAC0093BD9A /* PNManageMembershipsStatus.h in Headers */,
 				79E20D2C1C8B0AD5001BC9CC /* PNPushNotificationsStateModificationParser.h in Headers */,
+				A5CE356F2959C9260038FD6F /* PNMessageType+Private.h in Headers */,
 				79A238D31D2E70BD00D080CD /* NSURLSessionConfiguration+PNConfiguration.h in Headers */,
 				79E20D2B1C8B0A70001BC9CC /* PNPresenceChannelGroupHereNowResult.h in Headers */,
 				793248611D874D9F00FBDF36 /* PNPublishSequence.h in Headers */,
@@ -5267,6 +5315,7 @@
 				A55DAEFF24B1FE9E00766EE9 /* PNXML.h in Headers */,
 				A55A87DF22FD8272002D0A72 /* PNBaseObjectsRequest.h in Headers */,
 				A57A308C238D751400DE8C68 /* PNMPNSNotificationPayload.h in Headers */,
+				A5CE35642959C45B0038FD6F /* PNMessageType.h in Headers */,
 				79CBB11A1BD03DE4001FC34D /* PNConfiguration.h in Headers */,
 				A57A30EC238DCAAF00DE8C68 /* PNAPNSNotificationTarget+Private.h in Headers */,
 				A55A881E22FD8272002D0A72 /* PNFetchAllChannelsMetadataRequest.h in Headers */,
@@ -5315,6 +5364,7 @@
 				A5A451A1246DE792008ECC74 /* PNRemoveMembershipsRequest.h in Headers */,
 				A504E11F24AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.h in Headers */,
 				A55A86BB22FD817E002D0A72 /* PNChannelMetadata.h in Headers */,
+				A5CE35762959D1E80038FD6F /* PNSpaceId.h in Headers */,
 				79CBB1631BD03DE4001FC34D /* PNErrorCodes.h in Headers */,
 				A55A86C222FD817E002D0A72 /* PNUUIDMetadata+Private.h in Headers */,
 				79A0D8C11DC22FD60039A264 /* PNPresenceChannelHereNowAPICallBuilder.h in Headers */,
@@ -5921,6 +5971,7 @@
 				7925DB9C1D3FFCAC00857C0D /* PNLLogFileInformation.m in Sources */,
 				7915822C1BD709C60084FC70 /* PNClientInformation.m in Sources */,
 				793248651D874D9F00FBDF36 /* PNPublishSequence.m in Sources */,
+				A5CE35782959D1E80038FD6F /* PNSpaceId.m in Sources */,
 				A504E12124AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.m in Sources */,
 				791582231BD709C60084FC70 /* PNRequestParameters.m in Sources */,
 				791582291BD709C60084FC70 /* PNSubscriberResults.m in Sources */,
@@ -6064,6 +6115,7 @@
 				A56865702300709F0014E17C /* PNFetchMembershipsResult.m in Sources */,
 				A56FAEF9233161570072ADD6 /* PubNub+MessageActions.m in Sources */,
 				79A0D8651DC22C950039A264 /* PNSubscribeAPIBuilder.m in Sources */,
+				A5CE35662959C45B0038FD6F /* PNMessageType.m in Sources */,
 				A5046F2424784CAB0008C81E /* PNObjectsRemoveParser.m in Sources */,
 				A5046F1D24784CAB0008C81E /* PNRemoveUUIDMetadataRequest.m in Sources */,
 				A5046F0B24784CAB0008C81E /* PNMembership.m in Sources */,
@@ -6151,6 +6203,7 @@
 				791582C01BD709D10084FC70 /* PNPresenceWhereNowResult.m in Sources */,
 				791582F51BD709D10084FC70 /* PNPresenceHereNowParser.m in Sources */,
 				791582DA1BD709D10084FC70 /* PNMessagePublishParser.m in Sources */,
+				A5CE357A2959D1E80038FD6F /* PNSpaceId.m in Sources */,
 				A504E12324AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.m in Sources */,
 				791582CA1BD709D10084FC70 /* PNAcknowledgmentStatus.m in Sources */,
 				79A0D9871DC2315D0039A264 /* PNTimeAPICallBuilder.m in Sources */,
@@ -6294,6 +6347,7 @@
 				A56865722300709F0014E17C /* PNFetchMembershipsResult.m in Sources */,
 				A56FAEFB233161570072ADD6 /* PubNub+MessageActions.m in Sources */,
 				79A0D96D1DC2313A0039A264 /* PNSubscribeChannelsOrGroupsAPIBuilder.m in Sources */,
+				A5CE35682959C45B0038FD6F /* PNMessageType.m in Sources */,
 				A5046EC624784CAA0008C81E /* PNObjectsRemoveParser.m in Sources */,
 				A5046EBF24784CAA0008C81E /* PNRemoveUUIDMetadataRequest.m in Sources */,
 				A5046EAD24784CAA0008C81E /* PNMembership.m in Sources */,
@@ -6381,6 +6435,7 @@
 				7988426C1C18F1E3003E8948 /* PNPresenceWhereNowResult.m in Sources */,
 				798842BC1C18F2EA003E8948 /* PNPresenceHereNowParser.m in Sources */,
 				798842BB1C18F2EA003E8948 /* PNMessagePublishParser.m in Sources */,
+				A5CE357C2959D1E80038FD6F /* PNSpaceId.m in Sources */,
 				A504E12524AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.m in Sources */,
 				798842601C18F1E3003E8948 /* PNAcknowledgmentStatus.m in Sources */,
 				79A0D98B1DC2315F0039A264 /* PNTimeAPICallBuilder.m in Sources */,
@@ -6524,6 +6579,7 @@
 				A56865752300709F0014E17C /* PNFetchMembershipsResult.m in Sources */,
 				A56FAEFE233161570072ADD6 /* PubNub+MessageActions.m in Sources */,
 				79A0D96F1DC2313B0039A264 /* PNSubscribeChannelsOrGroupsAPIBuilder.m in Sources */,
+				A5CE356A2959C45B0038FD6F /* PNMessageType.m in Sources */,
 				A5046E6824784CA90008C81E /* PNObjectsRemoveParser.m in Sources */,
 				A5046E6124784CA90008C81E /* PNRemoveUUIDMetadataRequest.m in Sources */,
 				A5046E4F24784CA90008C81E /* PNMembership.m in Sources */,
@@ -6611,6 +6667,7 @@
 				79A8BC2C1C58F93900015BDE /* PNPresenceWhereNowResult.m in Sources */,
 				79A8BC621C58F93900015BDE /* PNPresenceHereNowParser.m in Sources */,
 				79A8BC461C58F93900015BDE /* PNMessagePublishParser.m in Sources */,
+				A5CE35792959D1E80038FD6F /* PNSpaceId.m in Sources */,
 				A504E12224AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.m in Sources */,
 				79A8BC361C58F93900015BDE /* PNAcknowledgmentStatus.m in Sources */,
 				79A0D9861DC2315D0039A264 /* PNTimeAPICallBuilder.m in Sources */,
@@ -6754,6 +6811,7 @@
 				A56865712300709F0014E17C /* PNFetchMembershipsResult.m in Sources */,
 				A56FAEFA233161570072ADD6 /* PubNub+MessageActions.m in Sources */,
 				79A0D96E1DC2313A0039A264 /* PNSubscribeChannelsOrGroupsAPIBuilder.m in Sources */,
+				A5CE35672959C45B0038FD6F /* PNMessageType.m in Sources */,
 				A5046EF524784CAB0008C81E /* PNObjectsRemoveParser.m in Sources */,
 				A5046EEE24784CAB0008C81E /* PNRemoveUUIDMetadataRequest.m in Sources */,
 				A5046EDC24784CAB0008C81E /* PNMembership.m in Sources */,
@@ -6841,6 +6899,7 @@
 				79CBB17B1BD03DE4001FC34D /* PNPresenceWhereNowParser.m in Sources */,
 				79CBB1791BD03DE4001FC34D /* PNPresenceHereNowParser.m in Sources */,
 				79CBB1771BD03DE4001FC34D /* PNMessagePublishParser.m in Sources */,
+				A5CE357B2959D1E80038FD6F /* PNSpaceId.m in Sources */,
 				A504E12424AA8FBF006DCF5B /* PNGenerateFileUploadURLStatus.m in Sources */,
 				79CBB11D1BD03DE4001FC34D /* PNAcknowledgmentStatus.m in Sources */,
 				79A0D9881DC2315E0039A264 /* PNTimeAPICallBuilder.m in Sources */,
@@ -6984,6 +7043,7 @@
 				A56865732300709F0014E17C /* PNFetchMembershipsResult.m in Sources */,
 				A56FAEFC233161570072ADD6 /* PubNub+MessageActions.m in Sources */,
 				79A0D9711DC2313C0039A264 /* PNSubscribeChannelsOrGroupsAPIBuilder.m in Sources */,
+				A5CE35692959C45B0038FD6F /* PNMessageType.m in Sources */,
 				A5046E9724784CAA0008C81E /* PNObjectsRemoveParser.m in Sources */,
 				A5046E9024784CAA0008C81E /* PNRemoveUUIDMetadataRequest.m in Sources */,
 				A5046E7E24784CAA0008C81E /* PNMembership.m in Sources */,

--- a/Framework/PubNub/PubNub.h
+++ b/Framework/PubNub/PubNub.h
@@ -54,6 +54,10 @@ FOUNDATION_EXPORT const unsigned char PubNubVersionString[];
 #import "PNResult.h"
 #import "PNStatus.h"
 
+// Models
+#import "PNMessageType.h"
+#import "PNSpaceId.h"
+
 // API
 #import "PubNub+Core.h"
 #import "PubNub+MessageActions.h"

--- a/PubNub/Core/PubNub+History.m
+++ b/PubNub/Core/PubNub+History.m
@@ -43,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   not.
  * @param includeMessageType Whether event type should be included in response or not.
  *   By default set to: \b YES.
+ * @param includeSpaceId Whether identifier of space to which event has been sent should be included or not.
  * @param includeUUID Whether event publisher UUID should be included in response or not.
  *   By default set to: \b YES.
  * @param shouldIncludeMessageActions Whether event actions should be included in response or not.
@@ -61,6 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
                    reverse:(nullable NSNumber *)shouldReverseOrder
           includeTimeToken:(nullable NSNumber *)shouldIncludeTimeToken
         includeMessageType:(nullable NSNumber *)includeMessageType
+            includeSpaceId:(nullable NSNumber *)includeSpaceId
                includeUUID:(nullable NSNumber *)includeUUID
      includeMessageActions:(nullable NSNumber *)shouldIncludeMessageActions
            includeMetadata:(nullable NSNumber *)shouldIncludeMetadata
@@ -153,6 +155,7 @@ NS_ASSUME_NONNULL_END
         NSNumber *reverse = parameters[NSStringFromSelector(@selector(reverse))];
         NSNumber *includeTimeToken = parameters[NSStringFromSelector(@selector(includeTimeToken))];
         NSNumber *includeMessageType = parameters[NSStringFromSelector(@selector(includeMessageType))];
+        NSNumber *includeSpaceId = parameters[NSStringFromSelector(@selector(includeSpaceId))];
         NSNumber *includeUUID = parameters[NSStringFromSelector(@selector(includeUUID))];
         NSNumber *includeMetadata = parameters[NSStringFromSelector(@selector(includeMetadata))];
         NSNumber *includeActions = parameters[NSStringFromSelector(@selector(includeMessageActions))];
@@ -167,6 +170,7 @@ NS_ASSUME_NONNULL_END
                          reverse:reverse
                 includeTimeToken:includeTimeToken
               includeMessageType:includeMessageType
+                  includeSpaceId:includeSpaceId
                      includeUUID:includeUUID
            includeMessageActions:includeActions
                  includeMetadata:includeMetadata
@@ -316,6 +320,7 @@ NS_ASSUME_NONNULL_END
                      reverse:@NO
             includeTimeToken:@NO
           includeMessageType:@YES
+              includeSpaceId:@NO
                  includeUUID:@YES
        includeMessageActions:@(shouldIncludeMessageActions)
              includeMetadata:@(shouldIncludeMetadata)
@@ -403,6 +408,7 @@ NS_ASSUME_NONNULL_END
                      reverse:@(shouldReverseOrder)
             includeTimeToken:@(shouldIncludeTimeToken)
           includeMessageType:@YES
+              includeSpaceId:@NO
                  includeUUID:@YES
        includeMessageActions:nil
              includeMetadata:nil
@@ -418,6 +424,7 @@ NS_ASSUME_NONNULL_END
                    reverse:(NSNumber *)shouldReverseOrder
           includeTimeToken:(NSNumber *)shouldIncludeTimeToken
         includeMessageType:(NSNumber *)includeMessageType
+            includeSpaceId:(NSNumber *)includeSpaceId
                includeUUID:(NSNumber *)includeUUID
      includeMessageActions:(NSNumber *)shouldIncludeMessageActions
            includeMetadata:(NSNumber *)shouldIncludeMetadata
@@ -436,9 +443,13 @@ NS_ASSUME_NONNULL_END
     if (!limit || limit.unsignedIntValue == 0) {
         limit = nil;
     }
-    
+
     if (!includeMessageType) {
         includeMessageType = @YES;
+    }
+
+    if (!includeSpaceId) {
+        includeSpaceId = @NO;
     }
     
     if (!includeUUID) {
@@ -508,6 +519,10 @@ NS_ASSUME_NONNULL_END
     if (operation == PNHistoryWithActionsOperation || multipleChannels) {
         [parameters addQueryParameter:(includeMessageType.boolValue ? @"true" : @"false")
                          forFieldName:@"include_message_type"];
+        [parameters addQueryParameter:(includeMessageType.boolValue ? @"true" : @"false")
+                         forFieldName:@"include_type"];
+        [parameters addQueryParameter:(includeSpaceId.boolValue ? @"true" : @"false")
+                         forFieldName:@"include_space_id"];
         [parameters addQueryParameter:(includeUUID.boolValue ? @"true" : @"false")
                          forFieldName:@"include_uuid"];
     }
@@ -569,6 +584,7 @@ NS_ASSUME_NONNULL_END
                                      reverse:shouldReverseOrder
                             includeTimeToken:shouldIncludeTimeToken
                           includeMessageType:includeMessageType
+                              includeSpaceId:includeSpaceId
                                  includeUUID:includeUUID
                        includeMessageActions:shouldIncludeMessageActions
                              includeMetadata:shouldIncludeMetadata

--- a/PubNub/Core/PubNub+Publish.h
+++ b/PubNub/Core/PubNub+Publish.h
@@ -3,6 +3,9 @@
 #import "PNPublishFileMessageRequest.h"
 #import "PNPublishRequest.h"
 
+#import "PNMessageType.h"
+#import "PNSpaceId.h"
+
 #import "PNPublishFileMessageAPICallBuilder.h"
 #import "PNPublishSizeAPICallBuilder.h"
 #import "PNPublishAPICallBuilder.h"

--- a/PubNub/Core/PubNub+Publish.m
+++ b/PubNub/Core/PubNub+Publish.m
@@ -1,8 +1,8 @@
 /**
  * @author Serhii Mamontov
- * @version 4.15.0
+ * @version 5.2.0
  * @since 4.0.0
- * @copyright © 2010-2020 PubNub, Inc.
+ * @copyright © 2010-2022 PubNub, Inc.
  */
 #import "PubNub+Publish.h"
 #import "PNBasePublishRequest+Private.h"
@@ -31,7 +31,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param message Object (\a NSString, \a NSNumber, \a NSArray, \a NSDictionary) which will be
  *     published.
+ * @param type Type with which message should be published.
  * @param channel Name of the channel to which message should be published.
+ * @param spaceId Identifier of space to which message should be published.
  * @param payloads Dictionary with payloads for different vendors (Apple with "apns" key and Google
  *     with "gcm").
  * @param shouldStore Whether message should be stored and available with history API or not.
@@ -49,7 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.8.2
  */
 - (void)publish:(nullable id)message
+             withType:(nullable PNMessageType *)type
             toChannel:(NSString *)channel
+              spaceId:(nullable PNSpaceId *)spaceId
     mobilePushPayload:(nullable NSDictionary<NSString *, id> *)payloads
        storeInHistory:(BOOL)shouldStore
                   ttl:(nullable NSNumber *)ttl
@@ -70,7 +74,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param message Object (\a NSString, \a NSNumber, \a NSArray, \a NSDictionary) which will be
  *     sent with signal.
+ * @param messageType Type with which signal should be published.
  * @param channel Name of the channel to which signal should be sent.
+ * @param spaceId Identifier of space to which signal should be published.
  * @param queryParameters List arbitrary query parameters which should be sent along with original
  *     API call.
  * @param block Signal completion block.
@@ -78,7 +84,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.9.0
  */
 - (void)signal:(id)message
+               withType:(nullable PNMessageType *)messageType
                 channel:(NSString *)channel
+                spaceId:(nullable PNSpaceId *)spaceId
     withQueryParameters:(nullable NSDictionary *)queryParameters
              completion:(nullable PNSignalCompletionBlock)block;
 
@@ -92,7 +100,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Size calculation use percent-escaped \c message and all added headers to get full size.
  *
  * @param message Message for which size should be calculated.
+ * @param type Type with which message should be published.
  * @param channel Name of the channel to which message should be published.
+ * @param spaceId Identifier of space to which message should be published.
  * @param compressMessage Whether message should be compressed before sending or not.
  * @param shouldStore Whether message should be stored and available with history API or not.
  * @param ttl How long message should be stored in channel's storage. If \b 0 it will be
@@ -108,7 +118,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.8.2
  */
 - (void)sizeOfMessage:(id)message
+             withType:(nullable PNMessageType *)type
             toChannel:(NSString *)channel
+              spaceId:(nullable PNSpaceId *)spaceId
            compressed:(BOOL)compressMessage
        storeInHistory:(BOOL)shouldStore
                   ttl:(nullable NSNumber *)ttl
@@ -142,7 +154,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param message Object (\a NSString, \a NSNumber, \a NSArray, \a NSDictionary) which will be
  *     published.
+ * @param type Type with which message should be published.
  * @param channel Name of the channel to which message should be published.
+ * @param spaceId Identifier of space to which message should be published.
  * @param compressMessage Whether message should be compressed before sending or not.
  * @param replicate Whether message should be replicated across the PubNub Real-Time Network and
  *     sent simultaneously to all subscribed clients on a channel.
@@ -160,7 +174,9 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.0
  */
 - (PNRequestParameters *)requestParametersForMessage:(NSString *)message
+                                            withType:(nullable PNMessageType *)type
                                            toChannel:(NSString *)channel
+                                             spaceId:(nullable PNSpaceId *)spaceId
                                           compressed:(BOOL)compressMessage
                                       storeInHistory:(BOOL)shouldStore
                                                  ttl:(nullable NSNumber *)ttl
@@ -256,12 +272,12 @@ NS_ASSUME_NONNULL_END
 }
 
 - (PNPublishAPICallBuilder * (^)(void))publish {
-    
     PNPublishAPICallBuilder *builder = nil;
     __weak __typeof(self) weakSelf = self;
+
     builder = [PNPublishAPICallBuilder builderWithExecutionBlock:^(NSArray<NSString *> *flags, 
                                                                    NSDictionary *parameters) {
-                                                                       
+
         NSString *channel = parameters[NSStringFromSelector(@selector(channel))];
         NSNumber *shouldStore = parameters[NSStringFromSelector(@selector(shouldStore))];
         NSNumber *ttl = parameters[NSStringFromSelector(@selector(ttl))];
@@ -273,9 +289,11 @@ NS_ASSUME_NONNULL_END
         }
 
         PNPublishRequest *request = [PNPublishRequest requestWithChannel:channel];
+        request.spaceId = parameters[NSStringFromSelector(@selector(spaceId))];
         request.metadata = parameters[NSStringFromSelector(@selector(metadata))];
         request.payloads = parameters[NSStringFromSelector(@selector(payloads))];
         request.message = parameters[NSStringFromSelector(@selector(message))];
+        request.messageType = parameters[NSStringFromSelector(@selector(messageType))];
         request.arbitraryQueryParameters = parameters[@"queryParam"];
         request.store = (shouldStore ? shouldStore.boolValue : YES);
         request.replicate = (replicate ? replicate.boolValue : YES);
@@ -291,9 +309,9 @@ NS_ASSUME_NONNULL_END
 }
 
 - (PNPublishAPICallBuilder * (^)(void))fire {
-    
     PNPublishAPICallBuilder *builder = nil;
     __weak __typeof(self) weakSelf = self;
+    
     builder = [PNPublishAPICallBuilder builderWithExecutionBlock:^(NSArray<NSString *> *flags, 
                                                                    NSDictionary *parameters) {
         
@@ -309,18 +327,25 @@ NS_ASSUME_NONNULL_END
 }
 
 - (PNSignalAPICallBuilder * (^)(void))signal {
-    
     PNSignalAPICallBuilder * builder = nil;
     __weak __typeof(self) weakSelf = self;
+    
     builder = [PNSignalAPICallBuilder builderWithExecutionBlock:^(NSArray<NSString *> *flags,
                                                                   NSDictionary *parameters) {
         
         id message = parameters[NSStringFromSelector(@selector(message))];
+        PNMessageType *messageType = parameters[NSStringFromSelector(@selector(messageType))];
         NSString *channel = parameters[NSStringFromSelector(@selector(channel))];
+        PNSpaceId *spaceId = parameters[NSStringFromSelector(@selector(spaceId))];
         NSDictionary *queryParam = parameters[@"queryParam"];
         id block = parameters[@"block"];
         
-        [weakSelf signal:message channel:channel withQueryParameters:queryParam completion:block];
+        [weakSelf signal:message
+                withType:messageType
+                 channel:channel
+                 spaceId:spaceId
+     withQueryParameters:queryParam
+              completion:block];
     }];
     
     return ^PNSignalAPICallBuilder * {
@@ -329,13 +354,14 @@ NS_ASSUME_NONNULL_END
 }
 
 - (PNPublishSizeAPICallBuilder * (^)(void))size {
-    
     PNPublishSizeAPICallBuilder *builder = nil;
     builder = [PNPublishSizeAPICallBuilder builderWithExecutionBlock:^(NSArray<NSString *> *flags,
                                                                        NSDictionary *parameters) {
                                      
         id message = parameters[NSStringFromSelector(@selector(message))];
+        PNMessageType *messageType = parameters[NSStringFromSelector(@selector(messageType))];
         NSString *channel = parameters[NSStringFromSelector(@selector(channel))];
+        PNSpaceId *spaceId = parameters[NSStringFromSelector(@selector(spaceId))];
         NSNumber *shouldStore = parameters[NSStringFromSelector(@selector(shouldStore))];
         NSNumber *ttl = parameters[NSStringFromSelector(@selector(ttl))];
         NSNumber *compressed = parameters[NSStringFromSelector(@selector(compress))];
@@ -349,7 +375,9 @@ NS_ASSUME_NONNULL_END
         }
                                          
         [self sizeOfMessage:message
+                   withType:messageType
                   toChannel:channel
+                    spaceId:spaceId
                  compressed:compressed.boolValue
              storeInHistory:(shouldStore ? shouldStore.boolValue : YES)
                         ttl:ttl
@@ -399,6 +427,7 @@ NS_ASSUME_NONNULL_END
     }];
 }
 
+
 #pragma mark - Publish with request
 
 - (void)publishWithRequest:(PNPublishRequest *)request completion:(PNPublishCompletionBlock)block {
@@ -409,9 +438,13 @@ NS_ASSUME_NONNULL_END
     request.useRandomInitializationVector = self.configuration.shouldUseRandomInitializationVector;
     request.cipherKey = self.configuration.cipherKey;
 
-    PNLogAPICall(self.logger, @"<PubNub::API> Publish%@ message to '%@' channel%@%@%@",
+    PNLogAPICall(self.logger, @"<PubNub::API> Publish%@ message%@ to '%@' channel%@%@%@%@",
                  (request.shouldCompress ? @" compressed" : @""),
+                 (request.messageType ? [NSString stringWithFormat:@" of '%@' type",
+                                     request.messageType.value] : @""),
                  (request.channel ?: @"<error>"),
+                 (request.spaceId ? [NSString stringWithFormat:@" (space id: %@)",
+                                     request.spaceId.value] : @""),
                  (request.metadata ? [NSString stringWithFormat:@" with metadata (%@)",
                                       request.metadata] : @""),
                  (!request.shouldStore ? @" which won't be saved in history" : @""),
@@ -646,7 +679,9 @@ NS_ASSUME_NONNULL_END
            completion:(PNPublishCompletionBlock)block {
     
     [self publish:message
+             withType:nil
             toChannel:channel
+              spaceId:nil
     mobilePushPayload:payloads
        storeInHistory:shouldStore
                   ttl:nil
@@ -658,7 +693,9 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)publish:(id)message
+             withType:(PNMessageType *)messageType
             toChannel:(NSString *)channel
+              spaceId:(PNSpaceId *)spaceId
     mobilePushPayload:(NSDictionary<NSString *, id> *)payloads
        storeInHistory:(BOOL)shouldStore
                   ttl:(NSNumber *)ttl
@@ -669,6 +706,7 @@ NS_ASSUME_NONNULL_END
            completion:(PNPublishCompletionBlock)block {
 
     PNPublishRequest *request = [PNPublishRequest requestWithChannel:channel];
+    request.spaceId = spaceId;
     request.arbitraryQueryParameters = queryParameters;
     request.ttl = ttl.unsignedIntegerValue;
     request.replicate = replicate;
@@ -677,6 +715,7 @@ NS_ASSUME_NONNULL_END
     request.payloads = payloads;
     request.store = shouldStore;
     request.message = message;
+    request.messageType = messageType;
                                  
     [self publishWithRequest:request completion:block];
 }
@@ -688,11 +727,13 @@ NS_ASSUME_NONNULL_END
            channel:(NSString *)channel
     withCompletion:(PNSignalCompletionBlock)block {
     
-    [self signal:message channel:channel withQueryParameters:nil completion:block];
+    [self signal:message withType:nil channel:channel spaceId:nil withQueryParameters:nil completion:block];
 }
 
 - (void)signal:(id)message
+               withType:(PNMessageType *)messageType
                 channel:(NSString *)channel
+                spaceId:(PNSpaceId *)spaceId
     withQueryParameters:(NSDictionary *)queryParameters
              completion:(PNSignalCompletionBlock)block {
     
@@ -717,11 +758,19 @@ NS_ASSUME_NONNULL_END
                           forPlaceholder:@"{channel}"];
         }
         
+        if (spaceId) {
+            [parameters addQueryParameter:spaceId.value forFieldName:@"space-id"];
+        }
+        
         if (([messageForSignal isKindOfClass:[NSString class]] && messageForSignal.length) ||
             messageForSignal) {
             
             [parameters addPathComponent:[PNString percentEscapedString:messageForSignal]
                           forPlaceholder:@"{message}"];
+        }
+        
+        if (messageType) {
+            [parameters addQueryParameter:messageType.value forFieldName:@"type"];
         }
         
         PNLogAPICall(strongSelf.logger, @"<PubNub::API> Signal to '%@' channel.",
@@ -735,7 +784,9 @@ NS_ASSUME_NONNULL_END
             if (status.isError) {
                 status.retryBlock = ^{
                     [weakSelf signal:message
+                            withType:messageType
                              channel:channel
+                             spaceId:spaceId
                  withQueryParameters:queryParameters
                           completion:block];
                 };
@@ -842,7 +893,9 @@ NS_ASSUME_NONNULL_END
            completion:(PNMessageSizeCalculationCompletionBlock)block {
     
     [self sizeOfMessage:message
+               withType:nil
               toChannel:channel
+                spaceId:nil
              compressed:compressMessage
          storeInHistory:shouldStore
                     ttl:nil
@@ -853,7 +906,9 @@ NS_ASSUME_NONNULL_END
 }
 
 - (void)sizeOfMessage:(id)message
+             withType:(PNMessageType *)messageType
             toChannel:(NSString *)channel
+              spaceId:(PNSpaceId *)spaceId
            compressed:(BOOL)compressMessage
        storeInHistory:(BOOL)shouldStore
                   ttl:(NSNumber *)ttl
@@ -899,7 +954,9 @@ NS_ASSUME_NONNULL_END
             }
             
             PNRequestParameters *parameters = [self requestParametersForMessage:messageForPublish
+                                                                       withType:messageType
                                                                       toChannel:channel
+                                                                        spaceId:spaceId
                                                                      compressed:compressMessage
                                                                  storeInHistory:shouldStore
                                                                             ttl:ttl
@@ -932,7 +989,9 @@ NS_ASSUME_NONNULL_END
                                     parameters:(NSDictionary *)parameters {
     
     id message = parameters[NSStringFromSelector(@selector(message))];
+    PNMessageType *messageType = parameters[NSStringFromSelector(@selector(messageType))];
     NSString *channel = parameters[NSStringFromSelector(@selector(channel))];
+    PNSpaceId *spaceId = parameters[NSStringFromSelector(@selector(spaceId))];
     NSDictionary *payloads = parameters[NSStringFromSelector(@selector(payloads))];
     NSNumber *shouldStore = parameters[NSStringFromSelector(@selector(shouldStore))];
     NSNumber *ttl = parameters[NSStringFromSelector(@selector(ttl))];
@@ -942,7 +1001,9 @@ NS_ASSUME_NONNULL_END
     NSDictionary *metadata = parameters[NSStringFromSelector(@selector(metadata))];
     
     [self publish:message
+         withType:messageType
         toChannel:channel
+          spaceId:spaceId
     mobilePushPayload:payloads
    storeInHistory:(shouldStore ? shouldStore.boolValue : YES)
               ttl:ttl
@@ -957,7 +1018,9 @@ NS_ASSUME_NONNULL_END
 #pragma mark - Misc
 
 - (PNRequestParameters *)requestParametersForMessage:(NSString *)message
+                                            withType:(PNMessageType *)messageType
                                            toChannel:(NSString *)channel
+                                             spaceId:(PNSpaceId *)spaceId
                                           compressed:(BOOL)compressMessage
                                       storeInHistory:(BOOL)shouldStore
                                                  ttl:(NSNumber *)ttl
@@ -973,6 +1036,10 @@ NS_ASSUME_NONNULL_END
     if (channel.length) {
         [parameters addPathComponent:[PNString percentEscapedString:channel]
                       forPlaceholder:@"{channel}"];
+    }
+    
+    if (spaceId) {
+        [parameters addQueryParameter:spaceId.value forFieldName:@"space-id"];
     }
 
     if (!shouldStore) {
@@ -990,6 +1057,10 @@ NS_ASSUME_NONNULL_END
     if (([message isKindOfClass:[NSString class]] && message.length) || message) {
         id targetMessage = !compressMessage ? [PNString percentEscapedString:message] : @"";
         [parameters addPathComponent:targetMessage forPlaceholder:@"{message}"];
+    }
+    
+    if (messageType) {
+        [parameters addQueryParameter:messageType.value forFieldName:@"type"];
     }
     
     if ([metadata isKindOfClass:[NSString class]] && metadata.length) {

--- a/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.h
@@ -122,6 +122,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) PNHistoryAPICallBuilder * (^includeMessageType)(BOOL includeMessageType);
 
 /**
+ * @brief Events' space presence flag.
+ *
+ * @note Available only when message fetched for multiple channels or should include message actions.
+ * @note Each fetched entry will contain published data under 'message' key and published message
+ * \c message \c type will be available under 'spaceId' key.
+ *
+ * @param includeSpaceId Whether identifier of space to which event has been sent should be included or not.
+ *   By default set to: \b NO.
+ *
+ * @return API call configuration builder.
+ *
+ * @since 5.2.0
+ */
+@property (nonatomic, readonly, strong) PNHistoryAPICallBuilder * (^includeSpaceId)(BOOL includeSpaceId);
+
+/**
  * @brief Events' publisher UUID presence flag.
  *
  * @note Available only when message fetched for multiple channels or should include message actions.

--- a/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/History/PNHistoryAPICallBuilder.m
@@ -76,6 +76,13 @@
     };
 }
 
+- (PNHistoryAPICallBuilder * _Nonnull (^)(BOOL includeSpaceId))includeSpaceId {
+    return ^PNHistoryAPICallBuilder * (BOOL includeSpaceId) {
+        [self setValue:@(includeSpaceId) forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
 - (PNHistoryAPICallBuilder * _Nonnull (^)(BOOL includeUUID))includeUUID {
     return ^PNHistoryAPICallBuilder * (BOOL includeUUID) {
         [self setValue:@(includeUUID) forParameter:NSStringFromSelector(_cmd)];

--- a/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.h
@@ -2,12 +2,20 @@
 #import "PNStructures.h"
 
 
+#pragma mark Class forward
+
+@class PNMessageType, PNSpaceId;
+
+
 NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Interface declaration
 
 /**
  * @brief Publish API call builder.
  *
  * @author Serhii Mamontov
+ * @version 5.2.0
  * @since 4.5.4
  * @copyright © 2010-2018 PubNub, Inc.
  */
@@ -28,6 +36,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) PNPublishAPICallBuilder * (^channel)(NSString *channel);
 
 /**
+ * @brief Target space identifier name.
+ *
+ * @param spaceId Identifier of the space to which message should be published.
+ *
+ * @return API call configuration builder.
+ * 
+ * @version 5.2.0
+ */
+@property (nonatomic, readonly, strong) PNPublishAPICallBuilder * (^spaceId)(PNSpaceId *spaceId);
+
+/**
  * @brief Message payload addition block.
  *
  * @discussion Provided object will be serialized into JSON string before pushing to \b PubNub
@@ -41,6 +60,17 @@ NS_ASSUME_NONNULL_BEGIN
  * @since 4.5.4
  */
 @property (nonatomic, readonly, strong) PNPublishAPICallBuilder * (^message)(id message);
+
+/**
+ * @brief Type of message which will be published.
+ *
+ * @param type Custom type for published message.
+ *
+ * @return API call configuration builder.
+ * 
+ * @version 5.2.0
+ */
+@property (nonatomic, readonly, strong) PNPublishAPICallBuilder * (^messageType)(PNMessageType *type);
 
 /**
  * @brief Message metadata addition block.

--- a/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Publish/PNPublishAPICallBuilder.m
@@ -1,5 +1,6 @@
 /**
  * @author Serhii Mamontov
+ * @version 5.2.0
  * @since 4.5.4
  * @copyright © 2010-2018 PubNub, Inc.
  */
@@ -20,23 +21,34 @@
 #pragma mark - Configuration
 
 - (PNPublishAPICallBuilder * (^)(NSString *channel))channel {
-    
     return ^PNPublishAPICallBuilder * (NSString *channel) {
         [self setValue:channel forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }
 
+- (PNPublishAPICallBuilder * (^)(PNSpaceId *spaceId))spaceId {
+    return ^PNPublishAPICallBuilder * (PNSpaceId *spaceId) {
+        [self setValue:spaceId forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
 - (PNPublishAPICallBuilder * (^)(id message))message {
-    
     return ^PNPublishAPICallBuilder * (id message) {
         [self setValue:message forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }
 
+- (PNPublishAPICallBuilder * (^)(PNMessageType *messageType))messageType {
+    return ^PNPublishAPICallBuilder * (PNMessageType *messageType) {
+        [self setValue:messageType forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
 - (PNPublishAPICallBuilder * (^)(NSDictionary *metadata))metadata {
-    
     return ^PNPublishAPICallBuilder * (NSDictionary *metadata) {
         [self setValue:metadata forParameter:NSStringFromSelector(_cmd)];
         return self;
@@ -44,7 +56,6 @@
 }
 
 - (PNPublishAPICallBuilder * (^)(BOOL shouldStore))shouldStore {
-    
     return ^PNPublishAPICallBuilder * (BOOL shouldStore) {
         [self setValue:@(shouldStore) forParameter:NSStringFromSelector(_cmd)];
         return self;
@@ -52,7 +63,6 @@
 }
 
 - (PNPublishAPICallBuilder * (^)(NSUInteger ttl))ttl {
-    
     return ^PNPublishAPICallBuilder * (NSUInteger ttl) {
         [self setValue:@(ttl) forParameter:NSStringFromSelector(_cmd)];
         return self;
@@ -60,7 +70,6 @@
 }
 
 - (PNPublishAPICallBuilder * (^)(BOOL compress))compress {
-    
     return ^PNPublishAPICallBuilder * (BOOL compress) {
         [self setValue:@(compress) forParameter:NSStringFromSelector(_cmd)];
         return self;
@@ -68,7 +77,6 @@
 }
 
 - (PNPublishAPICallBuilder * (^)(BOOL))replicate {
-    
     return ^PNPublishAPICallBuilder * (BOOL replicate) {
         [self setValue:@(replicate) forParameter:NSStringFromSelector(_cmd)];
         return self;
@@ -76,7 +84,6 @@
 }
 
 - (PNPublishAPICallBuilder * (^)(NSDictionary *payload))payloads {
-    
     return ^PNPublishAPICallBuilder * (NSDictionary *payload) {
         [self setValue:payload forParameter:NSStringFromSelector(_cmd)];
         return self;
@@ -87,7 +94,6 @@
 #pragma mark - Execution
 
 - (void(^)(PNPublishCompletionBlock block))performWithCompletion {
-    
     return ^(PNPublishCompletionBlock block) {
         [super performWithBlock:block];
     };

--- a/PubNub/Data/Builders/API Call/Publish/PNSignalAPICallBuilder.h
+++ b/PubNub/Data/Builders/API Call/Publish/PNSignalAPICallBuilder.h
@@ -2,13 +2,19 @@
 #import "PNStructures.h"
 
 
+#pragma mark Class forward
+
+@class PNMessageType, PNSpaceId;
+
 NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Interface declaration
 
 /**
  * @brief Signal API call builder.
  *
  * @author Serhii Mamontov
- * @version 4.9.0
+ * @version 5.2.0
  * @since 4.9.0
  * @copyright © 2010-2019 PubNub, Inc.
  */
@@ -27,6 +33,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) PNSignalAPICallBuilder * (^channel)(NSString *channel);
 
 /**
+ * @brief Target space identifier name.
+ *
+ * @param spaceId Identifier of the space to which signal should be published.
+ *
+ * @return API call configuration builder.
+ *
+ * @version 5.2.0
+ */
+@property (nonatomic, readonly, strong) PNSignalAPICallBuilder * (^spaceId)(PNSpaceId *spaceId);
+
+/**
  * @brief Signal payload addition block.
  *
  * @discussion Provided object will be serialized into JSON string before pushing to \b PubNub
@@ -38,6 +55,17 @@ NS_ASSUME_NONNULL_BEGIN
  * @return API call configuration builder.
  */
 @property (nonatomic, readonly, strong) PNSignalAPICallBuilder * (^message)(id message);
+
+/**
+ * @brief Type of signal which will be published.
+ *
+ * @param type Custom type for published signal.
+ *
+ * @return API call configuration builder.
+ *
+ * @version 5.2.0
+ */
+@property (nonatomic, readonly, strong) PNSignalAPICallBuilder * (^messageType)(PNMessageType *type);
 
 
 #pragma mark - Execution

--- a/PubNub/Data/Builders/API Call/Publish/PNSignalAPICallBuilder.m
+++ b/PubNub/Data/Builders/API Call/Publish/PNSignalAPICallBuilder.m
@@ -21,7 +21,6 @@
 #pragma mark - Configuration
 
 - (PNSignalAPICallBuilder * (^)(NSString *channel))channel {
-    
     return ^PNSignalAPICallBuilder * (NSString *channel) {
         if ([channel isKindOfClass:[NSString class]]) {
             [self setValue:channel forParameter:NSStringFromSelector(_cmd)];
@@ -31,10 +30,23 @@
     };
 }
 
+- (PNSignalAPICallBuilder * (^)(PNSpaceId *spaceId))spaceId {
+    return ^PNSignalAPICallBuilder * (PNSpaceId *spaceId) {
+        [self setValue:spaceId forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
 - (PNSignalAPICallBuilder * (^)(id message))message {
-    
     return ^PNSignalAPICallBuilder * (id message) {
         [self setValue:message forParameter:NSStringFromSelector(_cmd)];
+        return self;
+    };
+}
+
+- (PNSignalAPICallBuilder * (^)(PNMessageType * messageType))messageType {
+    return ^PNSignalAPICallBuilder * (PNMessageType *messageType) {
+        [self setValue:messageType forParameter:NSStringFromSelector(_cmd)];
         return self;
     };
 }

--- a/PubNub/Data/Managers/PNSubscriber.m
+++ b/PubNub/Data/Managers/PNSubscriber.m
@@ -1532,7 +1532,7 @@ NS_ASSUME_NONNULL_END
                     [self handleNewPresenceEvent:((PNPresenceEventResult *)eventResultObject)];
                 } else {
                     PNEnvelopeInformation *envelope = event[@"envelope"];
-                    PNMessageType messageType = envelope.messageType;
+                    PNServiceMessageType messageType = envelope.pubNubMessageType;
                     
                     if (messageType == PNObjectMessageType) {
                         [self handleNewObjectsEvent:eventResultObject];
@@ -1741,7 +1741,7 @@ NS_ASSUME_NONNULL_END
         NSMutableIndexSet *duplicateMessagesIndices = [NSMutableIndexSet indexSet];
         [events enumerateObjectsUsingBlock:^(NSDictionary<NSString *, id> *event, NSUInteger eventIdx, 
                                              BOOL *eventsEnumeratorStop) {
-            PNMessageType messageType = ((PNEnvelopeInformation *)event[@"envelope"]).messageType;
+            PNServiceMessageType messageType = ((PNEnvelopeInformation *)event[@"envelope"]).pubNubMessageType;
             BOOL isMessageEvent = (messageType != PNFileMessageType &&
                                    messageType != PNObjectMessageType &&
                                    messageType != PNMessageActionType);

--- a/PubNub/Data/Models/PNMessageType+Private.h
+++ b/PubNub/Data/Models/PNMessageType+Private.h
@@ -1,0 +1,38 @@
+#import "PNMessageType.h"
+#import "PNPrivateStructures.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Interface extension declaration
+
+/**
+ * @brief Extension for public interface for parsers support.
+ *
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 5.2.0
+ * @copyright © 2010-2022 PubNub Inc. All Rights Reserved.
+ */
+@interface PNMessageType (Private)
+
+
+#pragma mark - Initialization and configuration
+
+/**
+ * @brief Create and configure message type based on type provided by \b PubNub and user.
+ *
+ * @param userMessageType Custom message type which should be used when publish message.
+ * @param pubNubMessageType One of pre-defined message / event types.
+ *
+ * @return Configured and ready to use message type instance.
+ */
++ (instancetype)messageTypeFromString:(NSString *)userMessageType
+                    pubNubMessageType:(PNServiceMessageType)pubNubMessageType;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubNub/Data/Models/PNMessageType.h
+++ b/PubNub/Data/Models/PNMessageType.h
@@ -1,0 +1,76 @@
+#import <Foundation/Foundation.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Interface declaration
+
+/**
+ * @brief Published message representation model.
+ *
+ * @discussion This type let identify message received from subscriber later.
+ * There is five types which is set by \b PubNub service depending from used API endpoint:
+ * - \c message
+ * - \c signal
+ * - \c object
+ * - \c messageAction
+ * - \c file
+ *
+ * Additionally it is possible to specify custom type for published message using \b PNMessageType method
+ *
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 5.2.0
+ * @copyright © 2010-2022 PubNub Inc. All Rights Reserved.
+ */
+@interface PNMessageType : NSObject
+
+
+#pragma mark - Information
+
+/**
+ * @brief One of types associated with message when it has been published.
+ *
+ * @discussion This property may store \b PubNub defined types (like: message, signal, file, object, messageAction
+ */
+@property(nonatomic, readonly, copy) NSString *value;
+
+
+#pragma mark - Initialization and configuration
+
+/**
+ * @brief Create and configure message type instance.
+ *
+ * @param type Custom message type which should be used when publish message.
+ *
+ * @return Configured and ready to use message type instance.
+ */
++ (instancetype)messageTypeFromString:(NSString *)type;
+
+/**
+ * @brief Initialize message type instance.
+ *
+ * @note This method can't be used directly and will throw an exception.
+ *
+ * @return Message type instance.
+ */
+- (nullable instancetype)init NS_UNAVAILABLE;
+
+
+#pragma mark - Helper
+
+/**
+ * @brief Check whether receiving message type is equal to another instance.
+ *
+ * @param otherMessageType Second instance against which check should be done.
+ *
+ * @return \c YES if \c otherMessageType is equal to receiver.
+ */
+- (BOOL)isEqualToMessageType:(PNMessageType *)otherMessageType;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubNub/Data/Models/PNMessageType.m
+++ b/PubNub/Data/Models/PNMessageType.m
@@ -1,0 +1,119 @@
+/**
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 5.2.0
+ * @copyright © 2010-2022 PubNub Inc. All Rights Reserved.
+ */
+#import "PNMessageType+Private.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Protected interface declaration
+
+@interface PNMessageType () <NSCopying>
+
+/**
+ * @brief One of types associated with message when it has been published.
+ *
+ * @discussion This property may store \b PubNub defined types (like: message, signal, file, object, messageAction
+ */
+@property(nonatomic, copy) NSString *value;
+
+
+#pragma mark - Initialization and configuration
+
+/**
+ * @brief Create and configure instance from actual value.
+ *
+ * @param value Custom user type of stringified \b PubNub provided type.
+ */
+- (instancetype)initWithValueFromString:(NSString *)value NS_DESIGNATED_INITIALIZER;
+
+
+#pragma mark - Helper
+
+/**
+ * @brief Transform provided data to string.
+ *
+ * @param userType User-provided type which should be used for message type.
+ * @param pnType \b PubNub provided message type which should be stringified.
+ *
+ * @return Proper message type which will be used by user and publish endpoints.
+ */
++ (NSString *)valueFromUserType:(nullable NSString *)userType
+              pubNubMessageType:(PNServiceMessageType)pnType;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+
+#pragma mark - Interface implementation
+
+@implementation PNMessageType
+
+
+#pragma mark - Initialization and configuration
+
++ (instancetype)messageTypeFromString:(NSString *)type {
+    return [self messageTypeFromString:type pubNubMessageType:PNRegularMessageType];
+}
+
++ (instancetype)messageTypeFromString:(NSString *)userType pubNubMessageType:(PNServiceMessageType)pnType {
+    return [[self alloc] initWithValueFromString:[self valueFromUserType:userType pubNubMessageType:pnType]];
+}
+
+- (instancetype)init {
+    NSDictionary *errorInformation = @{ NSLocalizedRecoverySuggestionErrorKey: @"Use provided constructor" };
+    @throw [NSException exceptionWithName:@"PNInterfaceNotAvailable"
+                                   reason:@"+new or -init methods unavailable."
+                                 userInfo:errorInformation];
+    
+    return nil;
+}
+
+- (instancetype)initWithValueFromString:(NSString *)value {
+    if ((self = [super init])) {
+        _value = [value copy];
+    }
+    
+    return self;
+}
+
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    return [[PNMessageType alloc] initWithValueFromString:self.value];
+}
+
+
+#pragma mark - Helper
+
+- (BOOL)isEqual:(id)other {
+    return other && [other isKindOfClass:[self class]] ? [self isEqualToMessageType:other] : NO;
+}
+
+- (BOOL)isEqualToMessageType:(PNMessageType *)otherMessageType {
+    return [self.value isEqualToString:otherMessageType.value];
+}
+
++ (NSString *)valueFromUserType:(NSString *)userMessageType pubNubMessageType:(PNServiceMessageType)pubNubMessageType {
+    static NSArray<NSString *> *_pubNubMessageTypeMap;
+    static dispatch_once_t onceToken;
+
+    dispatch_once(&onceToken, ^{
+        _pubNubMessageTypeMap = @[@"message", @"signal", @"object", @"messageAction", @"file"];
+    });
+
+    return userMessageType ? userMessageType : _pubNubMessageTypeMap[pubNubMessageType];
+}
+
+#pragma mark -
+
+
+@end

--- a/PubNub/Data/Models/PNSpaceId.h
+++ b/PubNub/Data/Models/PNSpaceId.h
@@ -1,0 +1,64 @@
+#import <Foundation/Foundation.h>
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Interface declaration
+
+/**
+ * @brief Model which represent space into which message should be / has been published.
+ *
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 5.2.0
+ * @copyright © 2010-2022 PubNub Inc. All Rights Reserved.
+ */
+@interface PNSpaceId : NSObject
+
+
+#pragma mark - Information
+
+/**
+ * @brief Space into which message should be / has been published
+ */
+@property(nonatomic, readonly, copy) NSString *value;
+
+
+#pragma mark - Initialization and configuration
+
+/**
+ * @brief Create and configure space id instance.
+ *
+ * @param identifier Space id identifier.
+ *
+ * @return Configured and ready to use space id instance.
+ */
++ (instancetype)spaceIdFromString:(NSString *)identifier;
+
+/**
+ * @brief Initialize space id instance.
+ *
+ * @note This method can't be used directly and will throw an exception.
+ *
+ * @return Space id instance.
+ */
+- (nullable instancetype)init NS_UNAVAILABLE;
+
+
+#pragma mark - Helper
+
+/**
+ * @brief Check whether receiving space id is equal to another instance.
+ *
+ * @param otherSpaceId Second instance against which check should be done.
+ *
+ * @return \c YES if \c otherSpaceId is equal to receiver.
+ */
+- (BOOL)isEqualToSpaceId:(PNSpaceId *)otherSpaceId;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/PubNub/Data/Models/PNSpaceId.m
+++ b/PubNub/Data/Models/PNSpaceId.m
@@ -1,0 +1,81 @@
+/**
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 5.2.0
+ * @copyright © 2010-2022 PubNub Inc. All Rights Reserved.
+ */
+#import "PNSpaceId.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark Protected interface declaration
+
+@interface PNSpaceId () <NSCopying>
+
+/**
+ * @brief Space into which message should be / has been published
+ */
+@property(nonatomic, copy) NSString *value;
+
+
+#pragma mark - Initialization and configuration
+
+/**
+ * @brief Initialize space id instance.
+ *
+ * @param identifier Space id identifier.
+ *
+ * @return Initialized and ready to use space id instance.
+ */
+- (instancetype)initFromString:(NSString *)identifier NS_DESIGNATED_INITIALIZER;
+
+#pragma mark -
+
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+
+#pragma mark - Interface implementation
+
+@implementation PNSpaceId
+
+
+#pragma mark - Initialization and configuration
+
++ (instancetype)spaceIdFromString:(NSString *)identifier {
+    return [[self alloc] initFromString:identifier];
+}
+
+- (instancetype)initFromString:(NSString *)identifier {
+    if ((self = [super init])) {
+        _value = [identifier copy];
+    }
+    
+    return self;
+}
+
+
+#pragma mark - NSCopying
+
+- (id)copyWithZone:(NSZone *)zone {
+    return [[PNSpaceId alloc] initFromString:self.value];
+}
+
+
+#pragma mark - Helper
+
+- (BOOL)isEqual:(id)other {
+    return other && [other isKindOfClass:[self class]] ? [self isEqualToSpaceId:other] : NO;
+}
+
+- (BOOL)isEqualToSpaceId:(PNSpaceId *)otherSpaceId {
+    return [self.value isEqualToString:otherSpaceId.value];
+}
+
+#pragma mark -
+
+
+@end

--- a/PubNub/Data/PNEnvelopeInformation.h
+++ b/PubNub/Data/PNEnvelopeInformation.h
@@ -2,6 +2,11 @@
 #import "PNPrivateStructures.h"
 
 
+#pragma mark Class forward
+
+@class PNMessageType, PNSpaceId;
+
+
 /**
  * @brief Class describe real-time event envelope information.
  *
@@ -44,9 +49,23 @@
 @property (nonatomic, nullable, readonly, copy) NSString *subscribeKey;
 
 /**
- * @brief Object's message type.
+ * @brief \b PubNub defined object type.
+ *
+ * @since 5.2.0
  */
-@property (nonatomic, readonly, assign) PNMessageType messageType;
+@property (atomic, readonly, assign) PNServiceMessageType pubNubMessageType;
+
+/**
+ * @brief Object's message type.
+ *
+ * @since 5.2.0
+ */
+@property (nonatomic, nullable, readonly, strong) PNMessageType *messageType;
+
+/**
+ * @brief Identifier of space from which message has been received.
+ */
+@property (nonatomic, nullable, readonly, copy) PNSpaceId *spaceId;
 
 /**
  * @brief Event replication map (region based).

--- a/PubNub/Data/PNEnvelopeInformation.m
+++ b/PubNub/Data/PNEnvelopeInformation.m
@@ -86,6 +86,7 @@ struct PNEventDebugEnvelopeStructure {
     .subscribeKey = @"k",
     .pubNubMessageTypeKey = @"e",
     .userMessageTypeKey = @"mt",
+    .spaceIdKey = @"si",
     .replicationMap = @"r",
     .eatAfterReading = @"ear",
     .metadata = @"u",

--- a/PubNub/Data/Service Objects/PNResult+Private.h
+++ b/PubNub/Data/Service Objects/PNResult+Private.h
@@ -109,12 +109,34 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  @brief  Convert result object to dictionary which can be used to print out structured data
- 
+
  @return Object in dictionary representation.
- 
+
  @since 4.0
  */
 - (NSDictionary *)dictionaryRepresentation;
+
+/**
+ @brief  Convert result object to dictionary which can be used to print out structured data
+
+ @param dictionary Dictionary in which fields should be normalised.
+
+ @return Object in dictionary representation.
+
+ @since 5.2.0
+ */
+- (NSDictionary *)dictionaryRepresentationFromDictionary:(NSDictionary *)dictionary;
+
+/**
+ @brief  Convert result object to dictionary which can be used to print out structured data
+
+ @param array Array in which fields should be normalised.
+
+ @return Object in dictionary representation.
+
+ @since 5.2.0
+ */
+- (NSArray *)arrayRepresentationFromArray:(NSArray *)array;
 
 /**
  @brief  Convert result object to string which can be used to print out data

--- a/PubNub/Data/Service Objects/PNResult.m
+++ b/PubNub/Data/Service Objects/PNResult.m
@@ -201,9 +201,58 @@ NS_ASSUME_NONNULL_END
              @"Response": response};
 }
 
+- (NSDictionary *)dictionaryRepresentationFromDictionary:(NSDictionary *)dictionary {
+    NSMutableDictionary *representation = [NSMutableDictionary new];
+    Class messageTypeClass = NSClassFromString(@"PNMessageType");
+    Class spaceIdClass = NSClassFromString(@"PNSpaceId");
+
+    [dictionary enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
+        if ([obj isKindOfClass:messageTypeClass] || [obj isKindOfClass:spaceIdClass]) {
+            representation[key] = [obj valueForKey:@"value"];
+        } else if ([[obj class] isSubclassOfClass:[NSDictionary class]]) {
+            representation[key] = [self dictionaryRepresentationFromDictionary:obj];
+        } else if ([[obj class] isSubclassOfClass:[NSArray class]]) {
+            representation[key] = [self arrayRepresentationFromArray:obj];
+        } else {
+            representation[key] = obj;
+        }
+    }];
+
+    return representation;
+}
+
+- (NSArray *)arrayRepresentationFromArray:(NSArray *)array {
+    NSMutableArray *representation = [NSMutableArray new];
+    Class messageTypeClass = NSClassFromString(@"PNMessageType");
+    Class spaceIdClass = NSClassFromString(@"PNSpaceId");
+
+    [array enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([obj isKindOfClass:messageTypeClass] || [obj isKindOfClass:spaceIdClass]) {
+            if ([obj valueForKey:@"value"]) [representation addObject:[obj valueForKey:@"value"]];
+        } else if ([[obj class] isSubclassOfClass:[NSDictionary class]]) {
+            [representation addObject:[self dictionaryRepresentationFromDictionary:obj]];
+        } else if ([[obj class] isSubclassOfClass:[NSArray class]]) {
+            [representation addObject:[self arrayRepresentationFromArray:obj]];
+        } else {
+            [representation addObject:obj];
+        }
+    }];
+
+    return representation;
+}
+
 - (NSString *)stringifiedRepresentation {
-    
-    return [PNJSON JSONStringFrom:[self dictionaryRepresentation] withError:NULL];
+    NSDictionary *dictionary = [self dictionaryRepresentation];
+    NSString *representation;
+
+    @try {
+        representation = [PNJSON JSONStringFrom:dictionary withError:NULL];
+    } @catch (NSException *exception) {
+        dictionary = [self dictionaryRepresentationFromDictionary:dictionary];
+        representation = [PNJSON JSONStringFrom:dictionary withError:NULL];
+    }
+
+    return representation ? representation : @"unable to stirnfigy object";
 }
 
 - (NSString *)debugDescription {

--- a/PubNub/Data/Service Objects/PNSubscribeStatus.h
+++ b/PubNub/Data/Service Objects/PNSubscribeStatus.h
@@ -2,47 +2,65 @@
 #import "PNServiceData.h"
 
 
+#pragma mark Class forward
+
+@class PNMessageType, PNSpaceId;
+
+
 NS_ASSUME_NONNULL_BEGIN
 
+#pragma mark - Interface declaration
+
 /**
- @brief  Base class which allow to get access to general information about subscribe loop.
- 
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @brief Base class which allow to get access to general information about subscribe loop.
+ *
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 4.0.0
+ * @copyright © 2010-2022 PubNub, Inc.
  */
 @interface PNSubscriberData : PNServiceData
 
 
-///------------------------------------------------
-/// @name Information
-///------------------------------------------------
+#pragma mark - Information
 
 /**
- @brief  Name of channel for which subscriber received data.
- 
- @since 4.5.2
+ * @brief  Name of channel for which subscriber received data.
+ *
+ * @since 4.5.2
  */
 @property (nonatomic, readonly, strong) NSString *channel;
 
 /**
- @brief  Name of \c channel or channel \c group (in case if not equal to \c channel).
- 
- @since 4.5.2
+ * @brief Identifier to which message originally has been published.
+ *
+ * @since 5.2.0
+ */
+@property (nonatomic, nullable, readonly, strong) PNSpaceId *spaceId;
+
+/**
+ * @brief  Name of \c channel or channel \c group (in case if not equal to \c channel).
+ *
+ * @since 4.5.2
  */
 @property (nonatomic, nullable, readonly, strong) NSString *subscription;
 
 /**
- @brief  Time at which event arrived.
- 
- @since 4.0
+ * @brief Time at which event arrived.
  */
 @property (nonatomic, readonly, strong) NSNumber *timetoken;
 
 /**
- @brief  Stores reference on metadata information which has been passed along with received event.
- 
- @since 4.3.0
+ * @brief Type of message which has been published.
+ *
+ * @since 5.2.0
+ */
+@property (nonatomic, nullable, readonly, strong) PNMessageType *messageType;
+
+/**
+ * @brief Stores reference on metadata information which has been passed along with received event.
+ *
+ * @since 4.3.0
  */
 @property (nonatomic, nullable, readonly, strong) NSDictionary<NSString *, id> *userMetadata;
 
@@ -53,52 +71,40 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- @brief  Class which is used to provide access to request processing results.
- 
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @brief Class which is used to provide access to request processing results.
+ *
+ * @author Serhii Mamontov
+ * @since 4.0
+ * @copyright © 2010-2018 PubNub, Inc.
  */
 @interface PNSubscribeStatus : PNErrorStatus
 
 
-///------------------------------------------------
-/// @name Information
-///------------------------------------------------
+#pragma mark - Information
 
 /**
- @brief  Time token which has been used to establish current subscription cycle.
- 
- @since 4.0
+ * @brief Time token which has been used to establish current subscription cycle.
  */
 @property (nonatomic, readonly, strong) NSNumber *currentTimetoken;
 
 /**
- @brief  Stores reference on previous key which has been used in subscription cycle to receive
-         \c currentTimetoken along with other events.
- 
- @since 4.0
+ * @brief Stores reference on previous key which has been used in subscription cycle to receive
+ * \c currentTimetoken along with other events.
  */
 @property (nonatomic, readonly, strong) NSNumber *lastTimeToken;
 
 /**
- @brief  List of channels on which client currently subscribed.
- 
- @since 4.0
+ * @brief List of channels on which client currently subscribed.
  */
 @property (nonatomic, readonly, copy) NSArray<NSString *> *subscribedChannels;
 
 /**
- @brief  List of channel group names on which client currently subscribed.
- 
- @since 4.0
+ * @brief List of channel group names on which client currently subscribed.
  */
 @property (nonatomic, readonly, copy) NSArray<NSString *> *subscribedChannelGroups;
 
 /**
- @brief  Structured \b PNResult \c data field information.
- 
- @since 4.0
+ * @brief Structured \b PNResult \c data field information.
  */
 @property (nonatomic, readonly, strong) PNSubscriberData *data;
 

--- a/PubNub/Data/Service Objects/PNSubscribeStatus.m
+++ b/PubNub/Data/Service Objects/PNSubscribeStatus.m
@@ -1,12 +1,14 @@
 /**
- @author Sergey Mamontov
- @since 4.0
- @copyright © 2010-2018 PubNub, Inc.
+ * @author Serhii Mamontov
+ * @version 5.2.0
+ * @since 4.0.0
+ * @copyright © 2010-2022 PubNub, Inc.
  */
 #import "PNSubscribeStatus+Private.h"
 #import "PNEnvelopeInformation.h"
 #import "PNServiceData+Private.h"
 #import "PNResult+Private.h"
+#import "PNSpaceId.h"
 
 
 #pragma mark Interface implementation
@@ -17,32 +19,34 @@
 #pragma mark - Information
 
 - (NSString *)channel {
-    
     return self.serviceData[@"channel"];
 }
 
+- (PNSpaceId *)spaceId {
+    return self.envelope.spaceId;
+}
+
+- (PNMessageType *)messageType {
+    return self.envelope.messageType;
+}
+
 - (NSString *)subscription {
-    
     return self.serviceData[@"subscription"];
 }
 
 - (NSNumber *)timetoken {
-    
     return (self.serviceData[@"timetoken"]?: @0);
 }
 
 - (NSNumber *)region {
-    
     return (self.serviceData[@"region"]?: @0);
 }
 
 - (NSDictionary<NSString *, id> *)userMetadata {
-    
     return self.envelope.metadata;
 }
 
 - (PNEnvelopeInformation *)envelope {
-    
     return self.serviceData[@"envelope"];
 }
 

--- a/PubNub/Misc/PNPrivateStructures.h
+++ b/PubNub/Misc/PNPrivateStructures.h
@@ -29,11 +29,12 @@ extern NSString * const kPNPublishSequenceDataKey;
 extern NSString * const kPNConfigurationUUIDKey;
 
 /**
- * @brief Options describe object's message type.
+ * @brief \b PubNub provided service message types.
  *
- * @since 4.9.0
+ * @version 5.2.0
+ * @since 5.2.0
  */
-typedef NS_OPTIONS(NSUInteger, PNMessageType) {
+typedef NS_OPTIONS(NSUInteger, PNServiceMessageType) {
     /**
      @brief Type which represent regular message object.
      */

--- a/PubNub/Network/Parsers/PNHistoryParser.m
+++ b/PubNub/Network/Parsers/PNHistoryParser.m
@@ -168,6 +168,10 @@ NS_ASSUME_NONNULL_END
             if (![metadata isKindOfClass:[NSDictionary class]]) {
                 metadata = nil;
             }
+
+            if ([pubNubMessageType isKindOfClass:[NSNull class]]) {
+                pubNubMessageType = @(PNRegularMessageType);
+            }
             
             timeToken = timeToken ? @(((NSString *)timeToken).longLongValue) : nil;
             [self normalizeActionTimetokens:((NSDictionary *)actions).allValues];

--- a/PubNub/Network/Parsers/PNSubscribeParser.m
+++ b/PubNub/Network/Parsers/PNSubscribeParser.m
@@ -419,7 +419,7 @@ NS_ASSUME_NONNULL_END
 
     event[@"subscription"] = (subscriptionMatch ?: channel);
     event[@"channel"] = channel;
-    PNMessageType messageType = ((PNEnvelopeInformation *)event[@"envelope"]).messageType;
+    PNServiceMessageType messageType = ((PNEnvelopeInformation *)event[@"envelope"]).pubNubMessageType;
     BOOL isEncryptionSupported = messageType == PNRegularMessageType ||
                                  messageType == PNFileMessageType;
 

--- a/PubNub/Network/Requests/Publish/PNBasePublishRequest.h
+++ b/PubNub/Network/Requests/Publish/PNBasePublishRequest.h
@@ -2,9 +2,14 @@
 #import "PNRequest.h"
 
 
+#pragma mark Class forward
+
+@class PNMessageType, PNSpaceId;
+
+
 NS_ASSUME_NONNULL_BEGIN
 
-#pragma mark Interface declaration
+#pragma mark - Interface declaration
 
 /**
  * @brief Base class for all 'Publish' API endpoints which has shared query options.
@@ -40,12 +45,22 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, copy) NSString *channel;
 
 /**
+ * @brief Identifier of the space to which message should be published.
+ */
+@property (nonatomic, nullable, copy) PNSpaceId *spaceId;
+
+/**
  * @brief Message which will be published.
  *
  * @discussion Provided object will be serialized into JSON (\a NSString, \a NSNumber, \a NSArray, \a NSDictionary) string
  * before pushing to \b PubNub service. If client has been configured with cipher key message will be encrypted as well.
  */
 @property (nonatomic, nullable, strong) id message;
+
+/**
+ * @brief Custom type with which message should be published.
+ */
+@property (nonatomic, nullable, copy) PNMessageType *messageType;
 
 /**
  * @brief How long message should be stored in channel's storage. Pass \b 0 store message according to retention.

--- a/PubNub/Network/Requests/Publish/PNBasePublishRequest.m
+++ b/PubNub/Network/Requests/Publish/PNBasePublishRequest.m
@@ -6,6 +6,8 @@
  */
 #import "PNBasePublishRequest+Private.h"
 #import "PNRequest+Private.h"
+#import "PNMessageType.h"
+#import "PNSpaceId.h"
 #import "PNHelpers.h"
 #import "PNAES.h"
 
@@ -112,6 +114,14 @@ NS_ASSUME_NONNULL_END
     
     if (!self.shouldReplicate) {
         [parameters addQueryParameter:@"true" forFieldName:@"norep"];
+    }
+
+    if (self.spaceId) {
+        [parameters addQueryParameter:self.spaceId.value forFieldName:@"space-id"];
+    }
+
+    if (self.messageType) {
+        [parameters addQueryParameter:self.messageType.value forFieldName:@"type"];
     }
     
     parameters.POSTBodyCompressed = self.shouldCompress;

--- a/Tests/Podfile.lock
+++ b/Tests/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
   - Cucumberish (1.4.0)
   - OCMock (3.6)
-  - PubNub (5.1.2):
-    - PubNub/Core (= 5.1.2)
-  - PubNub/Core (5.1.2)
+  - PubNub (5.1.3):
+    - PubNub/Core (= 5.1.3)
+  - PubNub/Core (5.1.3)
   - YAHTTPVCR (1.4.2)
 
 DEPENDENCIES:
@@ -32,7 +32,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Cucumberish: 6cbd0c1f50306b369acebfe7d9f514c9c287d26c
   OCMock: 5ea90566be239f179ba766fd9fbae5885040b992
-  PubNub: 65ddd075debdb479878f7bd42e4f3ab7de25ccec
+  PubNub: 0c6f2e5728efe4bb65c26b991331aae39ac5e5a5
   YAHTTPVCR: e2aa406443a4db12585ff626b445369e1953a729
 
 PODFILE CHECKSUM: 569ce5fdb7670790d6d4a9d1a5a304a20781e374

--- a/Tests/Tests/Contract/PNContractCucumberTest.m
+++ b/Tests/Tests/Contract/PNContractCucumberTest.m
@@ -37,10 +37,19 @@ void CucumberishInit(void) {
     if ([xcTestBundlePath rangeOfString:@"Contract Tests Beta"].location != NSNotFound) {
         [excludeTags removeObject:@"beta"];
     }
+
+    // TODO: REMOVE AFTER ALL TESTS FOR MESSAGE TYPE WILL BE MERGED.
+    excludeTags = nil;
+    NSArray *includedTags = @[
+        @"featureSet=historyVSP",
+        @"featureSet=publishToSpace",
+        @"featureSet=signalToSpace",
+        @"featureSet=subscribeVSP"
+    ];
     
     NSBundle * bundle = [NSBundle bundleForClass:[PNContractTestCase class]];
     [Cucumberish executeFeaturesInDirectory:@"Features"
                                  fromBundle:bundle
-                                includeTags:nil
+                                includeTags:includedTags
                                 excludeTags:excludeTags];
 }

--- a/Tests/Tests/Contract/Steps/History/PNHistoryContractTestSteps.m
+++ b/Tests/Tests/Contract/Steps/History/PNHistoryContractTestSteps.m
@@ -14,8 +14,68 @@
 
 - (void)setup {
     [self startCucumberHookEventsListening];
+
+    When(@"^I fetch message history for '(.*)' channel$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        XCTAssertEqual(args.count, 1);
+        self.testedFeatureType = PNHistoryForChannelsOperation;
+
+        [self callCodeSynchronously:^(dispatch_block_t completion) {
+            self.client.history()
+                .channels(args)
+                .performWithCompletion(^(PNHistoryResult *result, PNErrorStatus *status) {
+                    [self storeRequestResult:result];
+                    [self storeRequestStatus:status];
+                    completion();
+                });
+        }];
+    });
+
+    Match(@[@"And"], @"^history response contains messages (with|without) ('(.*)' and '(.*)' )?message types$",
+          ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        XCTAssertGreaterThan(args.count, 0);
+        NSString *inclusionFlag = args.firstObject;
+        PNHistoryResult *result = (PNHistoryResult *)[self lastResult];
+        XCTAssertNotNil(result);
+
+        NSArray *messages = result.data.channels.allValues.firstObject;
+        XCTAssertGreaterThan(messages.count, 0);
+        NSArray *receivedMessageTypes = [messages valueForKeyPath:@"messageType.value"];
+        NSMutableArray *filteredReceivedMessageTypes = [NSMutableArray arrayWithArray:receivedMessageTypes];
+        [filteredReceivedMessageTypes removeObjectIdenticalTo:[NSNull null]];
+
+        XCTAssertFalse([inclusionFlag isEqual:@"with"] && filteredReceivedMessageTypes.count == 0);
+        XCTAssertFalse([inclusionFlag isEqual:@"without"] && filteredReceivedMessageTypes.count > 0);
+
+        if (args.count > 1) {
+            SEL compare = @selector(caseInsensitiveCompare:);
+            NSArray *expectedMessageTypes = [[args subarrayWithRange:NSMakeRange(2, 2)] sortedArrayUsingSelector:compare];
+            NSArray *receivedMessageTypes = [filteredReceivedMessageTypes sortedArrayUsingSelector:compare];
+            XCTAssertEqualObjects(receivedMessageTypes, expectedMessageTypes);
+        } else {
+            XCTAssertEqual([inclusionFlag isEqual:@"with"] ? messages.count : 0,
+                           filteredReceivedMessageTypes.count);
+        }
+    });
+
+    Match(@[@"And"], @"^history response contains messages (with|without) space ids$",
+          ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        XCTAssertGreaterThan(args.count, 0);
+        NSString *inclusionFlag = args.firstObject;
+        PNHistoryResult *result = (PNHistoryResult *)[self lastResult];
+        XCTAssertNotNil(result);
+
+        NSArray *messages = result.data.channels.allValues.firstObject;
+        XCTAssertGreaterThan(messages.count, 0);
+        NSArray *receivedSpaceIds = [messages valueForKeyPath:@"spaceId.value"];
+        NSMutableArray *filteredReceivedSpaceIds = [NSMutableArray arrayWithArray:receivedSpaceIds];
+        [filteredReceivedSpaceIds removeObjectIdenticalTo:[NSNull null]];
+        
+        XCTAssertFalse([inclusionFlag isEqual:@"with"] && filteredReceivedSpaceIds.count == 0);
+        XCTAssertFalse([inclusionFlag isEqual:@"without"] && filteredReceivedSpaceIds.count > 0);
+        XCTAssertEqual([inclusionFlag isEqual:@"with"] ? messages.count : 0, filteredReceivedSpaceIds.count);
+    });
     
-    When(@"^I fetch message history for (.*) channel(s)?$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    When(@"^I fetch message history for (single|multiple) channel(s)?$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         NSArray *channels = [args.firstObject isEqualToString:@"multiple"] ? @[@"test1", @"test2"] : @[@"test"];
         self.testedFeatureType = PNHistoryForChannelsOperation;
         
@@ -30,19 +90,45 @@
         }];
     });
     
-    Then(@"the response contains pagination info", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"^the response contains pagination info$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         PNHistoryResult *result = (PNHistoryResult *)[self lastResult];
         XCTAssertNotNil(result.data.start);
         XCTAssertNotNil(result.data.end);
     });
-    
-    When(@"I fetch message history with message actions", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+
+    When(@"^I fetch message history with message actions$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNHistoryWithActionsOperation;
-        
+
         [self callCodeSynchronously:^(dispatch_block_t completion) {
             self.client.history()
                 .channel(@"test")
                 .includeMessageActions(YES)
+                .performWithCompletion(^(PNHistoryResult *result, PNErrorStatus *status) {
+                    [self storeRequestResult:result];
+                    [self storeRequestStatus:status];
+                    completion();
+                });
+        }];
+    });
+
+    When(@"^I fetch message history with '(.*)' set to '(.*)' for '(.*)' channel$",
+         ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        XCTAssertEqual(args.count, 3);
+        self.testedFeatureType = PNHistoryWithActionsOperation;
+        BOOL includeMessageType = YES;
+        BOOL includeSpaceId = NO;
+
+        if ([args.firstObject isEqual:@"includeMessageType"]) {
+            includeMessageType = [args[1] isEqual:@"true"];
+        } else if ([args.firstObject isEqual:@"includeSpaceId"]) {
+            includeSpaceId = [args[1] isEqual:@"true"];
+        }
+
+        [self callCodeSynchronously:^(dispatch_block_t completion) {
+            self.client.history()
+                .channels(@[args[2]])
+                .includeMessageType(includeMessageType)
+                .includeSpaceId(includeSpaceId)
                 .performWithCompletion(^(PNHistoryResult *result, PNErrorStatus *status) {
                     [self storeRequestResult:result];
                     [self storeRequestStatus:status];

--- a/Tests/Tests/Contract/Steps/Publish/PNPublishContractTestSteps.m
+++ b/Tests/Tests/Contract/Steps/Publish/PNPublishContractTestSteps.m
@@ -15,7 +15,7 @@
 - (void)setup {
     [self startCucumberHookEventsListening];
     
-    When(@"I publish a message", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    When(@"^I publish a message$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNPublishOperation;
         
         [self callCodeSynchronously:^(dispatch_block_t completion) {
@@ -28,10 +28,10 @@
                 });
         }];
     });
-    
+
     When(@"^I publish a message with (.*) metadata$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNPublishOperation;
-        
+
         [self callCodeSynchronously:^(dispatch_block_t completion) {
             id meta = [args.lastObject isEqualToString:@"JSON"] ? @{@"test-user": @"bob"} : @"test-user=bob";
             self.client.publish()
@@ -44,14 +44,48 @@
                 });
         }];
     });
+
+    When(@"^I publish message with '(.*)' space id and '(.*)' message type$",
+         ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        self.testedFeatureType = PNPublishOperation;
+
+        [self callCodeSynchronously:^(dispatch_block_t completion) {
+            self.client.publish()
+                .message(@"hello")
+                .channel(@"test")
+                .messageType([PNMessageType messageTypeFromString:args.lastObject])
+                .spaceId([PNSpaceId spaceIdFromString:args.firstObject])
+                .performWithCompletion(^(PNPublishStatus *status) {
+                    [self storeRequestStatus:status];
+                    completion();
+                });
+        }];
+    });
     
-    When(@"I send a signal", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    When(@"^I send a signal$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNSignalOperation;
         
         [self callCodeSynchronously:^(dispatch_block_t completion) {
             self.client.signal()
                 .message(@"hello")
                 .channel(@"test")
+                .performWithCompletion(^(PNSignalStatus *status) {
+                    [self storeRequestStatus:status];
+                    completion();
+                });
+        }];
+    });
+
+    When(@"^I send a signal with '(.*)' space id and '(.*)' message type$",
+         ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        self.testedFeatureType = PNSignalOperation;
+
+        [self callCodeSynchronously:^(dispatch_block_t completion) {
+            self.client.signal()
+                .message(@"hello")
+                .channel(@"test")
+                .messageType([PNMessageType messageTypeFromString:args.lastObject])
+                .spaceId([PNSpaceId spaceIdFromString:args.firstObject])
                 .performWithCompletion(^(PNSignalStatus *status) {
                     [self storeRequestStatus:status];
                     completion();

--- a/Tests/Tests/Contract/Steps/Subscribe/PNSubscribeContractTestSteps.m
+++ b/Tests/Tests/Contract/Steps/Subscribe/PNSubscribeContractTestSteps.m
@@ -22,21 +22,37 @@
     Given(@"the invalid-crypto keyset", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.configuration.cipherKey = @"secret";
     });
-    
-    When(@"I subscribe", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+
+    When(@"^I subscribe$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNSubscribeOperation;
-        
+
         [self subscribeClient:nil synchronouslyToChannels:@[@"test"] groups:nil withPresence:NO timetoken:nil];
-        
+
+        // Give some time to rotate received timetokens.
+        [self pauseMainQueueFor:0.5f];
+    });
+
+    When(@"^I subscribe to '(.*)' channel$", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        self.testedFeatureType = PNSubscribeOperation;
+        XCTAssertGreaterThan(args.count, 0);
+
+        [self subscribeClient:nil synchronouslyToChannels:args groups:nil withPresence:NO timetoken:nil];
+
         // Give some time to rotate received timetokens.
         [self pauseMainQueueFor:0.5f];
     });
     
-    Then(@"I receive the message in my subscribe response", ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+    Then(@"^I receive (the|[0-9]+) message(s)? in my subscribe response$",
+         ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
         self.testedFeatureType = PNSubscribeOperation;
+        XCTAssertGreaterThan(args.count, 0);
+        NSUInteger expectedCount = ![args.firstObject isEqual:@"the"] ? args.firstObject.intValue : 1;
         
-        NSArray<PNMessageResult *> *messages = [self waitClient:nil toReceiveMessages:1 onChannel:nil];
+        NSArray<PNMessageResult *> *messages = [self waitClient:nil
+                                     toReceiveSignalsOrMessages:expectedCount
+                                                      onChannel:nil];
         XCTAssertNotNil(messages);
+        XCTAssertEqual(messages.count, expectedCount);
         if ([self checkInUserInfo:userInfo testingFeature:@"Message encryption"]) {
             XCTAssertEqualObjects(messages.lastObject.data.message, @"hello world");
         } else if ([self checkInUserInfo:userInfo testingFeature:@"Subscribe Loop"]) {
@@ -54,6 +70,37 @@
         XCTAssertEqual(statuses.lastObject.category, PNDecryptionErrorCategory);
 
         [self pauseMainQueueFor:0.5f];
+    });
+
+    Match(@[@"And"], @"^response contains messages with '(.*)' and '(.*)' message types$",
+          ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        XCTAssertEqual(args.count, 2);
+
+        NSArray *messages = [self waitClient:nil toReceiveSignalsOrMessages:2 onChannel:nil];
+        XCTAssertNotNil(messages);
+        XCTAssertEqual(messages.count, 2);
+
+        SEL compare = @selector(caseInsensitiveCompare:);
+        NSArray *expectedMessageTypes = [args sortedArrayUsingSelector:compare];
+        NSArray *receivedMessageTypes = [[messages valueForKeyPath:@"data.messageType.value"] sortedArrayUsingSelector:compare];
+        XCTAssertEqualObjects(receivedMessageTypes, expectedMessageTypes);
+    });
+
+    Match(@[@"And"], @"^response contains messages (with|without) space ids$",
+          ^(NSArray<NSString *> *args, NSDictionary *userInfo) {
+        XCTAssertEqual(args.count, 1);
+
+        NSArray *messages = [self waitClient:nil toReceiveSignalsOrMessages:2 onChannel:nil];
+        XCTAssertNotNil(messages);
+        XCTAssertEqual(messages.count, 2);
+
+        NSArray *receivedSpaceIds = [messages valueForKeyPath:@"data.spaceId.value"];
+        NSMutableArray *filteredReceivedSpaceIds = [NSMutableArray arrayWithArray:receivedSpaceIds];
+        [filteredReceivedSpaceIds removeObjectIdenticalTo:[NSNull null]];
+
+        XCTAssertFalse([args.firstObject isEqual:@"with"] && filteredReceivedSpaceIds.count == 0);
+        XCTAssertFalse([args.firstObject isEqual:@"without"] && filteredReceivedSpaceIds.count > 0);
+        XCTAssertEqual([args.firstObject isEqual:@"with"] ? messages.count : 0, filteredReceivedSpaceIds.count);
     });
 }
 

--- a/Tests/Tests/Helpers/PNContractTestCase.h
+++ b/Tests/Tests/Helpers/PNContractTestCase.h
@@ -93,6 +93,19 @@ synchronouslyFromChannels:(nullable NSArray *)channels
                                           onChannel:(nullable NSString *)channel;
 
 /**
+ * @brief Wait specified \b PubNub client to receive expected number (in total) of messages and signals.
+ *
+ * @param client \b PubNub client which is expecting to receive specific number (in total) of messages and signals.
+ * @param count How many messages and signals it is expected to receive.
+ * @param channel Channel on which messages and signals expected. All channels for \c client if \c nil.
+ *
+ * @return List of messages and signals when expected count received.
+ */
+- (nullable NSArray *)waitClient:(nullable PubNub *)client
+      toReceiveSignalsOrMessages:(NSUInteger)count
+                       onChannel:(nullable NSString *)channel;
+
+/**
  * @brief Wait specified \b PubNub client to receive expected number of status events.
  *
  * @param client \b PubNub client which is expecting to receive specific number of messages.


### PR DESCRIPTION
feat(publish): add message type support for `publish` API

Add new publish parameters to specify `messageType` and `spaceId`.

feat(signal): add message type support for `signal` API

Add new signal parameters to specify `messageType` and `spaceId`.

feat(history): add message type support for `history` API

Make it possible to opt-out message type receive for stored messages and get `spaceId` for stored message.